### PR TITLE
feat: セッション作成者を自動的にオーナーとして登録する

### DIFF
--- a/server/application/service-container.ts
+++ b/server/application/service-container.ts
@@ -71,6 +71,8 @@ export const createServiceContainer = (
     circleSessionService: createCircleSessionService({
       circleRepository: deps.circleRepository,
       circleSessionRepository: deps.circleSessionRepository,
+      circleSessionParticipationRepository:
+        deps.circleSessionParticipationRepository,
       accessService,
     }),
     circleSessionParticipationService: createCircleSessionParticipationService({


### PR DESCRIPTION
Closes #109

## Summary

- セッション作成時に、作成者を `CircleSessionOwner` として自動的に参加登録するようにした
- `CircleSessionService` に `CircleSessionParticipationRepository` への依存を追加
- `service-container.ts` のDI配線を更新

## Verification Steps

- `npm run test:run -- server/application/circle-session/circle-session-service.test.ts` → 10件全パス
- `npx tsc --noEmit` → 型エラーなし
- 開発サーバーで開催回を新規作成し、参加者一覧に作成者がオーナーとして表示されることを確認

## Notes

- 非トランザクション2段階書き込みは既存パターン（`CircleService.createCircle()`）と同一の既知制約。トランザクション導入は #161 で対応予定

🤖 Generated with [Claude Code](https://claude.com/claude-code)