### PR TITLE
feat: Next.jsファイルコンベンションに基づくエラーページの実装

### DIFF
--- a/app/error.tsx
+++ b/app/error.tsx
@@ -1,0 +1,56 @@
+"use client";
+
+import { useEffect } from "react";
+import Link from "next/link";
+import { Button } from "@/components/ui/button";
+
+type ErrorProps = {
+  error: Error & { digest?: string };
+  reset: () => void;
+};
+
+export default function Error({ error, reset }: ErrorProps) {
+  useEffect(() => {
+    console.error("Error caught by error boundary:", error);
+  }, [error]);
+
+  return (
+    <div className="flex min-h-svh flex-col items-center justify-center px-6">
+      <div className="max-w-md space-y-6 text-center">
+        <h1 className="text-6xl font-bold text-destructive">Error</h1>
+        <h2 className="text-2xl font-(--font-display) text-(--brand-ink)">
+          エラーが発生しました
+        </h2>
+        <p className="text-sm leading-relaxed text-(--brand-ink-muted)">
+          予期しないエラーが発生しました。再試行するか、しばらくしてからもう一度お試しください。
+        </p>
+        {process.env.NODE_ENV === "development" && (
+          <div className="rounded-lg border border-destructive/30 bg-destructive/5 p-4 text-left">
+            <p className="text-xs font-semibold text-destructive">
+              開発環境のみ表示
+            </p>
+            <p className="mt-2 break-all font-mono text-xs text-(--brand-ink-muted)">
+              {error.message}
+            </p>
+            {error.digest && (
+              <p className="mt-1 font-mono text-xs text-(--brand-ink-muted)">
+                Digest: {error.digest}
+              </p>
+            )}
+          </div>
+        )}
+        <div className="flex flex-col gap-3 sm:flex-row sm:justify-center">
+          <Button
+            onClick={reset}
+            className="bg-(--brand-moss) hover:bg-(--brand-moss)/90"
+          >
+            再試行
+          </Button>
+          <Button variant="outline" asChild>
+            <Link href="/">ホームに戻る</Link>
+          </Button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/app/global-error.tsx
+++ b/app/global-error.tsx
@@ -1,0 +1,158 @@
+"use client";
+
+import { useEffect } from "react";
+
+type GlobalErrorProps = {
+  error: Error & { digest?: string };
+  reset: () => void;
+};
+
+export default function GlobalError({ error, reset }: GlobalErrorProps) {
+  useEffect(() => {
+    console.error("Global error caught:", error);
+  }, [error]);
+
+  return (
+    <html lang="ja">
+      <body
+        style={{
+          margin: 0,
+          minHeight: "100svh",
+          display: "flex",
+          alignItems: "center",
+          justifyContent: "center",
+          fontFamily:
+            "'Zen Maru Gothic', 'Hiragino Kaku Gothic ProN', 'Yu Gothic', sans-serif",
+          backgroundColor: "#ffffff",
+          color: "#333333",
+        }}
+      >
+        <div
+          style={{
+            maxWidth: "28rem",
+            padding: "1.5rem",
+            textAlign: "center",
+          }}
+        >
+          <h1
+            style={{
+              fontSize: "3.75rem",
+              fontWeight: "bold",
+              color: "#c94b4b",
+              margin: 0,
+            }}
+          >
+            Error
+          </h1>
+          <h2
+            style={{
+              fontSize: "1.5rem",
+              marginTop: "1rem",
+              fontFamily:
+                "'Shippori Mincho B1', 'Hiragino Mincho ProN', 'Yu Mincho', serif",
+            }}
+          >
+            重大なエラーが発生しました
+          </h2>
+          <p
+            style={{
+              fontSize: "0.875rem",
+              marginTop: "1rem",
+              lineHeight: 1.6,
+              color: "#666666",
+            }}
+          >
+            アプリケーションの読み込み中にエラーが発生しました。再試行するか、しばらくしてからもう一度お試しください。
+          </p>
+          {process.env.NODE_ENV === "development" && (
+            <div
+              style={{
+                marginTop: "1.5rem",
+                padding: "1rem",
+                borderRadius: "0.5rem",
+                border: "1px solid rgba(201, 75, 75, 0.3)",
+                backgroundColor: "rgba(201, 75, 75, 0.05)",
+                textAlign: "left",
+              }}
+            >
+              <p
+                style={{
+                  fontSize: "0.75rem",
+                  fontWeight: "600",
+                  color: "#c94b4b",
+                  margin: 0,
+                }}
+              >
+                開発環境のみ表示
+              </p>
+              <p
+                style={{
+                  fontSize: "0.75rem",
+                  marginTop: "0.5rem",
+                  fontFamily: "monospace",
+                  color: "#666666",
+                  wordBreak: "break-all",
+                }}
+              >
+                {error.message}
+              </p>
+              {error.digest && (
+                <p
+                  style={{
+                    fontSize: "0.75rem",
+                    marginTop: "0.25rem",
+                    fontFamily: "monospace",
+                    color: "#666666",
+                  }}
+                >
+                  Digest: {error.digest}
+                </p>
+              )}
+            </div>
+          )}
+          <div
+            style={{
+              marginTop: "1.5rem",
+              display: "flex",
+              flexDirection: "column",
+              gap: "0.75rem",
+            }}
+          >
+            <button
+              onClick={reset}
+              style={{
+                padding: "0.5rem 1rem",
+                fontSize: "0.875rem",
+                fontWeight: "500",
+                color: "#ffffff",
+                backgroundColor: "#4a7c59",
+                border: "none",
+                borderRadius: "0.375rem",
+                cursor: "pointer",
+              }}
+            >
+              再試行
+            </button>
+            {/* Using <a> intentionally - Link may not work when root layout fails */}
+            {/* eslint-disable-next-line @next/next/no-html-link-for-pages */}
+            <a
+              href="/"
+              style={{
+                padding: "0.5rem 1rem",
+                fontSize: "0.875rem",
+                fontWeight: "500",
+                color: "#333333",
+                backgroundColor: "transparent",
+                border: "1px solid #e5e5e5",
+                borderRadius: "0.375rem",
+                textDecoration: "none",
+              }}
+            >
+              ホームに戻る
+            </a>
+          </div>
+        </div>
+      </body>
+    </html>
+  );
+}

--- a/app/not-found.tsx
+++ b/app/not-found.tsx
@@ -1,0 +1,21 @@
+import Link from "next/link";
+import { Button } from "@/components/ui/button";
+
+export default function NotFound() {
+  return (
+    <div className="flex min-h-svh flex-col items-center justify-center px-6">
+      <div className="max-w-md space-y-6 text-center">
+        <h1 className="text-6xl font-bold text-(--brand-moss)">404</h1>
+        <h2 className="text-2xl font-(--font-display) text-(--brand-ink)">
+          ページが見つかりません
+        </h2>
+        <p className="text-sm leading-relaxed text-(--brand-ink-muted)">
+          お探しのページは存在しないか、移動した可能性があります。
+        </p>
+        <Button asChild className="bg-(--brand-moss) hover:bg-(--brand-moss)/90">
+          <Link href="/">ホームに戻る</Link>
+        </Button>
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary

- Next.js App Routerのファイルコンベンションに基づいたカスタムエラーページを追加
- `circles/[circleId]/page.tsx` で `TRPCError NOT_FOUND` をキャッチして `notFound()` を呼ぶように修正

## Changes

### 新規ファイル
| ファイル | 説明 |
|---------|------|
| `app/not-found.tsx` | 404ページ（存在しないページへのアクセス時に表示） |
| `app/error.tsx` | エラーバウンダリ（ランタイムエラーをキャッチ、開発環境でエラー詳細表示） |
| `app/global-error.tsx` | ルートレイアウトエラー（layout.tsx でのエラーをキャッチ） |

### 変更ファイル
| ファイル | 変更内容 |
|---------|----------|
| `app/(authenticated)/circles/[circleId]/page.tsx` | `TRPCError NOT_FOUND` をキャッチして `notFound()` を呼ぶように修正 |

## Design

- プロジェクトのブランドカラー（moss, gold, sky, ink）を使用
- shadcn/ui Buttonコンポーネントを活用
- 日本語でのメッセージ表示
- 開発環境ではエラー詳細を表示

## Test plan

- [ ] 存在しないURLにアクセス → 404ページが表示される
- [ ] 存在しないCircle IDにアクセス → 404ページが表示される
- [ ] ランタイムエラー発生時 → エラーページが表示される

Closes #32

🤖 Generated with [Claude Code](https://claude.com/claude-code)