### PR TITLE
test: 全サービステストに認可拒否時のテストを追加

### DIFF
--- a/server/application/circle-session/circle-session-participation-service.test.ts
+++ b/server/application/circle-session/circle-session-participation-service.test.ts
@@ -91,6 +91,42 @@ beforeEach(() => {
 });
 
 describe("CircleSession 参加関係サービス", () => {
+  describe("認可拒否時のエラー", () => {
+    test("listParticipations は認可拒否時に Forbidden エラー", async () => {
+      vi.mocked(accessService.canViewCircleSession).mockResolvedValue(false);
+
+      await expect(
+        service.listParticipations({
+          actorId: "user-actor",
+          circleSessionId: circleSessionId("session-1"),
+        }),
+      ).rejects.toThrow("Forbidden");
+
+      expect(
+        circleSessionParticipationRepository.listParticipations,
+      ).not.toHaveBeenCalled();
+    });
+
+    test("addParticipation は認可拒否時に Forbidden エラー", async () => {
+      vi.mocked(accessService.canAddCircleSessionMember).mockResolvedValue(
+        false,
+      );
+
+      await expect(
+        service.addParticipation({
+          actorId: "user-actor",
+          circleSessionId: circleSessionId("session-1"),
+          userId: userId("user-1"),
+          role: "CircleSessionMember",
+        }),
+      ).rejects.toThrow("Forbidden");
+
+      expect(
+        circleSessionParticipationRepository.addParticipation,
+      ).not.toHaveBeenCalled();
+    });
+  });
+
   test("listParticipations は一覧を返す", async () => {
     vi.mocked(
       circleSessionParticipationRepository.listParticipations,

--- a/server/application/circle/circle-participation-service.test.ts
+++ b/server/application/circle/circle-participation-service.test.ts
@@ -46,6 +46,40 @@ beforeEach(() => {
 });
 
 describe("Circle 参加関係サービス", () => {
+  describe("認可拒否時のエラー", () => {
+    test("listByCircleId は認可拒否時に Forbidden エラー", async () => {
+      vi.mocked(accessService.canViewCircle).mockResolvedValue(false);
+
+      await expect(
+        service.listByCircleId({
+          actorId: "user-actor",
+          circleId: circleId("circle-1"),
+        }),
+      ).rejects.toThrow("Forbidden");
+
+      expect(
+        circleParticipationRepository.listByCircleId,
+      ).not.toHaveBeenCalled();
+    });
+
+    test("addParticipation は認可拒否時に Forbidden エラー", async () => {
+      vi.mocked(accessService.canAddCircleMember).mockResolvedValue(false);
+
+      await expect(
+        service.addParticipation({
+          actorId: "user-actor",
+          circleId: circleId("circle-1"),
+          userId: userId("user-1"),
+          role: "CircleMember",
+        }),
+      ).rejects.toThrow("Forbidden");
+
+      expect(
+        circleParticipationRepository.addParticipation,
+      ).not.toHaveBeenCalled();
+    });
+  });
+
   test("listByCircleId は一覧を返す", async () => {
     const createdAt = new Date("2025-01-01T00:00:00Z");
     vi.mocked(

--- a/server/application/circle/circle-service.test.ts
+++ b/server/application/circle/circle-service.test.ts
@@ -38,6 +38,39 @@ beforeEach(() => {
 });
 
 describe("Circle サービス", () => {
+  describe("認可拒否時のエラー", () => {
+    test("createCircle は認可拒否時に Forbidden エラー", async () => {
+      vi.mocked(accessService.canCreateCircle).mockResolvedValue(false);
+
+      await expect(
+        service.createCircle({
+          actorId: "user-1",
+          id: circleId("circle-1"),
+          name: "Home",
+          createdAt: new Date("2024-01-01T00:00:00Z"),
+        }),
+      ).rejects.toThrow("Forbidden");
+
+      expect(circleRepository.save).not.toHaveBeenCalled();
+    });
+
+    test("renameCircle は認可拒否時に Forbidden エラー", async () => {
+      const existing = createCircle({
+        id: circleId("circle-1"),
+        name: "Home",
+        createdAt: new Date("2024-01-01T00:00:00Z"),
+      });
+      vi.mocked(circleRepository.findById).mockResolvedValue(existing);
+      vi.mocked(accessService.canEditCircle).mockResolvedValue(false);
+
+      await expect(
+        service.renameCircle("user-1", existing.id, "Next"),
+      ).rejects.toThrow("Forbidden");
+
+      expect(circleRepository.save).not.toHaveBeenCalled();
+    });
+  });
+
   test("createCircle は研究会を保存する", async () => {
     const createdAt = new Date("2024-01-01T00:00:00Z");
 


### PR DESCRIPTION
## Summary

- Application層の全サービステストに、認可拒否時（AccessServiceが`false`を返した場合）のテストを追加
- 各サービスが認可結果を正しくハンドリングし、`ForbiddenError`をスローすることを検証

## Changes

| ファイル | 追加テスト |
|---------|-----------|
| circle-service.test.ts | createCircle, renameCircle |
| circle-participation-service.test.ts | listByCircleId, addParticipation |
| circle-session-service.test.ts | createCircleSession, rescheduleCircleSession |
| circle-session-participation-service.test.ts | listParticipations, addParticipation |
| match-service.test.ts | recordMatch, updateMatch |
| match-history-service.test.ts | listByMatchId |

## Test plan

- [x] `npm run test:run -- server/application` で全テストがパス
- [x] 型チェック（`npx tsc --noEmit`）がパス
- [x] lint（`npm run lint`）がパス

Closes #12

🤖 Generated with [Claude Code](https://claude.ai/code)