### PR TITLE
refactor: improve type safety for calendar tooltip extendedProps (#87)

### DIFF
--- a/app/(authenticated)/circles/components/circle-overview-calendar.tsx
+++ b/app/(authenticated)/circles/components/circle-overview-calendar.tsx
@@ -1,6 +1,9 @@
 "use client";
 
-import { SessionCalendar } from "@/components/calendar/session-calendar";
+import {
+  SessionCalendar,
+  type SessionExtendedProps,
+} from "@/components/calendar/session-calendar";
 import { Button } from "@/components/ui/button";
 import type { CircleOverviewSession } from "@/server/presentation/view-models/circle-overview";
 import type { EventInput } from "@fullcalendar/core";
@@ -31,7 +34,7 @@ export function CircleOverviewCalendar({
         extendedProps: {
           startsAt: s.startsAt,
           endsAt: s.endsAt,
-        },
+        } satisfies SessionExtendedProps,
       })),
     [sessions],
   );

--- a/app/(authenticated)/home/page.tsx
+++ b/app/(authenticated)/home/page.tsx
@@ -1,7 +1,10 @@
 "use client";
 
 import CircleCreateForm from "@/app/(authenticated)/home/circle-create-form";
-import { SessionCalendar } from "@/components/calendar/session-calendar";
+import {
+  SessionCalendar,
+  type SessionExtendedProps,
+} from "@/components/calendar/session-calendar";
 import { trpc } from "@/lib/trpc/client";
 import type { EventInput } from "@fullcalendar/core";
 import Link from "next/link";
@@ -44,7 +47,7 @@ export default function Home() {
       extendedProps: {
         startsAt: s.startsAt,
         endsAt: s.endsAt,
-      },
+      } satisfies SessionExtendedProps,
     }));
   }, [sessionsQuery.data]);
 

--- a/components/calendar/session-calendar.tsx
+++ b/components/calendar/session-calendar.tsx
@@ -13,16 +13,20 @@ import {
 
 const FC_PLUGINS = [dayGridPlugin, interactionPlugin];
 
-function formatTooltipDateTime(startsAt: unknown, endsAt: unknown): string {
-  const toDate = (v: unknown): Date | null => {
-    if (v instanceof Date) return v;
-    if (typeof v === "string" || typeof v === "number") return new Date(v);
-    return null;
-  };
+export type SessionExtendedProps = {
+  startsAt: string | Date;
+  endsAt: string | Date;
+};
+
+function formatTooltipDateTime(
+  startsAt: string | Date,
+  endsAt: string | Date,
+): string {
+  const toDate = (v: string | Date): Date =>
+    v instanceof Date ? v : new Date(v);
 
   const start = toDate(startsAt);
   const end = toDate(endsAt);
-  if (!start || !end) return "";
 
   const pad2 = (n: number) => String(n).padStart(2, "0");
   const date = `${start.getFullYear()}/${pad2(start.getMonth() + 1)}/${pad2(start.getDate())}`;
@@ -34,8 +38,7 @@ function formatTooltipDateTime(startsAt: unknown, endsAt: unknown): string {
 
 function EventWithTooltip({ arg }: { arg: EventContentArg }) {
   const { extendedProps, title } = arg.event;
-  const startsAt = extendedProps.startsAt;
-  const endsAt = extendedProps.endsAt;
+  const { startsAt, endsAt } = extendedProps as SessionExtendedProps;
 
   const hasTooltipData = startsAt && endsAt;
 


### PR DESCRIPTION
## Summary

- `SessionExtendedProps` 型を `session-calendar.tsx` から export し、`extendedProps` の構造を明示的に共有
- `formatTooltipDateTime` の引数を `unknown` → `string | Date` に narrowing
- producer 側（`circle-overview-calendar.tsx`, `home/page.tsx`）で `satisfies` を使いコンパイル時に型整合性を保証
- `toDate` ヘルパーから不要な null/number 分岐を削除し簡素化

Closes #87

## Verification

| チェック | 結果 |
|---------|------|
| `npx tsc --noEmit` | 通過 |
| `npm run test:run` | 全42ファイル・388テスト通過 |

### 手動検証手順

1. `npm run dev` で開発サーバーを起動
2. ホーム画面（`/`）でカレンダーのイベントにホバーし、ツールチップに日時が表示されることを確認
3. 研究会詳細画面のカレンダーでも同様にツールチップ表示を確認

## Known Limitations

- FullCalendar の `EventInput.extendedProps` が `Record<string, any>` のため、consumer 側の `as` キャストは残存（→ #144 で対応）
- `formatTooltipDateTime` の防御的チェック削除（→ #145 で対応）
- カレンダーコンポーネントのユニットテスト未整備（→ #146 で対応）

## Follow-up Issues

- #144 EventWithTooltip の as キャストを実行時型ガードに置き換える
- #145 formatTooltipDateTime に防御的な Invalid Date チェックを追加する
- #146 カレンダーコンポーネントのユニットテストを追加する

🤖 Generated with [Claude Code](https://claude.com/claude-code)