### PR TITLE
feat: ホーム画面の「最近参加した回」をカレンダーUIに置き換え

### DIFF
--- a/components/calendar/session-calendar.tsx
+++ b/components/calendar/session-calendar.tsx
@@ -13,7 +13,10 @@ type SessionCalendarProps = {
   onDateClick?: (arg: DateClickArg) => void;
 };
 
-export function SessionCalendar({ events, onDateClick }: SessionCalendarProps) {
+export function SessionCalendar({
+  events,
+  onDateClick,
+}: SessionCalendarProps) {
   return (
     <FullCalendar
       plugins={FC_PLUGINS}


### PR DESCRIPTION
## Summary

Closes #62

- ホーム画面の「最近参加した回」リスト表示を SessionCalendar コンポーネント(#61)に置き換え
- 参加済みセッションが月表示カレンダー上にイベントとして表示される
- カレンダー上のイベントクリックでセッション詳細ページに遷移
- 重複していたtRPCクエリ(limit:3 + limit:20)を単一クエリに統合し useMemo で最適化

## Changes

- `app/(authenticated)/home/page.tsx`: リスト表示を削除し SessionCalendar を配置。クエリ統合と useMemo 導入
- `components/calendar/session-calendar.tsx`: フォーマット修正のみ

## Test plan

- [x] `npx tsc --noEmit` — 型チェック OK
- [x] `npm run lint` — ESLint OK
- [x] 手動検証: カレンダー表示、イベント表示、クリック遷移、次回日程セクション、ローディング状態 — 全項目 OK

Verification details: `.claude/artifacts/issue-62/verify.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)