### PR TITLE
fix(a11y): add aria-hidden to decorative icon SVGs

### DIFF
--- a/app/(authenticated)/circle-sessions/components/circle-session-detail-view.tsx
+++ b/app/(authenticated)/circle-sessions/components/circle-session-detail-view.tsx
@@ -720,7 +720,7 @@ export function CircleSessionDetailView({
                   className="text-(--brand-ink-muted) hover:text-(--brand-ink)"
                   aria-label="メモを編集"
                 >
-                  <Pencil />
+                  <Pencil aria-hidden="true" />
                 </Button>
               ) : null}
             </div>
@@ -744,7 +744,7 @@ export function CircleSessionDetailView({
                   className={`border-(--brand-ink)/20 bg-white/80 text-(--brand-ink) hover:bg-white ${isSingleAction ? "w-full" : ""}`.trim()}
                   onClick={handleDuplicate}
                 >
-                  <Copy className="size-4" />
+                  <Copy className="size-4" aria-hidden="true" />
                   複製
                 </Button>
               ) : null}
@@ -760,7 +760,7 @@ export function CircleSessionDetailView({
                     className={isSingleAction ? "w-full" : ""}
                     onClick={() => setShowDeleteSessionDialog(true)}
                   >
-                    <Trash2 className="size-4" />
+                    <Trash2 className="size-4" aria-hidden="true" />
                     削除
                   </Button>
                   <AlertDialogContent>


### PR DESCRIPTION
## Summary

- 開催回詳細ページの装飾的アイコン（Pencil, Copy, Trash2）に `aria-hidden="true"` を追加
- WCAG 2.1 SC 4.1.2 (Name, Role, Value) および SC 1.1.1 (Non-text Content) 違反を修正

Closes #123

## Verification

| アイコン | 親要素のアクセシブルネーム | 判定 |
|----------|-------------------------|------|
| `<Pencil />` | `aria-label="メモを編集"` | ✅ |
| `<Copy />` | テキスト「複製」 | ✅ |
| `<Trash2 />` | テキスト「削除」 | ✅ |

### How to verify
1. 開催回詳細ページを開く
2. VoiceOver等のスクリーンリーダーで各ボタンにフォーカス
3. SVGアーティファクトなしで適切な名前が読み上げられることを確認

## Test plan
- [x] 全415テストがパス（リグレッションなし）
- [ ] スクリーンリーダーでの手動検証

🤖 Generated with [Claude Code](https://claude.com/claude-code)