### PR TITLE
fix: 対局結果削除mutationにonErrorハンドラーを追加 (#111)

### DIFF
--- a/app/(authenticated)/circle-sessions/components/circle-session-detail-view.tsx
+++ b/app/(authenticated)/circle-sessions/components/circle-session-detail-view.tsx
@@ -639,6 +639,9 @@ export function CircleSessionDetailView({
           );
           setActiveDialog(null);
         },
+        onError: () => {
+          setActiveDialog(null);
+        },
       },
     );
   };


### PR DESCRIPTION
## Summary

- 対局結果の削除失敗時にダイアログが閉じない問題を修正
- `deleteMatch` mutation に `onError` ハンドラーを追加し、エラー時にもダイアログを閉じるようにした

Closes #111

## Verification Steps

1. `npm run dev` で開発サーバーを起動
2. テストアカウント（sota@example.com / demo-pass-1）でログイン
3. 開催回の詳細画面で対局結果の削除ダイアログを開く
4. DevTools > Network > Offline にして削除を実行
5. ダイアログが閉じ、エラートースト「対局結果の削除に失敗しました」が表示されることを確認

## Related Issues

- #188: createMatch / updateMatch にも同様のバグが残存（follow-up）
- #189: 対局 mutation のエラーハンドリングパターン統一（follow-up）

🤖 Generated with [Claude Code](https://claude.com/claude-code)