### PR TITLE
refactor: replace unsafe SessionExtendedProps cast with narrowed type assertions (#144)

### DIFF
--- a/components/calendar/session-calendar.tsx
+++ b/components/calendar/session-calendar.tsx
@@ -39,7 +39,8 @@ export function formatTooltipDateTime(
 
 export function EventWithTooltip({ arg }: { arg: EventContentArg }) {
   const { extendedProps, title } = arg.event;
-  const { startsAt, endsAt } = extendedProps as SessionExtendedProps;
+  const startsAt = extendedProps.startsAt as string | Date | undefined;
+  const endsAt = extendedProps.endsAt as string | Date | undefined;
 
   const hasTooltipData = startsAt && endsAt;
 


### PR DESCRIPTION
## Summary

- `EventWithTooltip` の `as SessionExtendedProps` キャストを削除し、`startsAt` / `endsAt` を個別に `string | Date | undefined` として型アサーション
- 既存の `hasTooltipData` truthiness チェックが `undefined` ケースを正しくガードしていることを確認済み

Closes #144

## Verification

- `npx tsc --noEmit`: パス
- `npm run test:run`: 418テスト全パス
- 変更は1ファイル・2行のみ（`session-calendar.tsx` L42-43）

## Review points

- `extendedProps` の実行時型検証は Out of Scope（フォローアップ: #185）
- ビジネスロジックの変更なし

🤖 Generated with [Claude Code](https://claude.com/claude-code)