### PR TITLE
fix: prevent duplicate keydown listener on calendar cells

### DIFF
--- a/components/calendar/session-calendar.tsx
+++ b/components/calendar/session-calendar.tsx
@@ -90,8 +90,9 @@ export function SessionCalendar({
     function applyKeyboardSupport() {
       const cells = container!.querySelectorAll<HTMLElement>(".fc-daygrid-day");
       cells.forEach((cell) => {
-        if (cell.getAttribute("tabindex") === "0") return;
+        if (cell.dataset.kbBound) return;
         cell.setAttribute("tabindex", "0");
+        cell.dataset.kbBound = "true";
         cell.addEventListener("keydown", (e) => {
           if (e.key === "Enter" || e.key === " ") {
             e.preventDefault();


### PR DESCRIPTION
## Summary

Closes #148

- `MutationObserver` が月移動等で発火するたびに `applyKeyboardSupport` が呼ばれ、`addEventListener("keydown", ...)` が同一セルに重複登録される問題を修正
- `tabindex` チェックの代わりに `cell.dataset.kbBound` マーカーを使用し、二重登録を確実に防止

## Changes

- `components/calendar/session-calendar.tsx`: ガード条件を `cell.getAttribute("tabindex") === "0"` から `cell.dataset.kbBound` に変更し、バインド後にマーカーを設定

## Verification

- [x] `npm run lint` PASS
- [x] `npx tsc --noEmit` PASS
- [ ] 手動検証: カレンダーで月移動後に Enter/Space が1回だけ発火することを確認
- [ ] 手動検証: `focus-visible` リングが正常に表示されることを確認

## Follow-up Issues

- #155 カレンダー日付セルにaria-labelとrole属性を追加する
- #156 カレンダーで矢印キーによるグリッドナビゲーションを実装する
- #157 カレンダーイベント要素にキーボード操作サポートを追加する
- #158 applyKeyboardSupportの冪等性テストを追加する

🤖 Generated with [Claude Code](https://claude.com/claude-code)