### PR TITLE
refactor: Infrastructure層のBranded型キャストを汎用ヘルパーに統一

### DIFF
--- a/server/infrastructure/common/id-utils.ts
+++ b/server/infrastructure/common/id-utils.ts
@@ -1,0 +1,13 @@
+/**
+ * Branded型のIDを永続化用の文字列に変換する。
+ * Branded型は実行時には単なる文字列だが、型システム上は異なる型として扱われる。
+ * Infrastructure層でPrismaに渡す際に使用する。
+ */
+export const toPersistenceId = <T extends string>(id: T): string => id;
+
+/**
+ * Branded型のID配列を永続化用の文字列配列に変換する。
+ */
+export const toPersistenceIds = <T extends string>(
+  ids: readonly T[],
+): string[] => ids.map((id) => id);

--- a/server/infrastructure/mappers/circle-mapper.ts
+++ b/server/infrastructure/mappers/circle-mapper.ts
@@ -2,6 +2,7 @@ import type { Circle as PrismaCircle } from "@/generated/prisma/client";
 import { createCircle } from "@/server/domain/models/circle/circle";
 import type { Circle } from "@/server/domain/models/circle/circle";
 import { circleId } from "@/server/domain/common/ids";
+import { toPersistenceId } from "@/server/infrastructure/common/id-utils";
 
 export const mapCircleToDomain = (circle: PrismaCircle): Circle =>
   createCircle({
@@ -11,7 +12,7 @@ export const mapCircleToDomain = (circle: PrismaCircle): Circle =>
   });
 
 export const mapCircleToPersistence = (circle: Circle) => ({
-  id: circle.id as string,
+  id: toPersistenceId(circle.id),
   name: circle.name,
   createdAt: circle.createdAt,
 });

--- a/server/infrastructure/mappers/circle-participation-mapper.test.ts
+++ b/server/infrastructure/mappers/circle-participation-mapper.test.ts
@@ -1,16 +1,16 @@
 import { describe, expect, test } from "vitest";
 import { circleId, userId } from "@/server/domain/common/ids";
 import {
-  mapCircleIdToPersistence,
   mapCircleParticipationFromPersistence,
   mapCircleRoleFromPersistence,
   mapCircleRoleToPersistence,
 } from "@/server/infrastructure/mappers/circle-participation-mapper";
