### PR TITLE
次回日程カードにセッションタイトルを表示する

### DIFF
--- a/app/(authenticated)/circles/components/circle-overview-view.tsx
+++ b/app/(authenticated)/circles/components/circle-overview-view.tsx
@@ -115,26 +115,31 @@ export function CircleOverviewView({
         <div className="flex flex-wrap items-start justify-between gap-6">
           <div className="min-w-60 flex-1">
             {heroContent ?? defaultHero}
-            {nextSession ? (
-              <LinkCard
-                href={nextSessionHref}
-                className="mt-4 block rounded-2xl border border-border/60 bg-white/80 px-4 py-3 text-sm transition hover:border-border hover:bg-white hover:shadow-sm"
-              >
-                <p className="text-xs font-semibold text-(--brand-ink)">
-                  次回日程
-                </p>
-                <p className="mt-1 text-(--brand-ink-muted)">
-                  {nextSession.dateTimeLabel}
-                  {nextSession.locationLabel
-                    ? ` / ${nextSession.locationLabel}`
-                    : ""}
-                </p>
-              </LinkCard>
-            ) : (
-              <div className="mt-4 rounded-2xl border border-dashed border-border/60 bg-white/70 px-4 py-3 text-xs text-(--brand-ink-muted)">
-                次回日程は未設定です
-              </div>
-            )}
+            <div className="mt-4">
+              <p className="mb-2 text-xs font-semibold text-(--brand-ink-muted)">
+                次回日程
+              </p>
+              {nextSession ? (
+                <LinkCard
+                  href={nextSessionHref}
+                  className="block rounded-2xl border border-border/60 bg-white/80 px-4 py-3 text-sm transition hover:border-border hover:bg-white hover:shadow-sm"
+                >
+                  <p className="text-sm font-semibold text-(--brand-ink)">
+                    {nextSession.title}
+                  </p>
+                  <p className="mt-1 text-xs text-(--brand-ink-muted)">
+                    {nextSession.dateTimeLabel}
+                    {nextSession.locationLabel
+                      ? ` / ${nextSession.locationLabel}`
+                      : ""}
+                  </p>
+                </LinkCard>
+              ) : (
+                <div className="rounded-2xl border border-dashed border-border/60 bg-white/70 px-4 py-3 text-xs text-(--brand-ink-muted)">
+                  次回日程は未設定です
+                </div>
+              )}
+            </div>
           </div>
           <div className="flex w-full flex-col gap-4 sm:w-auto sm:min-w-60 sm:max-w-[320px]">
             <div

--- a/server/presentation/providers/circle-overview-provider.ts
+++ b/server/presentation/providers/circle-overview-provider.ts
@@ -217,6 +217,9 @@ export const createCircleOverviewProvider = (
       nextSession: nextSession
         ? {
             id: nextSession.id as string,
+            title: nextSession.title?.trim()
+              ? nextSession.title
+              : buildSessionTitle(nextSession.sequence),
             dateTimeLabel: formatDateTimeRange(
               nextSession.startsAt,
               nextSession.endsAt,

--- a/server/presentation/view-models/circle-overview.ts
+++ b/server/presentation/view-models/circle-overview.ts
@@ -40,6 +40,7 @@ export type CircleOverviewViewModel = {
   scheduleNote: string | null;
   nextSession: {
     id: string | null;
+    title: string;
     dateTimeLabel: string;
     locationLabel: string | null;
   } | null;


### PR DESCRIPTION
## Summary

- `nextSession` ViewModelに `title` フィールドを追加
- Providerでセッションタイトルを生成（カスタムタイトルがない場合は `第N回 研究会` をフォールバック）
- 「次回日程」ラベルをカード外のセクション見出しに移動し、カード内にセッションタイトルを表示

## Test plan

- [x] TypeScript型チェック通過
- [x] ESLint通過
- [x] 全テスト通過（357 tests）
- [ ] 開発サーバーで次回日程カードの表示を目視確認

closes #52

🤖 Generated with [Claude Code](https://claude.com/claude-code)