### PR TITLE
feat: サービス名を「SKKT」に変更

### DIFF
--- a/app/(authenticated)/help/page.tsx
+++ b/app/(authenticated)/help/page.tsx
@@ -3,10 +3,10 @@ export default function HelpPage() {
     <div className="mx-auto flex w-full max-w-3xl flex-col gap-6">
       <header className="rounded-3xl border border-border/60 bg-white/90 p-8 shadow-sm">
         <h1 className="mt-3 text-3xl font-(--font-display) text-(--brand-ink) sm:text-4xl">
-          将研ログについて
+          SKKTについて
         </h1>
         <p className="mt-4 text-sm leading-relaxed text-(--brand-ink-muted) sm:text-base">
-          将研ログは研究会の活動記録を効率的に行うための記録ツールです。
+          SKKT(将棋研究会管理ツール)は研究会の活動記録を効率的に行うための記録ツールです。
         </p>
       </header>
 

--- a/app/(public)/page.tsx
+++ b/app/(public)/page.tsx
@@ -33,10 +33,10 @@ export default async function LandingPage() {
           <div className="grid gap-8 lg:grid-cols-[1.2fr_0.8fr] lg:items-center">
             <div className="space-y-5">
               <h1 className="text-4xl font-(--font-display) text-(--brand-ink) sm:text-5xl">
-                将研ログ
+                SKKT
               </h1>
               <p className="max-w-2xl text-base leading-relaxed text-(--brand-ink-muted) sm:text-lg">
-                研究会の記録と共有を、迷わず続けられる場所へ。将研ログは、
+                研究会の記録と共有を、迷わず続けられる場所へ。SKKTは、
                 日程管理から振り返りまでをやさしく支える記録サービスです。
               </p>
             </div>

--- a/app/components/footer.tsx
+++ b/app/components/footer.tsx
@@ -1,7 +1,7 @@
 export default function Footer() {
   return (
     <footer className="border-t bg-muted p-3 text-center text-sm text-gray-600">
-      Copyright &copy; {new Date().getFullYear()} 将研ログ. All rights reserved.
+      Copyright &copy; {new Date().getFullYear()} SKKT. All rights reserved.
     </footer>
   );
 }

--- a/app/components/header.tsx
+++ b/app/components/header.tsx
@@ -8,7 +8,7 @@ export default function Header() {
     <header className="border-b bg-muted px-4 py-3 flex items-center justify-between">
       <div className="flex items-center gap-3">
         <SidebarTrigger className="md:hidden" />
-        <span className="text-lg font-semibold">将研ログ</span>
+        <span className="text-lg font-semibold">SKKT</span>
       </div>
 
       <UserMenu />

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -21,7 +21,7 @@ const shippori = Shippori_Mincho_B1({
 });
 
 export const metadata: Metadata = {
-  title: "将研ログ",
+  title: "SKKT",
   description: "将棋研究会の活動記録をつけるアプリケーション",
 };
 


### PR DESCRIPTION
## Summary

- サービス名を「将研ログ」から「SKKT」に変更
- ヘルプページではフルネーム「SKKT(将棋研究会管理ツール)」を使用

## 変更箇所

| ファイル | 変更内容 |
|---------|---------|
| `app/components/header.tsx` | ヘッダーのサービス名 |
| `app/components/footer.tsx` | フッターのコピーライト |
| `app/layout.tsx` | ページメタデータ(title) |
| `app/(authenticated)/help/page.tsx` | ヘルプページのタイトルと説明文 |
| `app/(public)/page.tsx` | ランディングページのタイトルと説明文 |

## Test plan

- [ ] ランディングページ (`/`) でタイトルが「SKKT」と表示される
- [ ] ログイン後、ヘッダーに「SKKT」が表示される
- [ ] ヘルプページ (`/help`) で「SKKTについて」と表示される
- [ ] ヘルプページの説明文に「SKKT(将棋研究会管理ツール)」と表示される
- [ ] フッターに「SKKT」が表示される
- [ ] ブラウザタブのタイトルが「SKKT」である

closes #44

🤖 Generated with [Claude Code](https://claude.com/claude-code)