### PR TITLE
feat: ヘッダーにユーザーメニューを追加

### DIFF
--- a/app/components/header.tsx
+++ b/app/components/header.tsx
@@ -1,8 +1,7 @@
 "use client";
 
-import { Button } from "@/components/ui/button";
 import { SidebarTrigger } from "@/components/ui/sidebar";
-import { signOut } from "next-auth/react";
+import UserMenu from "./user-menu";
 
 export default function Header() {
   return (
@@ -12,11 +11,7 @@ export default function Header() {
         <span className="text-lg font-semibold">将研ログ</span>
       </div>
 
-      <div className="flex gap-2">
-        <Button variant="outline" onClick={() => signOut({ callbackUrl: "/" })}>
-          ログアウト
-        </Button>
-      </div>
+      <UserMenu />
     </header>
   );
 }

--- a/app/components/user-menu.tsx
+++ b/app/components/user-menu.tsx
@@ -1,0 +1,68 @@
+"use client";
+
+import { useSession, signOut } from "next-auth/react";
+import { useTheme } from "next-themes";
+import { User, Sun, Moon, LogOut, Trash2 } from "lucide-react";
+import { Button } from "@/components/ui/button";
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuTrigger,
+} from "@/components/ui/dropdown-menu";
+
+export default function UserMenu() {
+  const { data: session } = useSession();
+  const { theme, setTheme } = useTheme();
+
+  const handleLogout = () => {
+    signOut({ callbackUrl: "/" });
+  };
+
+  const handleDeleteAccount = () => {
+    alert("アカウント削除機能は現在実装中です");
+  };
+
+  const toggleTheme = () => {
+    setTheme(theme === "dark" ? "light" : "dark");
+  };
+
+  return (
+    <DropdownMenu>
+      <DropdownMenuTrigger asChild>
+        <Button variant="outline" size="icon" aria-label="ユーザーメニュー">
+          <User className="h-4 w-4" />
+        </Button>
+      </DropdownMenuTrigger>
+      <DropdownMenuContent align="end" className="w-48">
+        <div className="px-3 py-2 text-sm font-medium border-b">
+          {session?.user?.name ?? "ユーザー"}
+        </div>
+        <DropdownMenuItem onClick={toggleTheme}>
+          {theme === "dark" ? (
+            <>
+              <Sun className="mr-2 h-4 w-4" />
+              ライトモード
+            </>
+          ) : (
+            <>
+              <Moon className="mr-2 h-4 w-4" />
+              ダークモード
+            </>
+          )}
+        </DropdownMenuItem>
+        <DropdownMenuItem onClick={handleLogout}>
+          <LogOut className="mr-2 h-4 w-4" />
+          ログアウト
+        </DropdownMenuItem>
+        <DropdownMenuItem
+          onClick={handleDeleteAccount}
+          className="text-destructive focus:text-destructive"
+        >
+          <Trash2 className="mr-2 h-4 w-4" />
+          アカウント削除
+        </DropdownMenuItem>
+      </DropdownMenuContent>
+    </DropdownMenu>
+  );
+}

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -31,7 +31,7 @@ export default function RootLayout({
   children: React.ReactNode;
 }) {
   return (
-    <html lang="ja">
+    <html lang="ja" suppressHydrationWarning>
       <body
         className={`${zenMaru.variable} ${shippori.variable} min-h-svh w-screen bg-background overflow-x-hidden`}
       >

--- a/app/providers.tsx
+++ b/app/providers.tsx
@@ -1,6 +1,8 @@
 "use client";
 
 import type { ReactNode } from "react";
+import { SessionProvider } from "next-auth/react";
+import { ThemeProvider } from "next-themes";
 import { TrpcProvider } from "@/lib/trpc/client";
 
 type ProvidersProps = {
@@ -8,5 +10,11 @@ type ProvidersProps = {
 };
 
 export default function Providers({ children }: ProvidersProps) {
-  return <TrpcProvider>{children}</TrpcProvider>;
+  return (
+    <SessionProvider>
+      <ThemeProvider attribute="class" defaultTheme="system" enableSystem>
+        <TrpcProvider>{children}</TrpcProvider>
+      </ThemeProvider>
+    </SessionProvider>
+  );
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -31,6 +31,7 @@
         "lucide-react": "^0.556.0",
         "next": "16.0.10",
         "next-auth": "^4.24.13",
+        "next-themes": "^0.4.6",
         "pg": "^8.17.2",
         "react": "19.2.3",
         "react-dom": "19.2.3",
@@ -8112,6 +8113,16 @@
         "nodemailer": {
           "optional": true
         }
+      }
+    },
+    "node_modules/next-themes": {
+      "version": "0.4.6",
+      "resolved": "https://registry.npmjs.org/next-themes/-/next-themes-0.4.6.tgz",
+      "integrity": "sha512-pZvgD5L0IEvX5/9GWyHMf3m8BKiVQwsCMHfoFosXtXBMnaS0ZnIJ9ST4b4NqLVKDEm8QBxoNNGNaBv2JNF6XNA==",
+      "license": "MIT",
+      "peerDependencies": {
+        "react": "^16.8 || ^17 || ^18 || ^19 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17 || ^18 || ^19 || ^19.0.0-rc"
       }
     },
     "node_modules/next/node_modules/postcss": {

--- a/package.json
+++ b/package.json
@@ -43,6 +43,7 @@
     "lucide-react": "^0.556.0",
     "next": "16.0.10",
     "next-auth": "^4.24.13",
+    "next-themes": "^0.4.6",
     "pg": "^8.17.2",
     "react": "19.2.3",
     "react-dom": "19.2.3",


### PR DESCRIPTION
## Summary
- ヘッダーにドロップダウン形式のユーザーメニューを追加
- `next-themes` を導入してテーマ切り替え機能（ライト/ダークモード）を実装
- `SessionProvider` を追加してクライアントサイドでユーザー名を取得可能に

## 変更内容
- `app/providers.tsx`: SessionProvider, ThemeProvider を追加
- `app/layout.tsx`: suppressHydrationWarning を追加
- `app/components/user-menu.tsx`: ユーザーメニューコンポーネントを新規作成
- `app/components/header.tsx`: 既存のログアウトボタンを UserMenu に置き換え

## Test plan
- [ ] ログイン後、ヘッダー右側のユーザーアイコンをクリック
- [ ] ドロップダウンにユーザー名が表示されることを確認
- [ ] テーマ切り替え（ライト/ダーク）が動作することを確認
- [ ] ログアウトが動作することを確認
- [ ] アカウント削除をクリックすると警告アラートが表示されることを確認

Closes #6

🤖 Generated with [Claude Code](https://claude.com/claude-code)