### PR TITLE
セッションロールバッジをセッション名の横にインライン表示する

### DIFF
--- a/app/(authenticated)/circle-sessions/components/circle-session-detail-view.tsx
+++ b/app/(authenticated)/circle-sessions/components/circle-session-detail-view.tsx
@@ -535,9 +535,18 @@ export function CircleSessionDetailView({
       <section className="rounded-3xl border border-border/60 bg-white/90 p-8 shadow-sm">
         <div className="flex flex-wrap items-start justify-between gap-6">
           <div className="min-w-60 flex-1">
-            <h1 className="mt-3 text-3xl font-(--font-display) text-(--brand-ink) sm:text-4xl">
-              {detail.title}
-            </h1>
+            <div className="mt-3 flex flex-wrap items-baseline gap-3">
+              <h1 className="text-3xl font-(--font-display) text-(--brand-ink) sm:text-4xl">
+                {detail.title}
+              </h1>
+              {roleLabel ? (
+                <span
+                  className={`rounded-full px-2.5 py-0.5 text-xs ${roleBadgeClassName}`}
+                >
+                  {roleLabel}
+                </span>
+              ) : null}
+            </div>
             <p className="mt-3 text-sm text-(--brand-ink-muted)">
               {detail.dateTimeLabel}
               {detail.locationLabel ? ` / ${detail.locationLabel}` : ""}
@@ -573,18 +582,6 @@ export function CircleSessionDetailView({
             </div>
           </div>
         </div>
-        {roleLabel ? (
-          <div className="mt-6 flex flex-wrap items-center justify-between gap-3">
-            <div className="flex items-center gap-2 rounded-full border border-border/60 bg-white/70 px-3 py-1 text-xs">
-              <span className="text-(--brand-ink-muted)">あなたのロール</span>
-              <span
-                className={`rounded-full px-2.5 py-1 text-xs ${roleBadgeClassName}`}
-              >
-                {roleLabel}
-              </span>
-            </div>
-          </div>
-        ) : null}
       </section>
 
       <section className="grid gap-6 lg:grid-cols-1">


### PR DESCRIPTION
## Summary

- セッション詳細ページの「あなたのロール」表示をヒーローセクション最下部から、セッション名の横へ移動
- #54 (研究会ページ) の修正と同じパターンを適用し、UIの一貫性を確保

## Changes

- ロールバッジをセッション名（h1）の横にインライン表示（`flex-wrap items-baseline gap-3`）
- ヒーローセクション最下部の独立したロール表示セクションを削除

## Test plan

- [ ] セッション詳細ページでロールバッジがセッション名の横に表示されることを確認
- [ ] オーナー/マネージャー/メンバー各ロールでバッジの色が正しく表示されることを確認
- [ ] モバイル表示でタイトルが長い場合にバッジが正しく折り返されることを確認

Closes #58

🤖 Generated with [Claude Code](https://claude.com/claude-code)