### PR TITLE
chore: package.jsonのnameフィールドを「skkt」に更新

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,11 +1,11 @@
 {
-  "name": "shogi-ken-log",
+  "name": "skkt",
   "version": "0.1.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "shogi-ken-log",
+      "name": "skkt",
       "version": "0.1.0",
       "hasInstallScript": true,
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "shogi-ken-log",
+  "name": "skkt",
   "version": "0.1.0",
   "private": true,
   "scripts": {


### PR DESCRIPTION
## Summary
- `package.json` の `name` フィールドを `shogi-ken-log` から `skkt` に更新
- `package-lock.json` も合わせて再生成

## Background
Issue #44, #47 でサービス名を「SKKT」に変更したが、`package.json` には旧名称が残っていた。

## Test plan
- [x] 型チェック通過
- [x] 全357テスト通過
- [x] `private: true` のためnpm公開には影響なし

Closes #49

🤖 Generated with [Claude Code](https://claude.com/claude-code)