### PR TITLE
refactor: Presentation層のInfrastructure依存を解消

### DIFF
--- a/app/api/auth/signup/route.ts
+++ b/app/api/auth/signup/route.ts
@@ -1,5 +1,10 @@
 import { NextResponse } from "next/server";
-import { signupService } from "@/server/presentation/api/signup";
+import { createSignupService } from "@/server/application/auth/signup-service";
+import { prismaSignupRepository } from "@/server/infrastructure/repository/user/prisma-signup-repository";
+
+const signupService = createSignupService({
+  signupRepository: prismaSignupRepository,
+});
 
 type SignupPayload = {
   email?: string;

--- a/server/presentation/api/signup.ts
+++ b/server/presentation/api/signup.ts
@@ -1,6 +1,0 @@
-import { createSignupService } from "@/server/application/auth/signup-service";
-import { prismaSignupRepository } from "@/server/infrastructure/repository/user/prisma-signup-repository";
-
-export const signupService = createSignupService({
-  signupRepository: prismaSignupRepository,
-});


### PR DESCRIPTION
## Summary

- `server/presentation/api/signup.ts`を削除し、Route Handler (`app/api/auth/signup/route.ts`) で直接DI注入するよう変更
- Presentation層がInfrastructure層を直接importするクリーンアーキテクチャ違反を解消

## Test plan

- [x] `npx tsc --noEmit` - 型チェック通過
- [x] `npm run test:run` - 全332テスト通過
- [x] `npm run lint` - Lintエラーなし
- [x] `npm run dev` - サインアップ機能の動作確認済み

Closes #25

🤖 Generated with [Claude Code](https://claude.com/claude-code)