### PR TITLE
fix: replace aria-label with sr-only text on calendar events

### DIFF
--- a/components/calendar/event-with-tooltip.test.tsx
+++ b/components/calendar/event-with-tooltip.test.tsx
@@ -1,0 +1,63 @@
+// @vitest-environment jsdom
+import type { EventContentArg } from "@fullcalendar/core";
+import type { EventImpl } from "@fullcalendar/core/internal";
+import { cleanup, render, screen } from "@testing-library/react";
+import { afterEach, describe, expect, it } from "vitest";
+import { EventWithTooltip } from "./session-calendar";
+
+afterEach(() => {
+  cleanup();
+});
+
+function buildArg(
+  overrides: {
+    title?: string;
+    startsAt?: string;
+    endsAt?: string;
+  } = {},
+): { arg: EventContentArg } {
+  const title = overrides.title ?? "月例会";
+  const event = {
+    title,
+    extendedProps: {
+      startsAt: overrides.startsAt ?? "2025-01-15T14:00:00",
+      endsAt: overrides.endsAt ?? "2025-01-15T16:00:00",
+    },
+  } as unknown as EventImpl;
+
+  return {
+    arg: { event } as unknown as EventContentArg,
+  };
+}
+
+describe("EventWithTooltip", () => {
+  it("sr-only スパンにカンマ区切りの日時テキストを含む", () => {
+    render(<EventWithTooltip {...buildArg()} />);
+
+    const srOnly = screen.getByText(/2025\/01\/15/);
+    expect(srOnly.className).toContain("sr-only");
+    expect(srOnly.textContent).toBe(", 2025/01/15 14:00 - 16:00");
+  });
+
+  it("aria-label 属性を使用しない", () => {
+    render(<EventWithTooltip {...buildArg()} />);
+
+    const trigger = screen.getByText("月例会");
+    expect(trigger.closest("[aria-label]")).toBeNull();
+  });
+
+  it("日時データがない場合 sr-only スパンを含まない", () => {
+    const arg = {
+      arg: {
+        event: {
+          title: "テスト",
+          extendedProps: {},
+        } as unknown as EventImpl,
+      } as unknown as EventContentArg,
+    };
+
+    render(<EventWithTooltip {...arg} />);
+
+    expect(screen.queryByText(/\d{4}\/\d{2}\/\d{2}/)).toBeNull();
+  });
+});

--- a/components/calendar/session-calendar.tsx
+++ b/components/calendar/session-calendar.tsx
@@ -37,7 +37,7 @@ function formatTooltipDateTime(
   return `${date} ${startTime} - ${endTime}`;
 }
 
-function EventWithTooltip({ arg }: { arg: EventContentArg }) {
+export function EventWithTooltip({ arg }: { arg: EventContentArg }) {
   const { extendedProps, title } = arg.event;
   const { startsAt, endsAt } = extendedProps as SessionExtendedProps;
 
@@ -47,19 +47,20 @@ function EventWithTooltip({ arg }: { arg: EventContentArg }) {
     return <span className="truncate">{title}</span>;
   }
 
-  const ariaLabel = `${title} ${formatTooltipDateTime(startsAt, endsAt)}`;
+  const dateTimeLabel = formatTooltipDateTime(startsAt, endsAt);
 
   return (
     <Tooltip>
       <TooltipTrigger asChild>
-        <span className="block truncate" aria-label={ariaLabel}>
+        <span className="block truncate">
           {title}
+          <span className="sr-only">{`, ${dateTimeLabel}`}</span>
         </span>
       </TooltipTrigger>
       <TooltipContent side="top" sideOffset={4}>
         <div className="space-y-0.5 text-left">
           <p className="font-semibold">{title}</p>
-          <p>{formatTooltipDateTime(startsAt, endsAt)}</p>
+          <p>{dateTimeLabel}</p>
         </div>
       </TooltipContent>
     </Tooltip>


### PR DESCRIPTION
## Summary

- カレンダーイベントの `<span>` に付与していた `aria-label` を `sr-only` テキストに置き換え
- HTML-AAM 仕様上、role なしの汎用要素では `aria-label` が Safari + VoiceOver で無視される問題を解決
- `formatTooltipDateTime` の重複呼び出しをローカル変数に抽出

Closes #150

## Test plan

- [ ] `npx tsc --noEmit` が通ること
- [ ] `npx vitest run components/calendar/event-with-tooltip.test.tsx` の 3 テストが pass すること
- [ ] カレンダー画面で視覚的な表示に変更がないこと
- [ ] macOS VoiceOver でイベントにフォーカスし、タイトルと日時が読み上げられること

🤖 Generated with [Claude Code](https://claude.com/claude-code)