### PR TITLE
feat: セッション作成フォームにデフォルト日時を設定 (#85)

### DIFF
--- a/app/(authenticated)/circles/[circleId]/sessions/new/circle-session-create-form.tsx
+++ b/app/(authenticated)/circles/[circleId]/sessions/new/circle-session-create-form.tsx
@@ -18,6 +18,27 @@ type CircleSessionCreateFormProps = {
   defaultNote?: string;
 };
 
+const DEFAULT_START_TIME = "10:00";
+const DEFAULT_END_TIME = "18:00";
+
+function getLocalDateString(): string {
+  const now = new Date();
+  const year = now.getFullYear();
+  const month = String(now.getMonth() + 1).padStart(2, "0");
+  const day = String(now.getDate()).padStart(2, "0");
+  return `${year}-${month}-${day}`;
+}
+
+function toDatetimeLocal(
+  value: string | undefined,
+  defaultTime: string,
+  fallbackDate?: string,
+): string {
+  if (value && value.includes("T")) return value;
+  const date = value || fallbackDate || getLocalDateString();
+  return `${date}T${defaultTime}`;
+}
+
 export function CircleSessionCreateForm({
   circleId,
   defaultStartsAt,
@@ -27,14 +48,16 @@ export function CircleSessionCreateForm({
   defaultNote,
 }: CircleSessionCreateFormProps) {
   const [title, setTitle] = useState(defaultTitle ?? "");
-  const [startsAt, setStartsAt] = useState(
-    defaultStartsAt
-      ? defaultStartsAt.includes("T")
-        ? defaultStartsAt
-        : `${defaultStartsAt}T00:00`
-      : "",
+  const [startsAt, setStartsAt] = useState(() =>
+    toDatetimeLocal(defaultStartsAt, DEFAULT_START_TIME),
   );
-  const [endsAt, setEndsAt] = useState(defaultEndsAt ?? "");
+  const [endsAt, setEndsAt] = useState(() => {
+    const startDate = toDatetimeLocal(
+      defaultStartsAt,
+      DEFAULT_START_TIME,
+    ).slice(0, 10);
+    return toDatetimeLocal(defaultEndsAt, DEFAULT_END_TIME, startDate);
+  });
   const [location, setLocation] = useState(defaultLocation ?? "");
   const [note, setNote] = useState(defaultNote ?? "");
 


### PR DESCRIPTION
## Summary

- セッション作成フォームの開始日時・終了日時にデフォルト値を設定
- 新規作成ボタン経由: 当日の 10:00〜18:00
- カレンダーUI経由: 選択日の 10:00〜18:00
- UTCではなくローカル日付を使用するよう修正済み

Closes #85

## Test plan

- [x] 全10テスト pass 確認済み (`circle-session-create-form.test.tsx`)
- [ ] 新規作成ボタンから遷移 → 当日 10:00 / 18:00 が設定されていること
- [ ] カレンダーで日付選択して遷移 → 選択日 10:00 / 18:00 が設定されていること
- [ ] datetime-local形式で明示的に渡された場合、そのまま使用されること

## Related

- Follow-up: #106 (タイムゾーン境界テストの追加)

🤖 Generated with [Claude Code](https://claude.com/claude-code)