### PR TITLE
feat: ユーザーメニューのトリガーにユーザー名を表示

### DIFF
--- a/app/components/user-menu.tsx
+++ b/app/components/user-menu.tsx
@@ -30,8 +30,9 @@ export default function UserMenu() {
   return (
     <DropdownMenu>
       <DropdownMenuTrigger asChild>
-        <Button variant="outline" size="icon" aria-label="ユーザーメニュー">
+        <Button variant="outline" aria-label="ユーザーメニュー">
           <User className="h-4 w-4" />
+          <span>{session?.user?.name ?? "ユーザー"}</span>
         </Button>
       </DropdownMenuTrigger>
       <DropdownMenuContent align="end" className="w-48">


### PR DESCRIPTION
## Summary

- ユーザーメニューのトリガーボタンにユーザー名を常に表示するように変更

## Changes

- `size="icon"` を削除してボタンを通常サイズに変更
- ユーザーアイコンの横にユーザー名を表示する `<span>` を追加

## Test plan

- [ ] 開発サーバーでログイン後、ヘッダーのユーザーメニューにユーザー名が表示されていることを確認
- [ ] ドロップダウンメニューの既存機能（テーマ切替、ログアウト、アカウント削除）が正常に動作することを確認

Closes #42

🤖 Generated with [Claude Code](https://claude.com/claude-code)