### PR TITLE
feat: add session creation from calendar date click (#64)

### DIFF
--- a/app/(authenticated)/circles/[circleId]/sessions/new/circle-session-create-form.tsx
+++ b/app/(authenticated)/circles/[circleId]/sessions/new/circle-session-create-form.tsx
@@ -10,14 +10,18 @@ import { useRouter } from "next/navigation";
 
 type CircleSessionCreateFormProps = {
   circleId: string;
+  defaultStartsAt?: string;
 };
 
 export function CircleSessionCreateForm({
   circleId,
+  defaultStartsAt,
 }: CircleSessionCreateFormProps) {
   const [sequence, setSequence] = useState("");
   const [title, setTitle] = useState("");
-  const [startsAt, setStartsAt] = useState("");
+  const [startsAt, setStartsAt] = useState(
+    defaultStartsAt ? `${defaultStartsAt}T00:00` : "",
+  );
   const [endsAt, setEndsAt] = useState("");
   const [location, setLocation] = useState("");
   const [note, setNote] = useState("");

--- a/app/(authenticated)/circles/[circleId]/sessions/new/page.tsx
+++ b/app/(authenticated)/circles/[circleId]/sessions/new/page.tsx
@@ -2,19 +2,25 @@ import { CircleSessionCreateForm } from "./circle-session-create-form";
 
 type NewCircleSessionPageProps = {
   params: Promise<{ circleId: string }>;
+  searchParams: Promise<{ startsAt?: string }>;
 };
 
 export default async function NewCircleSessionPage({
   params,
+  searchParams,
 }: NewCircleSessionPageProps) {
   const { circleId } = await params;
+  const { startsAt } = await searchParams;
 
   return (
     <div className="mx-auto flex w-full max-w-2xl flex-col gap-6 py-8">
       <h1 className="text-2xl font-(--font-display) text-(--brand-ink)">
         新規開催回の作成
       </h1>
-      <CircleSessionCreateForm circleId={circleId} />
+      <CircleSessionCreateForm
+        circleId={circleId}
+        defaultStartsAt={startsAt}
+      />
     </div>
   );
 }


### PR DESCRIPTION
## Summary

- カレンダー上のセッション未登録日付をクリックすると、セッション新規作成ページへ遷移
- クリックした日付が `startsAt` クエリパラメータ経由でフォームの開始日時に初期設定される
- 作成権限（Owner/Manager）を持つユーザーのみ日付クリックが有効（`createSessionHref` の有無で制御）

## Changes

- `circle-overview-calendar.tsx`: `handleDateClick` を追加。セッション未登録の日付クリックで作成ページへ遷移
- `page.tsx`: `searchParams` から `startsAt` を受け取りフォームに渡す
- `circle-session-create-form.tsx`: `defaultStartsAt` prop を追加し、開始日時の初期値を設定

## Test plan

- [ ] Owner/Manager でログインし、セッション未登録の日付をクリック → 作成ページに遷移し、日付が初期設定されている
- [ ] セッション登録済みの日付をクリック → 遷移しない
- [ ] Member でログインし、日付をクリック → 何も起きない
- [ ] `/circles/{id}/sessions/new` にパラメータなしでアクセス → 開始日時が空
- [ ] `/circles/{id}/sessions/new?startsAt=invalid` にアクセス → datetime-local が空表示

Closes #64

🤖 Generated with [Claude Code](https://claude.com/claude-code)