### PR TITLE
refactor: consolidate duplicate button permission to server-side

### DIFF
--- a/app/(authenticated)/circle-sessions/components/circle-session-detail-view.tsx
+++ b/app/(authenticated)/circle-sessions/components/circle-session-detail-view.tsx
@@ -354,9 +354,7 @@ export function CircleSessionDetailView({
   };
 
   const router = useRouter();
-  const canDuplicate =
-    detail.viewerCircleRole === "owner" ||
-    detail.viewerCircleRole === "manager";
+  const canDuplicate = detail.canCreateCircleSession;
 
   const handleDuplicate = () => {
     const params = new URLSearchParams();

--- a/server/presentation/view-models/circle-session-detail.ts
+++ b/server/presentation/view-models/circle-session-detail.ts
@@ -30,7 +30,7 @@ export type CircleSessionDetailViewModel = {
   startsAtInput: string;
   endsAtInput: string;
   viewerRole: CircleSessionRoleKey | null;
-  viewerCircleRole: CircleRoleKey | null;
+  canCreateCircleSession: boolean;
   participations: CircleSessionParticipation[];
   matches: CircleSessionMatch[];
 };


### PR DESCRIPTION
## Summary

Closes #96

- `viewerCircleRole` を ViewModel から削除し、`canCreateCircleSession: boolean` に置き換え
- Provider 内で `AccessService.canCreateCircleSession` を呼び出してサーバー側で権限判定
- クライアント側は `detail.canCreateCircleSession` を参照するだけに簡素化

## 変更ファイル

| ファイル | 変更内容 |
|---------|---------|
| `circle-session-detail.ts` | `viewerCircleRole` → `canCreateCircleSession` |
| `trpc-circle-session-detail-provider.ts` | `circleParticipations` 全件取得を `AccessService` 単一呼び出しに置換、不要コード削除 |
| `circle-session-detail-view.tsx` | クライアント側ロール判定を `detail.canCreateCircleSession` 参照に変更 |

## Test plan

- [x] `npx tsc --noEmit` 通過
- [x] `npm run test:run` 全366テスト通過
- [ ] オーナー（sota@example.com）で複製ボタンが表示されることを確認
- [ ] メンバー（ito@example.com）で複製ボタンが非表示であることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)