### PR TITLE
Domain層テストを補強: updateMatchPlayersの正常系とtitle自動生成

### DIFF
--- a/server/domain/models/circle-session/circle-session.test.ts
+++ b/server/domain/models/circle-session/circle-session.test.ts
@@ -22,6 +22,18 @@ describe("CircleSession ドメイン", () => {
     expect(session.title).toBe("第1回 研究会");
   });
 
+  test("createCircleSession は title 未指定時に自動生成する", () => {
+    const session = createCircleSession({
+      id: circleSessionId("session-1"),
+      circleId: circleId("circle-1"),
+      sequence: 5,
+      startsAt: new Date("2024-01-01T10:00:00Z"),
+      endsAt: new Date("2024-01-01T12:00:00Z"),
+    });
+
+    expect(session.title).toBe("第5回 研究会");
+  });
+
   test("createCircleSession は回次が正の整数でない場合に拒否する", () => {
     expect(() =>
       createCircleSession({

--- a/server/domain/models/match/match.test.ts
+++ b/server/domain/models/match/match.test.ts
@@ -45,6 +45,21 @@ describe("Match ドメイン", () => {
     ).toThrow("order must be a positive integer");
   });
 
+  test("updateMatchPlayers は対局者を正しく更新する", () => {
+    const match = createMatch({
+      id: matchId("match-1"),
+      circleSessionId: circleSessionId("session-1"),
+      order: 1,
+      player1Id: userId("user-1"),
+      player2Id: userId("user-2"),
+    });
+
+    const updated = updateMatchPlayers(match, userId("user-3"), userId("user-4"));
+
+    expect(updated.player1Id).toBe(userId("user-3"));
+    expect(updated.player2Id).toBe(userId("user-4"));
+  });
+
   test("updateMatchPlayers は対局者の違いを検証する", () => {
     const match = createMatch({
       id: matchId("match-1"),


### PR DESCRIPTION
## Summary

- `updateMatchPlayers` の正常系テストを追加（B3-1対応）
- `createCircleSession` の title 自動生成テストを追加（B5-1対応）

## Test plan

- [x] `npm run test:run` で全343テストがパス

Closes #10

🤖 Generated with [Claude Code](https://claude.com/claude-code)