### PR TITLE
test: add unit tests for calendar component (#146)

### DIFF
--- a/components/calendar/event-with-tooltip.test.tsx
+++ b/components/calendar/event-with-tooltip.test.tsx
@@ -3,7 +3,7 @@ import type { EventContentArg } from "@fullcalendar/core";
 import type { EventImpl } from "@fullcalendar/core/internal";
 import { cleanup, render, screen } from "@testing-library/react";
 import { afterEach, describe, expect, it } from "vitest";
-import { EventWithTooltip } from "./session-calendar";
+import { EventWithTooltip, formatTooltipDateTime } from "./session-calendar";
 
 afterEach(() => {
   cleanup();
@@ -12,8 +12,8 @@ afterEach(() => {
 function buildArg(
   overrides: {
     title?: string;
-    startsAt?: string;
-    endsAt?: string;
+    startsAt?: string | Date;
+    endsAt?: string | Date;
   } = {},
 ): { arg: EventContentArg } {
   const title = overrides.title ?? "月例会";
@@ -59,5 +59,43 @@ describe("EventWithTooltip", () => {
     render(<EventWithTooltip {...arg} />);
 
     expect(screen.queryByText(/\d{4}\/\d{2}\/\d{2}/)).toBeNull();
+  });
+
+  it("Date 型の startsAt / endsAt で正しくレンダリングされる", () => {
+    render(
+      <EventWithTooltip
+        {...buildArg({
+          startsAt: new Date(2025, 2, 10, 10, 0),
+          endsAt: new Date(2025, 2, 10, 12, 30),
+        })}
+      />,
+    );
+
+    const srOnly = screen.getByText(/2025\/03\/10/);
+    expect(srOnly.className).toContain("sr-only");
+    expect(srOnly.textContent).toBe(", 2025/03/10 10:00 - 12:30");
+  });
+});
+
+describe("formatTooltipDateTime", () => {
+  it("string 型の日付入力で正しいフォーマットを返す", () => {
+    const result = formatTooltipDateTime(
+      "2025-06-01T09:00:00",
+      "2025-06-01T11:30:00",
+    );
+    expect(result).toBe("2025/06/01 09:00 - 11:30");
+  });
+
+  it("Date 型の日付入力で正しいフォーマットを返す", () => {
+    const result = formatTooltipDateTime(
+      new Date(2025, 0, 15, 14, 0),
+      new Date(2025, 0, 15, 16, 0),
+    );
+    expect(result).toBe("2025/01/15 14:00 - 16:00");
+  });
+
+  it("不正な日付文字列の場合 NaN を含む文字列を返す", () => {
+    const result = formatTooltipDateTime("invalid-date", "also-invalid");
+    expect(result).toContain("NaN");
   });
 });

--- a/components/calendar/session-calendar.tsx
+++ b/components/calendar/session-calendar.tsx
@@ -19,7 +19,7 @@ export type SessionExtendedProps = {
   endsAt: string | Date;
 };
 
-function formatTooltipDateTime(
+export function formatTooltipDateTime(
   startsAt: string | Date,
   endsAt: string | Date,
 ): string {


### PR DESCRIPTION
## Summary

- `formatTooltipDateTime` に対するユニットテストを追加（string / Date 入力、不正入力のエッジケース）
- `EventWithTooltip` に Date 型 props でのレンダリングテストを追加
- `formatTooltipDateTime` をテスト可能にするため export に変更（純粋関数のため副作用なし）

Closes #146

## Test plan

- [ ] `npm run test:run -- components/calendar/event-with-tooltip.test.tsx` で全7テストがパスすること
- [ ] `npx tsc --noEmit` で型エラーがないこと
- [ ] `session-calendar.tsx` の変更が export 追加のみであること（動作変更なし）

🤖 Generated with [Claude Code](https://claude.com/claude-code)