+import { toPersistenceId } from "@/server/infrastructure/common/id-utils";
 import { CircleRole } from "@/server/domain/services/authz/roles";
 
 describe("Circle 参加者マッパー", () => {
   test("CircleId を永続化向けに変換できる", () => {
-    const mapped = mapCircleIdToPersistence(circleId("circle-1"));
+    const mapped = toPersistenceId(circleId("circle-1"));
 
     expect(mapped).toBe("circle-1");
   });

--- a/server/infrastructure/mappers/circle-participation-mapper.ts
+++ b/server/infrastructure/mappers/circle-participation-mapper.ts
@@ -1,10 +1,7 @@
-import type { CircleId } from "@/server/domain/common/ids";
 import { circleId, userId } from "@/server/domain/common/ids";
 import type { CircleParticipation } from "@/server/domain/models/circle/circle-participation";
 import type { CircleRole } from "@/server/domain/services/authz/roles";
 import type { CircleRole as PrismaCircleRole } from "@/generated/prisma/enums";
-
-export const mapCircleIdToPersistence = (id: CircleId): string => id as string;
 
 export const mapCircleRoleToPersistence = (
   role: CircleRole,

--- a/server/infrastructure/mappers/circle-session-mapper.ts
+++ b/server/infrastructure/mappers/circle-session-mapper.ts
@@ -2,6 +2,7 @@ import type { CircleSession as PrismaCircleSession } from "@/generated/prisma/cl
 import { createCircleSession } from "@/server/domain/models/circle-session/circle-session";
 import type { CircleSession } from "@/server/domain/models/circle-session/circle-session";
 import { circleId, circleSessionId } from "@/server/domain/common/ids";
+import { toPersistenceId } from "@/server/infrastructure/common/id-utils";
 
 export const mapCircleSessionToDomain = (
   session: PrismaCircleSession,
@@ -19,8 +20,8 @@ export const mapCircleSessionToDomain = (
   });
 
 export const mapCircleSessionToPersistence = (session: CircleSession) => ({
-  id: session.id as string,
-  circleId: session.circleId as string,
+  id: toPersistenceId(session.id),
+  circleId: toPersistenceId(session.circleId),
   sequence: session.sequence,
   title: session.title,
   startsAt: session.startsAt,

--- a/server/infrastructure/mappers/circle-session-participation-mapper.test.ts
+++ b/server/infrastructure/mappers/circle-session-participation-mapper.test.ts
@@ -1,28 +1,25 @@
 import { describe, expect, test } from "vitest";
 import { circleSessionId, userId } from "@/server/domain/common/ids";
 import {
-  mapCircleSessionIdToPersistence,
   mapCircleSessionParticipationFromPersistence,
   mapCircleSessionRoleFromPersistence,
   mapCircleSessionRoleToPersistence,
-  mapUserIdsToPersistence,
 } from "@/server/infrastructure/mappers/circle-session-participation-mapper";
+import {
+  toPersistenceId,
+  toPersistenceIds,
+} from "@/server/infrastructure/common/id-utils";
 import { CircleSessionRole } from "@/server/domain/services/authz/roles";
 
 describe("CircleSession 参加者マッパー", () => {
   test("CircleSessionId を永続化向けに変換できる", () => {
-    const mapped = mapCircleSessionIdToPersistence(
-      circleSessionId("session-1"),
-    );
+    const mapped = toPersistenceId(circleSessionId("session-1"));
 
     expect(mapped).toBe("session-1");
   });
 
   test("UserId 配列を永続化向けに変換できる", () => {
-    const mapped = mapUserIdsToPersistence([
-      userId("user-1"),
-      userId("user-2"),
-    ]);
+    const mapped = toPersistenceIds([userId("user-1"), userId("user-2")]);
 
     expect(mapped).toEqual(["user-1", "user-2"]);
   });

--- a/server/infrastructure/mappers/circle-session-participation-mapper.ts
+++ b/server/infrastructure/mappers/circle-session-participation-mapper.ts
@@ -1,15 +1,7 @@
-import type { CircleSessionId, UserId } from "@/server/domain/common/ids";
 import { circleSessionId, userId } from "@/server/domain/common/ids";
 import type { CircleSessionParticipation } from "@/server/domain/models/circle-session/circle-session-participation";
 import type { CircleSessionRole } from "@/server/domain/services/authz/roles";
 import type { CircleSessionRole as PrismaCircleSessionRole } from "@/generated/prisma/enums";
-
-export const mapCircleSessionIdToPersistence = (
-  circleSessionId: CircleSessionId,
-): string => circleSessionId as string;
-
-export const mapUserIdsToPersistence = (userIds: readonly UserId[]): string[] =>
-  userIds.map((id) => id as string);
 
 export const mapCircleSessionRoleToPersistence = (
   role: CircleSessionRole,

--- a/server/infrastructure/mappers/match-history-mapper.ts
+++ b/server/infrastructure/mappers/match-history-mapper.ts
@@ -6,6 +6,7 @@ import type {
 } from "@/server/domain/models/match-history/match-history";
 import type { MatchOutcome } from "@/server/domain/models/match/match";
 import { matchHistoryId, matchId, userId } from "@/server/domain/common/ids";
+import { toPersistenceId } from "@/server/infrastructure/common/id-utils";
 
 export const mapMatchHistoryToDomain = (
   history: PrismaMatchHistory,
@@ -23,13 +24,13 @@ export const mapMatchHistoryToDomain = (
   });
 
 export const mapMatchHistoryToPersistence = (history: MatchHistory) => ({
-  id: history.id as string,
-  matchId: history.matchId as string,
-  editorId: history.editorId as string,
+  id: toPersistenceId(history.id),
+  matchId: toPersistenceId(history.matchId),
+  editorId: toPersistenceId(history.editorId),
   action: history.action,
   createdAt: history.createdAt,
   order: history.order,
-  player1Id: history.player1Id as string,
-  player2Id: history.player2Id as string,
+  player1Id: toPersistenceId(history.player1Id),
+  player2Id: toPersistenceId(history.player2Id),
   outcome: history.outcome,
 });

--- a/server/infrastructure/mappers/match-mapper.ts
+++ b/server/infrastructure/mappers/match-mapper.ts
@@ -2,6 +2,7 @@ import type { Match as PrismaMatch } from "@/generated/prisma/client";
 import { restoreMatch } from "@/server/domain/models/match/match";
 import type { Match, MatchOutcome } from "@/server/domain/models/match/match";
 import { circleSessionId, matchId, userId } from "@/server/domain/common/ids";
+import { toPersistenceId } from "@/server/infrastructure/common/id-utils";
 
 export const mapMatchToDomain = (match: PrismaMatch): Match =>
   restoreMatch({
@@ -15,11 +16,11 @@ export const mapMatchToDomain = (match: PrismaMatch): Match =>
   });
 
 export const mapMatchToPersistence = (match: Match) => ({
-  id: match.id as string,
-  circleSessionId: match.circleSessionId as string,
+  id: toPersistenceId(match.id),
+  circleSessionId: toPersistenceId(match.circleSessionId),
   order: match.order,
-  player1Id: match.player1Id as string,
-  player2Id: match.player2Id as string,
+  player1Id: toPersistenceId(match.player1Id),
+  player2Id: toPersistenceId(match.player2Id),
   outcome: match.outcome,
   deletedAt: match.deletedAt,
 });

--- a/server/infrastructure/mappers/user-mapper.ts
+++ b/server/infrastructure/mappers/user-mapper.ts
@@ -2,6 +2,7 @@ import type { User as PrismaUser } from "@/generated/prisma/client";
 import { createUser } from "@/server/domain/models/user/user";
 import type { User } from "@/server/domain/models/user/user";
 import { userId } from "@/server/domain/common/ids";
+import { toPersistenceId } from "@/server/infrastructure/common/id-utils";
 
 export const mapUserToDomain = (user: PrismaUser): User =>
   createUser({
@@ -13,7 +14,7 @@ export const mapUserToDomain = (user: PrismaUser): User =>
   });
 
 export const mapUserToPersistence = (user: User) => ({
-  id: user.id as string,
+  id: toPersistenceId(user.id),
   name: user.name,
   email: user.email,
   image: user.image,

--- a/server/infrastructure/repository/circle-session/prisma-circle-session-participation-repository.ts
+++ b/server/infrastructure/repository/circle-session/prisma-circle-session-participation-repository.ts
@@ -2,21 +2,22 @@ import type { CircleSessionParticipationRepository } from "@/server/domain/model
 import type { CircleSessionId, UserId } from "@/server/domain/common/ids";
 import { prisma } from "@/server/infrastructure/db";
 import {
-  mapCircleSessionIdToPersistence,
   mapCircleSessionParticipationFromPersistence,
   mapCircleSessionRoleToPersistence,
-  mapUserIdsToPersistence,
 } from "@/server/infrastructure/mappers/circle-session-participation-mapper";
 import type { CircleSessionRole } from "@/server/domain/services/authz/roles";
 import type { CircleSessionParticipation } from "@/server/domain/models/circle-session/circle-session-participation";
+import {
+  toPersistenceId,
+  toPersistenceIds,
+} from "@/server/infrastructure/common/id-utils";
 
 export const prismaCircleSessionParticipationRepository: CircleSessionParticipationRepository =
   {
     async listParticipations(
       circleSessionId: CircleSessionId,
     ): Promise<CircleSessionParticipation[]> {
-      const persistedCircleSessionId =
-        mapCircleSessionIdToPersistence(circleSessionId);
+      const persistedCircleSessionId = toPersistenceId(circleSessionId);
 
       const participations = await prisma.circleSessionMembership.findMany({
         where: { circleSessionId: persistedCircleSessionId },
@@ -27,7 +28,7 @@ export const prismaCircleSessionParticipationRepository: CircleSessionParticipat
     },
 
     async listByUserId(userId: UserId): Promise<CircleSessionParticipation[]> {
-      const [persistedUserId] = mapUserIdsToPersistence([userId]);
+      const persistedUserId = toPersistenceId(userId);
 
       const participations = await prisma.circleSessionMembership.findMany({
         where: { userId: persistedUserId },
@@ -42,9 +43,8 @@ export const prismaCircleSessionParticipationRepository: CircleSessionParticipat
       userId: UserId,
       role: CircleSessionRole,
     ): Promise<void> {
-      const persistedCircleSessionId =
-        mapCircleSessionIdToPersistence(circleSessionId);
-      const [persistedUserId] = mapUserIdsToPersistence([userId]);
+      const persistedCircleSessionId = toPersistenceId(circleSessionId);
+      const persistedUserId = toPersistenceId(userId);
       const persistedRole = mapCircleSessionRoleToPersistence(role);
 
       await prisma.circleSessionMembership.create({
@@ -61,9 +61,8 @@ export const prismaCircleSessionParticipationRepository: CircleSessionParticipat
       userId: UserId,
       role: CircleSessionRole,
     ): Promise<void> {
-      const persistedCircleSessionId =
-        mapCircleSessionIdToPersistence(circleSessionId);
-      const [persistedUserId] = mapUserIdsToPersistence([userId]);
+      const persistedCircleSessionId = toPersistenceId(circleSessionId);
+      const persistedUserId = toPersistenceId(userId);
       const persistedRole = mapCircleSessionRoleToPersistence(role);
 
       await prisma.circleSessionMembership.update({
@@ -83,9 +82,8 @@ export const prismaCircleSessionParticipationRepository: CircleSessionParticipat
       circleSessionId: CircleSessionId,
       userIds: readonly UserId[],
     ): Promise<boolean> {
-      const persistedCircleSessionId =
-        mapCircleSessionIdToPersistence(circleSessionId);
-      const uniqueIds = Array.from(new Set(mapUserIdsToPersistence(userIds)));
+      const persistedCircleSessionId = toPersistenceId(circleSessionId);
+      const uniqueIds = Array.from(new Set(toPersistenceIds(userIds)));
       if (uniqueIds.length === 0) {
         return false;
       }
@@ -104,9 +102,8 @@ export const prismaCircleSessionParticipationRepository: CircleSessionParticipat
       circleSessionId: CircleSessionId,
       userId: UserId,
     ): Promise<void> {
-      const persistedCircleSessionId =
-        mapCircleSessionIdToPersistence(circleSessionId);
-      const [persistedUserId] = mapUserIdsToPersistence([userId]);
+      const persistedCircleSessionId = toPersistenceId(circleSessionId);
+      const persistedUserId = toPersistenceId(userId);
 
       await prisma.circleSessionMembership.deleteMany({
         where: {

--- a/server/infrastructure/repository/circle-session/prisma-circle-session-repository.ts
+++ b/server/infrastructure/repository/circle-session/prisma-circle-session-repository.ts
@@ -6,11 +6,15 @@ import {
 } from "@/server/infrastructure/mappers/circle-session-mapper";
 import type { CircleSession } from "@/server/domain/models/circle-session/circle-session";
 import type { CircleId, CircleSessionId } from "@/server/domain/common/ids";
+import {
+  toPersistenceId,
+  toPersistenceIds,
+} from "@/server/infrastructure/common/id-utils";
 
 export const prismaCircleSessionRepository: CircleSessionRepository = {
   async findById(id: CircleSessionId): Promise<CircleSession | null> {
     const found = await prisma.circleSession.findUnique({
-      where: { id: id as string },
+      where: { id: toPersistenceId(id) },
     });
 
     return found ? mapCircleSessionToDomain(found) : null;
@@ -20,7 +24,7 @@ export const prismaCircleSessionRepository: CircleSessionRepository = {
     if (ids.length === 0) {
       return [];
     }
-    const uniqueIds = Array.from(new Set(ids.map((id) => id as string)));
+    const uniqueIds = Array.from(new Set(toPersistenceIds(ids)));
     const sessions = await prisma.circleSession.findMany({
       where: { id: { in: uniqueIds } },
     });
@@ -37,7 +41,7 @@ export const prismaCircleSessionRepository: CircleSessionRepository = {
 
   async listByCircleId(circleId: CircleId): Promise<CircleSession[]> {
     const sessions = await prisma.circleSession.findMany({
-      where: { circleId: circleId as string },
+      where: { circleId: toPersistenceId(circleId) },
       orderBy: { sequence: "asc" },
     });
 
@@ -62,6 +66,6 @@ export const prismaCircleSessionRepository: CircleSessionRepository = {
   },
 
   async delete(id: CircleSessionId): Promise<void> {
-    await prisma.circleSession.delete({ where: { id: id as string } });
+    await prisma.circleSession.delete({ where: { id: toPersistenceId(id) } });
   },
 };

--- a/server/infrastructure/repository/circle/prisma-circle-participation-repository.ts
+++ b/server/infrastructure/repository/circle/prisma-circle-participation-repository.ts
@@ -4,15 +4,15 @@ import type { CircleRole } from "@/server/domain/services/authz/roles";
 import type { CircleParticipation } from "@/server/domain/models/circle/circle-participation";
 import { prisma } from "@/server/infrastructure/db";
 import {
-  mapCircleIdToPersistence,
   mapCircleParticipationFromPersistence,
   mapCircleRoleToPersistence,
 } from "@/server/infrastructure/mappers/circle-participation-mapper";
+import { toPersistenceId } from "@/server/infrastructure/common/id-utils";
 
 export const prismaCircleParticipationRepository: CircleParticipationRepository =
   {
     async listByCircleId(circleId: CircleId): Promise<CircleParticipation[]> {
-      const persistedCircleId = mapCircleIdToPersistence(circleId);
+      const persistedCircleId = toPersistenceId(circleId);
 
       const participations = await prisma.circleMembership.findMany({
         where: { circleId: persistedCircleId },
@@ -24,7 +24,7 @@ export const prismaCircleParticipationRepository: CircleParticipationRepository 
 
     async listByUserId(userId: UserId): Promise<CircleParticipation[]> {
       const participations = await prisma.circleMembership.findMany({
-        where: { userId: userId as string },
+        where: { userId: toPersistenceId(userId) },
         orderBy: { createdAt: "desc" },
         select: { circleId: true, userId: true, role: true, createdAt: true },
       });
@@ -37,13 +37,13 @@ export const prismaCircleParticipationRepository: CircleParticipationRepository 
       userId: UserId,
       role: CircleRole,
     ): Promise<void> {
-      const persistedCircleId = mapCircleIdToPersistence(circleId);
+      const persistedCircleId = toPersistenceId(circleId);
       const persistedRole = mapCircleRoleToPersistence(role);
 
       await prisma.circleMembership.create({
         data: {
           circleId: persistedCircleId,
-          userId: userId as string,
+          userId: toPersistenceId(userId),
           role: persistedRole,
         },
       });
@@ -54,13 +54,13 @@ export const prismaCircleParticipationRepository: CircleParticipationRepository 
       userId: UserId,
       role: CircleRole,
     ): Promise<void> {
-      const persistedCircleId = mapCircleIdToPersistence(circleId);
+      const persistedCircleId = toPersistenceId(circleId);
       const persistedRole = mapCircleRoleToPersistence(role);
 
       await prisma.circleMembership.update({
         where: {
           userId_circleId: {
-            userId: userId as string,
+            userId: toPersistenceId(userId),
             circleId: persistedCircleId,
           },
         },
@@ -74,12 +74,12 @@ export const prismaCircleParticipationRepository: CircleParticipationRepository 
       circleId: CircleId,
       userId: UserId,
     ): Promise<void> {
-      const persistedCircleId = mapCircleIdToPersistence(circleId);
+      const persistedCircleId = toPersistenceId(circleId);
 
       await prisma.circleMembership.deleteMany({
         where: {
           circleId: persistedCircleId,
-          userId: userId as string,
+          userId: toPersistenceId(userId),
         },
       });
     },

--- a/server/infrastructure/repository/circle/prisma-circle-repository.ts
+++ b/server/infrastructure/repository/circle/prisma-circle-repository.ts
@@ -6,11 +6,15 @@ import {
   mapCircleToDomain,
   mapCircleToPersistence,
 } from "@/server/infrastructure/mappers/circle-mapper";
+import {
+  toPersistenceId,
+  toPersistenceIds,
+} from "@/server/infrastructure/common/id-utils";
 
 export const prismaCircleRepository: CircleRepository = {
   async findById(id: CircleId): Promise<Circle | null> {
     const found = await prisma.circle.findUnique({
-      where: { id: id as string },
+      where: { id: toPersistenceId(id) },
     });
 
     return found ? mapCircleToDomain(found) : null;
@@ -20,7 +24,7 @@ export const prismaCircleRepository: CircleRepository = {
     if (ids.length === 0) {
       return [];
     }
-    const uniqueIds = Array.from(new Set(ids.map((id) => id as string)));
+    const uniqueIds = Array.from(new Set(toPersistenceIds(ids)));
     const circles = await prisma.circle.findMany({
       where: { id: { in: uniqueIds } },
     });
@@ -45,6 +49,6 @@ export const prismaCircleRepository: CircleRepository = {
   },
 
   async delete(id: CircleId): Promise<void> {
-    await prisma.circle.delete({ where: { id: id as string } });
+    await prisma.circle.delete({ where: { id: toPersistenceId(id) } });
   },
 };

--- a/server/infrastructure/repository/match-history/prisma-match-history-repository.ts
+++ b/server/infrastructure/repository/match-history/prisma-match-history-repository.ts
@@ -6,11 +6,12 @@ import {
 } from "@/server/infrastructure/mappers/match-history-mapper";
 import type { MatchHistory } from "@/server/domain/models/match-history/match-history";
 import type { MatchId } from "@/server/domain/common/ids";
+import { toPersistenceId } from "@/server/infrastructure/common/id-utils";
 
 export const prismaMatchHistoryRepository: MatchHistoryRepository = {
   async listByMatchId(matchId: MatchId): Promise<MatchHistory[]> {
     const histories = await prisma.matchHistory.findMany({
-      where: { matchId: matchId as string },
+      where: { matchId: toPersistenceId(matchId) },
       orderBy: { createdAt: "asc" },
     });
 

--- a/server/infrastructure/repository/match/prisma-match-repository.ts
+++ b/server/infrastructure/repository/match/prisma-match-repository.ts
@@ -6,11 +6,12 @@ import {
 } from "@/server/infrastructure/mappers/match-mapper";
 import type { Match } from "@/server/domain/models/match/match";
 import type { CircleSessionId, MatchId } from "@/server/domain/common/ids";
+import { toPersistenceId } from "@/server/infrastructure/common/id-utils";
 
 export const prismaMatchRepository: MatchRepository = {
   async findById(id: MatchId): Promise<Match | null> {
     const found = await prisma.match.findUnique({
-      where: { id: id as string },
+      where: { id: toPersistenceId(id) },
     });
 
     return found ? mapMatchToDomain(found) : null;
@@ -20,7 +21,7 @@ export const prismaMatchRepository: MatchRepository = {
     circleSessionId: CircleSessionId,
   ): Promise<Match[]> {
     const matches = await prisma.match.findMany({
-      where: { circleSessionId: circleSessionId as string },
+      where: { circleSessionId: toPersistenceId(circleSessionId) },
       orderBy: { order: "asc" },
     });
 

--- a/server/infrastructure/repository/user/prisma-user-repository.ts
+++ b/server/infrastructure/repository/user/prisma-user-repository.ts
@@ -6,14 +6,15 @@ import {
   mapUserToDomain,
   mapUserToPersistence,
 } from "@/server/infrastructure/mappers/user-mapper";
-
-const mapIdsToPersistence = (ids: readonly UserId[]) =>
-  ids.map((id) => id as string);
+import {
+  toPersistenceId,
+  toPersistenceIds,
+} from "@/server/infrastructure/common/id-utils";
 
 export const prismaUserRepository: UserRepository = {
   async findById(id: UserId): Promise<User | null> {
     const found = await prisma.user.findUnique({
-      where: { id: id as string },
+      where: { id: toPersistenceId(id) },
     });
 
     return found ? mapUserToDomain(found) : null;
@@ -23,7 +24,7 @@ export const prismaUserRepository: UserRepository = {
     if (ids.length === 0) {
       return [];
     }
-    const uniqueIds = Array.from(new Set(mapIdsToPersistence(ids)));
+    const uniqueIds = Array.from(new Set(toPersistenceIds(ids)));
     const users = await prisma.user.findMany({
       where: { id: { in: uniqueIds } },
     });


### PR DESCRIPTION
## Summary
- `toPersistenceId`/`toPersistenceIds` ヘルパー関数を `server/infrastructure/common/id-utils.ts` に作成
- マッパー・リポジトリで使用していた `as string` キャストを汎用ヘルパーに置き換え
- 既存のファイルローカルヘルパー（`mapCircleIdToPersistence`、`mapCircleSessionIdToPersistence`、`mapUserIdsToPersistence`など）を削除

## Test plan
- [x] `npm run test:run` - 全332件のテストがパス
- [x] `npx tsc --noEmit` - 型チェックがパス
- [x] `npm run lint` - Lintエラーなし

Closes #27

🤖 Generated with [Claude Code](https://claude.com/claude-code)