### PR TITLE
ロール別デモ用の不要コードを削除する

### DIFF
--- a/app/(authenticated)/circle-sessions/components/circle-session-detail-container.tsx
+++ b/app/(authenticated)/circle-sessions/components/circle-session-detail-container.tsx
@@ -1,7 +1,4 @@
-import {
-  CircleSessionDetailView,
-  type CircleSessionRoleLink,
-} from "@/app/(authenticated)/circle-sessions/components/circle-session-detail-view";
+import { CircleSessionDetailView } from "@/app/(authenticated)/circle-sessions/components/circle-session-detail-view";
 import type {
   CircleSessionDetailProvider,
   CircleSessionDetailProviderInput,
@@ -11,19 +8,17 @@ export type CircleSessionDetailContainerProps = {
   provider: CircleSessionDetailProvider;
   circleSessionId: string;
   viewerId: CircleSessionDetailProviderInput["viewerId"];
-  roleLinks?: CircleSessionRoleLink[];
 };
 
 export async function CircleSessionDetailContainer({
   provider,
   circleSessionId,
   viewerId,
-  roleLinks,
 }: CircleSessionDetailContainerProps) {
   const detail = await provider.getDetail({
     circleSessionId,
     viewerId,
   });
 
-  return <CircleSessionDetailView detail={detail} roleLinks={roleLinks} />;
+  return <CircleSessionDetailView detail={detail} />;
 }

--- a/app/(authenticated)/circle-sessions/components/circle-session-detail-view.tsx
+++ b/app/(authenticated)/circle-sessions/components/circle-session-detail-view.tsx
@@ -1,7 +1,6 @@
 "use client";
 
 import { FormEvent, useEffect, useRef, useState } from "react";
-import Link from "next/link";
 import { Pencil } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import {
@@ -49,15 +48,8 @@ type RoleConfig = {
   actions: RoleAction[];
 };
 
-export type CircleSessionRoleLink = {
-  role: CircleSessionRoleKey;
-  label: string;
-  href: string;
-};
-
 export type CircleSessionDetailViewProps = {
   detail: CircleSessionDetailViewModel;
-  roleLinks?: CircleSessionRoleLink[];
 };
 
 const roleLabels: Record<CircleSessionRoleKey, string> = {
@@ -213,7 +205,6 @@ const getMatchOutcome = (
 
 export function CircleSessionDetailView({
   detail,
-  roleLinks,
 }: CircleSessionDetailViewProps) {
   const participations = detail.participations;
   const matches = detail.matches;
@@ -592,29 +583,6 @@ export function CircleSessionDetailView({
                 {roleLabel}
               </span>
             </div>
-            {roleLinks?.length ? (
-              <div className="flex flex-wrap items-center gap-2">
-                <p className="text-xs font-semibold text-(--brand-ink)">
-                  ロール別デモ
-                </p>
-                {roleLinks.map((link) => {
-                  const isActive = detail.viewerRole === link.role;
-                  return (
-                    <Link
-                      key={link.role}
-                      href={link.href}
-                      className={`rounded-full border px-3 py-1 text-xs transition ${
-                        isActive
-                          ? "border-(--brand-ink)/30 bg-(--brand-ink)/10 text-(--brand-ink)"
-                          : "border-border/60 bg-white/70 text-(--brand-ink-muted) hover:border-border hover:text-(--brand-ink)"
-                      }`}
-                    >
-                      {link.label}
-                    </Link>
-                  );
-                })}
-              </div>
-            ) : null}
           </div>
         ) : null}
       </section>

--- a/app/(authenticated)/circles/components/circle-overview-container.tsx
+++ b/app/(authenticated)/circles/components/circle-overview-container.tsx
@@ -2,22 +2,18 @@ import type { ReactNode } from "react";
 import { CircleOverviewView } from "@/app/(authenticated)/circles/components/circle-overview-view";
 import type {
   CircleOverviewProvider,
-  CircleOverviewProviderInput,
   CircleOverviewViewModel,
 } from "@/server/presentation/view-models/circle-overview";
 import type {
   CircleOverviewMember,
   CircleOverviewSession,
 } from "@/server/presentation/view-models/circle-overview";
-import type { CircleOverviewRoleLink } from "@/app/(authenticated)/circles/components/circle-overview-view";
 
 export type CircleOverviewContainerProps = {
   provider: CircleOverviewProvider;
   circleId: string;
   viewerId: string | null;
-  viewerRoleOverride?: CircleOverviewProviderInput["viewerRoleOverride"];
   heroContent?: ReactNode;
-  roleLinks?: CircleOverviewRoleLink[];
   getSessionHref?: (session: CircleOverviewSession) => string | null;
   getMemberHref?: (member: CircleOverviewMember) => string | null;
   getNextSessionHref?: (
@@ -29,9 +25,7 @@ export async function CircleOverviewContainer({
   provider,
   circleId,
   viewerId,
-  viewerRoleOverride,
   heroContent,
-  roleLinks,
   getSessionHref,
   getMemberHref,
   getNextSessionHref,
@@ -39,14 +33,12 @@ export async function CircleOverviewContainer({
   const overview = await provider.getOverview({
     circleId,
     viewerId,
-    viewerRoleOverride,
   });
 
   return (
     <CircleOverviewView
       overview={overview}
       heroContent={heroContent}
-      roleLinks={roleLinks}
       getSessionHref={getSessionHref}
       getMemberHref={getMemberHref}
       getNextSessionHref={getNextSessionHref}

--- a/app/(authenticated)/circles/components/circle-overview-view.tsx
+++ b/app/(authenticated)/circles/components/circle-overview-view.tsx
@@ -9,16 +9,9 @@ import type {
 import Link from "next/link";
 import type { ReactNode } from "react";
 
-export type CircleOverviewRoleLink = {
-  role: CircleRoleKey;
-  label: string;
-  href: string;
-};
-
 export type CircleOverviewViewProps = {
   overview: CircleOverviewViewModel;
   heroContent?: ReactNode;
-  roleLinks?: CircleOverviewRoleLink[];
   getSessionHref?: (session: CircleOverviewSession) => string | null;
   getMemberHref?: (member: CircleOverviewMember) => string | null;
   getNextSessionHref?: (
@@ -50,15 +43,6 @@ const sessionStatusClasses: Record<CircleSessionStatus, string> = {
   draft: "bg-(--brand-gold)/20 text-(--brand-ink)",
 };
 
-const panelStatusClasses: Record<string, string> = {
-  要対応: "bg-(--brand-gold)/25 text-(--brand-ink)",
-  進行中: "bg-(--brand-sky)/20 text-(--brand-ink)",
-  準備中: "bg-(--brand-moss)/20 text-(--brand-ink)",
-  登録済み: "bg-(--brand-moss)/20 text-(--brand-ink)",
-  確認中: "bg-(--brand-sky)/20 text-(--brand-ink)",
-  お知らせ: "bg-(--brand-ink)/10 text-(--brand-ink)",
-};
-
 type LinkCardProps = {
   href?: string | null;
   className: string;
@@ -80,7 +64,6 @@ const LinkCard = ({ href, className, children }: LinkCardProps) => {
 export function CircleOverviewView({
   overview,
   heroContent,
-  roleLinks,
   getSessionHref,
   getMemberHref,
   getNextSessionHref,
@@ -91,7 +74,6 @@ export function CircleOverviewView({
   const roleBadgeClassName = overview.viewerRole
     ? roleClasses[overview.viewerRole]
     : "bg-(--brand-ink)/10 text-(--brand-ink)";
-  const isSingleAction = overview.actions.length === 1;
   const scheduleText = overview.scheduleNote
     ? `参加者 ${overview.participationCount}名 / ${overview.scheduleNote}`
     : `参加者 ${overview.participationCount}名`;
@@ -150,58 +132,6 @@ export function CircleOverviewView({
               )}
             </div>
           </div>
-          <div className="flex w-full flex-col gap-4 sm:w-auto sm:min-w-60 sm:max-w-[320px]">
-            {roleLinks?.length ? (
-              <div className="flex flex-wrap items-center justify-end gap-2">
-                {roleLinks.map((link) => {
-                  const isActive = overview.viewerRole === link.role;
-                  return (
-                    <Link
-                      key={link.role}
-                      href={link.href}
-                      className={`rounded-full border px-2.5 py-0.5 text-xs transition ${
-                        isActive
-                          ? "border-(--brand-ink)/30 bg-(--brand-ink)/10 text-(--brand-ink)"
-                          : "border-border/60 bg-white/70 text-(--brand-ink-muted) hover:border-border hover:text-(--brand-ink)"
-                      }`}
-                    >
-                      {link.label}
-                    </Link>
-                  );
-                })}
-              </div>
-            ) : null}
-            <div
-              className={`flex gap-3 ${isSingleAction ? "flex-col" : "flex-wrap"}`}
-            >
-              {overview.actions.map((action) => {
-                const button = (
-                  <Button
-                    key={action.label}
-                    variant={action.variant}
-                    className={`${action.className ?? ""} ${isSingleAction ? "w-full" : ""}`.trim()}
-                  >
-                    {action.label}
-                  </Button>
-                );
-
-                if (!action.href) {
-                  return button;
-                }
-
-                return (
-                  <Button
-                    key={action.label}
-                    variant={action.variant}
-                    className={`${action.className ?? ""} ${isSingleAction ? "w-full" : ""}`.trim()}
-                    asChild
-                  >
-                    <Link href={action.href}>{action.label}</Link>
-                  </Button>
-                );
-              })}
-            </div>
-          </div>
         </div>
       </section>
 
@@ -258,47 +188,6 @@ export function CircleOverviewView({
         </div>
 
         <div className="flex flex-col gap-6">
-          {overview.rolePanel ? (
-            <div className="rounded-2xl border border-border/60 bg-white/90 p-6 shadow-sm">
-              <div className="flex items-center justify-between">
-                <p className="text-sm font-semibold text-(--brand-ink)">
-                  {overview.rolePanel.title}
-                </p>
-                <Button
-                  variant="ghost"
-                  className="text-xs text-(--brand-ink-muted) hover:text-(--brand-ink)"
-                >
-                  すべて見る
-                </Button>
-              </div>
-              <div className="mt-4 space-y-3">
-                {overview.rolePanel.items.map((item) => (
-                  <div
-                    key={item.title}
-                    className="flex items-center justify-between gap-4 rounded-xl border border-border/60 bg-white/70 p-4"
-                  >
-                    <div>
-                      <p className="text-sm font-semibold text-(--brand-ink)">
-                        {item.title}
-                      </p>
-                      <p className="text-xs text-(--brand-ink-muted)">
-                        {item.meta}
-                      </p>
-                    </div>
-                    <span
-                      className={`rounded-full px-2.5 py-1 text-xs ${
-                        panelStatusClasses[item.status] ??
-                        "bg-(--brand-ink)/10 text-(--brand-ink)"
-                      }`}
-                    >
-                      {item.status}
-                    </span>
-                  </div>
-                ))}
-              </div>
-            </div>
-          ) : null}
-
           <div className="rounded-2xl border border-border/60 bg-white/90 p-6 shadow-sm">
             <div className="flex items-center justify-between">
               <p className="text-sm font-semibold text-(--brand-ink)">

--- a/app/(authenticated)/home/circle-create-form.tsx
+++ b/app/(authenticated)/home/circle-create-form.tsx
@@ -8,7 +8,7 @@ import { Input } from "@/components/ui/input";
 import { trpc } from "@/lib/trpc/client";
 import { useRouter } from "next/navigation";
 
-export default function CircleCreateDemo() {
+export default function CircleCreateForm() {
   const [name, setName] = useState("");
   const createCircle = trpc.circles.create.useMutation();
   const router = useRouter();

--- a/app/(authenticated)/home/page.tsx
+++ b/app/(authenticated)/home/page.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { Button } from "@/components/ui/button";
-import CircleCreateDemo from "@/app/(authenticated)/home/circle-create-demo";
+import CircleCreateForm from "@/app/(authenticated)/home/circle-create-form";
 import Link from "next/link";
 import { trpc } from "@/lib/trpc/client";
 
@@ -103,7 +103,7 @@ export default function Home() {
           className="flex items-center rounded-2xl border border-border/60 bg-white/85 p-6 shadow-sm motion-safe:animate-[rise_0.7s_ease-out]"
           style={{ animationDelay: "140ms" }}
         >
-          <CircleCreateDemo />
+          <CircleCreateForm />
         </div>
       </section>
 

--- a/server/presentation/providers/circle-overview-provider.ts
+++ b/server/presentation/providers/circle-overview-provider.ts
@@ -2,8 +2,6 @@ import { CircleRole } from "@/server/domain/services/authz/roles";
 import { circleId, userId } from "@/server/domain/common/ids";
 import type { ServiceContainer } from "@/server/application/service-container";
 import type {
-  CircleOverviewAction,
-  CircleOverviewPanelItem,
   CircleOverviewProvider,
   CircleOverviewProviderInput,
   CircleOverviewSession,
@@ -12,79 +10,10 @@ import type {
 } from "@/server/presentation/view-models/circle-overview";
 import { NotFoundError } from "@/server/domain/common/errors";
 
-type RoleConfig = {
-  actions: CircleOverviewAction[];
-  panelTitle: string;
-  panelItems: CircleOverviewPanelItem[];
-};
-
 const roleKeyByDto: Record<CircleRole, CircleRoleKey> = {
   [CircleRole.CircleOwner]: "owner",
   [CircleRole.CircleManager]: "manager",
   [CircleRole.CircleMember]: "member",
-};
-
-const defaultActions: CircleOverviewAction[] = [
-  {
-    label: "開催日程を追加",
-    className: "bg-(--brand-moss) text-white hover:bg-(--brand-moss)/90",
-  },
-  {
-    label: "参加者を管理",
-    variant: "outline",
-    className:
-      "border-(--brand-moss)/30 bg-white/70 text-(--brand-ink) hover:bg-white",
-  },
-];
-
-const ownerManagerBase: Pick<
-  RoleConfig,
-  "actions" | "panelTitle" | "panelItems"
-> = {
-  actions: [
-    {
-      label: "開催日程を追加",
-      className:
-        "bg-(--brand-gold) text-(--brand-ink) hover:bg-(--brand-gold)/90",
-    },
-    {
-      label: "参加者を管理",
-      variant: "outline",
-      className:
-        "border-(--brand-gold)/40 bg-white/70 text-(--brand-ink) hover:bg-white",
-    },
-  ],
-  panelTitle: "運営タスク",
-  panelItems: [
-    { title: "参加申請の承認", meta: "承認待ち 2件", status: "要対応" },
-    { title: "次期の役割設定", meta: "4月期の割り当て", status: "準備中" },
-    { title: "開催場所の更新", meta: "京都キャンパス A", status: "進行中" },
-  ],
-};
-
-const roleConfigs: Record<CircleRoleKey, RoleConfig> = {
-  owner: { ...ownerManagerBase },
-  manager: { ...ownerManagerBase },
-  member: {
-    actions: [
-      {
-        label: "参加予定を登録",
-        className: "bg-(--brand-moss) text-white hover:bg-(--brand-moss)/90",
-      },
-      {
-        label: "参加者一覧",
-        variant: "outline",
-        className:
-          "border-(--brand-moss)/30 bg-white/70 text-(--brand-ink) hover:bg-white",
-      },
-    ],
-    panelTitle: "メンバーの参加メモ",
-    panelItems: [
-      { title: "次回の参加", meta: "出席で登録済み", status: "登録済み" },
-      { title: "対局テーマ", meta: "中盤の形を研究", status: "確認中" },
-      { title: "連絡事項", meta: "3/15 会場変更", status: "お知らせ" },
-    ],
-  },
 };
 
 const pad2 = (value: number) => String(value).padStart(2, "0");
@@ -179,15 +108,13 @@ export const createCircleOverviewProvider = (
     );
 
     const viewerId = input.viewerId ?? actorId ?? null;
-    const viewerRole =
-      input.viewerRoleOverride ??
-      getViewerRole(
-        participations.map((p) => ({
-          userId: p.userId as string,
-          role: p.role,
-        })),
-        viewerId,
-      );
+    const viewerRole = getViewerRole(
+      participations.map((p) => ({
+        userId: p.userId as string,
+        role: p.role,
+      })),
+      viewerId,
+    );
 
     const now = new Date();
     const recentSessions = sessions
@@ -228,13 +155,6 @@ export const createCircleOverviewProvider = (
           }
         : null,
       viewerRole,
-      actions: viewerRole ? roleConfigs[viewerRole].actions : defaultActions,
-      rolePanel: viewerRole
-        ? {
-            title: roleConfigs[viewerRole].panelTitle,
-            items: roleConfigs[viewerRole].panelItems,
-          }
-        : null,
       recentSessions,
       members: participations.map((participation) => ({
         userId: participation.userId as string,

--- a/server/presentation/view-models/circle-overview.ts
+++ b/server/presentation/view-models/circle-overview.ts
@@ -1,25 +1,6 @@
 export type CircleRoleKey = "owner" | "manager" | "member";
 export type CircleSessionStatus = "scheduled" | "done" | "draft";
 
-export type CircleOverviewAction = {
-  label: string;
-  variant?:
-    | "default"
-    | "outline"
-    | "ghost"
-    | "secondary"
-    | "destructive"
-    | "link";
-  className?: string;
-  href?: string;
-};
-
-export type CircleOverviewPanelItem = {
-  title: string;
-  meta: string;
-  status: string;
-};
-
 export type CircleOverviewSession = {
   id: string | null;
   title: string;
@@ -45,11 +26,6 @@ export type CircleOverviewViewModel = {
     locationLabel: string | null;
   } | null;
   viewerRole: CircleRoleKey | null;
-  actions: CircleOverviewAction[];
-  rolePanel: {
-    title: string;
-    items: CircleOverviewPanelItem[];
-  } | null;
   recentSessions: CircleOverviewSession[];
   members: CircleOverviewMember[];
 };
@@ -57,7 +33,6 @@ export type CircleOverviewViewModel = {
 export type CircleOverviewProviderInput = {
   circleId: string;
   viewerId: string | null;
-  viewerRoleOverride?: CircleRoleKey | null;
 };
 
 export type CircleOverviewProvider = {


### PR DESCRIPTION
## Summary
- セッション詳細・研究会概要ページからロール別デモUI（リンク、アクションボタン、ロールパネル）を削除
- `viewerRoleOverride` 基盤、`CircleOverviewAction`/`CircleOverviewPanelItem` 等の不要な型・定数を削除
- `circle-create-demo.tsx` を `circle-create-form.tsx` にリネーム（コンポーネント名も `CircleCreateForm` に変更）

## Test plan
- [x] `npx tsc --noEmit` 型チェック通過
- [x] `npm run lint` lint通過
- [x] `npm run test:run` 全357テスト通過

closes #56

🤖 Generated with [Claude Code](https://claude.com/claude-code)