### PR TITLE
Domain層テスト: 軽微なテストケース追加 (#11)

### DIFF
--- a/server/domain/common/validation.test.ts
+++ b/server/domain/common/validation.test.ts
@@ -8,8 +8,12 @@ import {
 } from "@/server/domain/common/validation";
 
 describe("バリデーション", () => {
-  test("assertNonEmpty は空文字でエラー", () => {
+  test("assertNonEmpty は空文字（空白のみ）でエラー", () => {
     expect(() => assertNonEmpty(" ", "name")).toThrow("name is required");
+  });
+
+  test("assertNonEmpty は空文字（長さ0）でエラー", () => {
+    expect(() => assertNonEmpty("", "name")).toThrow("name is required");
   });
 
   test("assertNonEmpty はトリム後の値を返す", () => {
@@ -28,6 +32,12 @@ describe("バリデーション", () => {
 
   test("assertPositiveInteger は小数でエラー", () => {
     expect(() => assertPositiveInteger(1.2, "count")).toThrow(
+      "count must be a positive integer",
+    );
+  });
+
+  test("assertPositiveInteger は負の整数でエラー", () => {
+    expect(() => assertPositiveInteger(-1, "count")).toThrow(
       "count must be a positive integer",
     );
   });
@@ -54,6 +64,12 @@ describe("バリデーション", () => {
   test("assertStartBeforeEnd は同一時刻ならエラーにならない", () => {
     const at = new Date("2024-01-01T00:00:00Z");
     expect(() => assertStartBeforeEnd(at, at, "session")).not.toThrow();
+  });
+
+  test("assertStartBeforeEnd は開始が終了より前なら成功する", () => {
+    const startsAt = new Date("2024-01-01T00:00:00Z");
+    const endsAt = new Date("2024-01-02T00:00:00Z");
+    expect(() => assertStartBeforeEnd(startsAt, endsAt, "session")).not.toThrow();
   });
 
   test("assertDifferentIds は同一でエラー", () => {

--- a/server/domain/models/circle-session/circle-session.test.ts
+++ b/server/domain/models/circle-session/circle-session.test.ts
@@ -91,4 +91,54 @@ describe("CircleSession ドメイン", () => {
 
     expect(rescheduled.startsAt.toISOString()).toBe("2024-01-02T10:00:00.000Z");
   });
+
+  test("rescheduleCircleSession は不正な日時を拒否する", () => {
+    const session = createCircleSession({
+      id: circleSessionId("session-1"),
+      circleId: circleId("circle-1"),
+      sequence: 1,
+      title: "第1回 研究会",
+      startsAt: new Date("2024-01-01T10:00:00Z"),
+      endsAt: new Date("2024-01-01T12:00:00Z"),
+    });
+
+    expect(() =>
+      rescheduleCircleSession(
+        session,
+        new Date("invalid"),
+        new Date("2024-01-02T12:00:00Z"),
+      ),
+    ).toThrow("startsAt must be a valid date");
+  });
+
+  test("rescheduleCircleSession は開始が終了より後なら拒否する", () => {
+    const session = createCircleSession({
+      id: circleSessionId("session-1"),
+      circleId: circleId("circle-1"),
+      sequence: 1,
+      title: "第1回 研究会",
+      startsAt: new Date("2024-01-01T10:00:00Z"),
+      endsAt: new Date("2024-01-01T12:00:00Z"),
+    });
+
+    expect(() =>
+      rescheduleCircleSession(
+        session,
+        new Date("2024-01-02T13:00:00Z"),
+        new Date("2024-01-02T12:00:00Z"),
+      ),
+    ).toThrow("CircleSession start must be before or equal to end");
+  });
+
+  test("createCircleSession は note 未指定時に空文字を設定する", () => {
+    const session = createCircleSession({
+      id: circleSessionId("session-1"),
+      circleId: circleId("circle-1"),
+      sequence: 1,
+      startsAt: new Date("2024-01-01T10:00:00Z"),
+      endsAt: new Date("2024-01-01T12:00:00Z"),
+    });
+
+    expect(session.note).toBe("");
+  });
 });

--- a/server/domain/models/circle/circle.test.ts
+++ b/server/domain/models/circle/circle.test.ts
@@ -23,4 +23,9 @@ describe("Circle ドメイン", () => {
     const renamed = renameCircle(circle, "  Next ");
     expect(renamed.name).toBe("Next");
   });
+
+  test("renameCircle は空名を拒否する", () => {
+    const circle = createCircle({ id: circleId("circle-1"), name: "Home" });
+    expect(() => renameCircle(circle, "  ")).toThrow("Circle name is required");
+  });
 });

--- a/server/domain/models/match/match.test.ts
+++ b/server/domain/models/match/match.test.ts
@@ -3,6 +3,7 @@ import { circleSessionId, matchId, userId } from "@/server/domain/common/ids";
 import {
   createMatch,
   deleteMatch,
+  hasDifferentPlayers,
   updateMatchOutcome,
   updateMatchPlayers,
   restoreMatch,
@@ -114,5 +115,59 @@ describe("Match ドメイン", () => {
 
     expect(restored.deletedAt?.toISOString()).toBe("2024-01-02T00:00:00.000Z");
     expect(restored.outcome).toBe("P2_WIN");
+  });
+
+  test("restoreMatch は deletedAt が null の場合に null を設定する", () => {
+    const restored = restoreMatch({
+      id: matchId("match-1"),
+      circleSessionId: circleSessionId("session-1"),
+      order: 1,
+      player1Id: userId("user-1"),
+      player2Id: userId("user-2"),
+      outcome: "P1_WIN",
+      deletedAt: null,
+    });
+
+    expect(restored.deletedAt).toBeNull();
+  });
+
+  test("restoreMatch は deletedAt が undefined の場合に null を設定する", () => {
+    const restored = restoreMatch({
+      id: matchId("match-1"),
+      circleSessionId: circleSessionId("session-1"),
+      order: 1,
+      player1Id: userId("user-1"),
+      player2Id: userId("user-2"),
+      outcome: "P1_WIN",
+      deletedAt: undefined,
+    });
+
+    expect(restored.deletedAt).toBeNull();
+  });
+
+  test("deleteMatch は引数なしでデフォルトの日時を設定する", () => {
+    const match = createMatch({
+      id: matchId("match-1"),
+      circleSessionId: circleSessionId("session-1"),
+      order: 1,
+      player1Id: userId("user-1"),
+      player2Id: userId("user-2"),
+    });
+
+    const before = new Date();
+    const deleted = deleteMatch(match);
+    const after = new Date();
+
+    expect(deleted.deletedAt).not.toBeNull();
+    expect(deleted.deletedAt!.getTime()).toBeGreaterThanOrEqual(before.getTime());
+    expect(deleted.deletedAt!.getTime()).toBeLessThanOrEqual(after.getTime());
+  });
+
+  test("hasDifferentPlayers は異なるプレイヤーで true を返す", () => {
+    expect(hasDifferentPlayers(userId("user-1"), userId("user-2"))).toBe(true);
+  });
+
+  test("hasDifferentPlayers は同一プレイヤーで false を返す", () => {
+    expect(hasDifferentPlayers(userId("user-1"), userId("user-1"))).toBe(false);
   });
 });

--- a/server/domain/services/authz/ownership.test.ts
+++ b/server/domain/services/authz/ownership.test.ts
@@ -79,6 +79,16 @@ describe("Owner の不変条件", () => {
     ).toThrow("Target member not found");
   });
 
+  test("transferCircleOwnership は同一ユーザーへの移譲を拒否する", () => {
+    expect(() =>
+      transferCircleOwnership(
+        [{ userId: userId("user-1"), role: CircleRole.CircleOwner }],
+        userId("user-1"),
+        userId("user-1"),
+      ),
+    ).toThrow("owner transfer must be different");
+  });
+
   test("assertSingleCircleSessionOwner は Owner が 1 人なら通る", () => {
     expect(() =>
       assertSingleCircleSessionOwner([
@@ -159,5 +169,39 @@ describe("Owner の不変条件", () => {
         userId("user-1"),
       ),
     ).toThrow("owner transfer must be different");
+  });
+
+  test("transferCircleSessionOwnership は Owner 以外からの移譲を拒否する", () => {
+    expect(() =>
+      transferCircleSessionOwnership(
+        [
+          {
+            userId: userId("user-1"),
+            role: CircleSessionRole.CircleSessionManager,
+          },
+          {
+            userId: userId("user-2"),
+            role: CircleSessionRole.CircleSessionOwner,
+          },
+        ],
+        userId("user-1"),
+        userId("user-2"),
+      ),
+    ).toThrow("Current owner must be CircleSessionOwner");
+  });
+
+  test("transferCircleSessionOwnership は移譲先がいない場合に失敗する", () => {
+    expect(() =>
+      transferCircleSessionOwnership(
+        [
+          {
+            userId: userId("user-1"),
+            role: CircleSessionRole.CircleSessionOwner,
+          },
+        ],
+        userId("user-1"),
+        userId("user-2"),
+      ),
+    ).toThrow("Target member not found");
   });
 });

--- a/server/domain/services/authz/policies.test.ts
+++ b/server/domain/services/authz/policies.test.ts
@@ -252,18 +252,24 @@ describe("認可ポリシー", () => {
   });
 
   describe("対局", () => {
+    // 対局関連の5つのポリシー（記録・閲覧・編集・削除・履歴閲覧）は
+    // すべて同一の認可条件「研究会メンバーまたは開催回メンバーであること」を持つ。
+    // そのため同一のテストケースを共有し、ポリシー間の一貫性を保証している。
     const cases = [
       {
+        label: "CircleMember",
         circle: member(CircleMember),
         session: noSessionMember(),
         expected: true,
       },
       {
+        label: "CircleSessionMember",
         circle: noMember(),
         session: sessionMember(CircleSessionMember),
         expected: true,
       },
       {
+        label: "非メンバー",
         circle: noMember(),
         session: noSessionMember(),
         expected: false,
@@ -280,7 +286,7 @@ describe("認可ポリシー", () => {
 
     for (const policy of policies) {
       test.each(cases)(
-        `${policy.label}: $expected`,
+        `${policy.label}: $label → $expected`,
         ({ circle, session, expected }) => {
           expect(policy.fn(circle, session)).toBe(expected);
         },

--- a/server/domain/services/circle-session/participation.test.ts
+++ b/server/domain/services/circle-session/participation.test.ts
@@ -17,6 +17,12 @@ const baseMatch = () =>
   });
 
 describe("開催回参加取消の不変条件", () => {
+  test("対局が0件なら参加者を削除できる", () => {
+    expect(() =>
+      assertCanRemoveCircleSessionParticipation([], userId("user-1")),
+    ).not.toThrow();
+  });
+
   test("対局に登場する参加者は削除できない", () => {
     const matches = [baseMatch()];
 


### PR DESCRIPTION
## Summary

Issue #11 で指摘されたDomain層テストの軽微な改善を実施。テストを仕様書として読んだときの網羅性向上が目的。

### 追加したテストケース

| グループ | 内容 |
|----------|------|
| A-1〜A-3 | バリデーション関数（空文字、負数、正常系） |
| B1-1 | `renameCircle` の空名拒否 |
| B3-2〜B3-4 | `restoreMatch`（null/undefined deletedAt）、`deleteMatch`（引数なし）、`hasDifferentPlayers` |
| B5-2〜B5-3 | `rescheduleCircleSession` 異常系、`note` デフォルト値 |
| C3-1〜C3-2 | 所有権移譲テストをCircle/CircleSession間で対称に |
| C4-1〜C4-2 | 対局ポリシーにコメント追加とラベル改善 |
| C5-1 | 空配列での参加者削除テスト |

## Test plan

- [x] `npm run test:run` で全359テストが成功

Closes #11

🤖 Generated with [Claude Code](https://claude.com/claude-code)