### PR TITLE
feat: カレンダーイベントホバー時にツールチップを表示 (#78)

### DIFF
--- a/app/(authenticated)/circles/components/circle-overview-calendar.tsx
+++ b/app/(authenticated)/circles/components/circle-overview-calendar.tsx
@@ -28,6 +28,11 @@ export function CircleOverviewCalendar({
         start: s.startsAt,
         end: s.endsAt,
         url: s.id ? `/circle-sessions/${s.id}` : undefined,
+        extendedProps: {
+          status: s.status,
+          startsAt: s.startsAt,
+          endsAt: s.endsAt,
+        },
       })),
     [sessions],
   );

--- a/app/(authenticated)/home/page.tsx
+++ b/app/(authenticated)/home/page.tsx
@@ -41,6 +41,11 @@ export default function Home() {
       start: s.startsAt,
       end: s.endsAt,
       url: `/circle-sessions/${s.circleSessionId}`,
+      extendedProps: {
+        status: s.status,
+        startsAt: s.startsAt,
+        endsAt: s.endsAt,
+      },
     }));
   }, [sessionsQuery.data]);
 

--- a/components/calendar/session-calendar.tsx
+++ b/components/calendar/session-calendar.tsx
@@ -4,9 +4,67 @@ import FullCalendar from "@fullcalendar/react";
 import dayGridPlugin from "@fullcalendar/daygrid";
 import interactionPlugin from "@fullcalendar/interaction";
 import type { DateClickArg } from "@fullcalendar/interaction";
-import type { EventInput } from "@fullcalendar/core";
+import type { EventContentArg, EventInput } from "@fullcalendar/core";
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipTrigger,
+} from "@/components/ui/tooltip";
 
 const FC_PLUGINS = [dayGridPlugin, interactionPlugin];
+
+const STATUS_LABEL: Record<string, string> = {
+  scheduled: "予定",
+  done: "終了",
+  draft: "下書き",
+};
+
+function formatTooltipDateTime(startsAt: unknown, endsAt: unknown): string {
+  const toDate = (v: unknown): Date | null => {
+    if (v instanceof Date) return v;
+    if (typeof v === "string" || typeof v === "number") return new Date(v);
+    return null;
+  };
+
+  const start = toDate(startsAt);
+  const end = toDate(endsAt);
+  if (!start || !end) return "";
+
+  const pad2 = (n: number) => String(n).padStart(2, "0");
+  const date = `${start.getFullYear()}/${pad2(start.getMonth() + 1)}/${pad2(start.getDate())}`;
+  const startTime = `${pad2(start.getHours())}:${pad2(start.getMinutes())}`;
+  const endTime = `${pad2(end.getHours())}:${pad2(end.getMinutes())}`;
+
+  return `${date} ${startTime} - ${endTime}`;
+}
+
+function EventWithTooltip({ arg }: { arg: EventContentArg }) {
+  const { extendedProps, title } = arg.event;
+  const status = extendedProps.status as string | undefined;
+  const startsAt = extendedProps.startsAt;
+  const endsAt = extendedProps.endsAt;
+
+  const hasTooltipData = status && startsAt && endsAt;
+
+  if (!hasTooltipData) {
+    return <span className="truncate">{title}</span>;
+  }
+
+  return (
+    <Tooltip>
+      <TooltipTrigger asChild>
+        <span className="block truncate">{title}</span>
+      </TooltipTrigger>
+      <TooltipContent side="top" sideOffset={4}>
+        <div className="space-y-0.5 text-left">
+          <p className="font-semibold">{title}</p>
+          <p>{formatTooltipDateTime(startsAt, endsAt)}</p>
+          <p>ステータス: {STATUS_LABEL[status] ?? status}</p>
+        </div>
+      </TooltipContent>
+    </Tooltip>
+  );
+}
 
 type SessionCalendarProps = {
   events?: EventInput[];
@@ -24,6 +82,7 @@ export function SessionCalendar({
       locale="ja"
       events={events}
       dateClick={onDateClick}
+      eventContent={(arg) => <EventWithTooltip arg={arg} />}
     />
   );
 }


### PR DESCRIPTION
## Summary

- カレンダー上のイベント（ドット）にマウスホバーした際に、セッション情報をツールチップで表示
- shadcn/ui の Tooltip + FullCalendar の `eventContent` を使用
- 研究会概要ページ・ホームページ両方のカレンダーに適用

Closes #78

## Changes

- `components/calendar/session-calendar.tsx`: `EventWithTooltip` コンポーネント追加、ステータスラベルの日本語マッピング、日時フォーマットヘルパー
- `circle-overview-calendar.tsx` / `home/page.tsx`: `extendedProps` にステータス・日時データを追加

## How to verify

1. `npm run dev` で開発サーバー起動
2. 研究会概要ページ (`/circles/{id}`) のカレンダーでイベントにホバー → ツールチップにタイトル・日時・ステータスが表示される
3. ホームページ (`/`) のカレンダーでも同様に確認
4. ステータスが日本語ラベル（予定/終了/下書き）で表示されること

## Points to review

- `extendedProps` の型定義が呼び出し側と消費側で暗黙的に共有されている（共有型の導入は follow-up 候補）
- モバイル/タッチデバイスではホバー不可のためツールチップ非対応（issue スコープ外）
- キーボードアクセシビリティは Radix TooltipTrigger の内部挙動に依存（実機確認推奨）

🤖 Generated with [Claude Code](https://claude.com/claude-code)