### PR TITLE
fix: add onError handler to createMatch/updateMatch mutations to close dialog on failure (#188)

### DIFF
--- a/app/(authenticated)/circle-sessions/components/circle-session-detail-view.tsx
+++ b/app/(authenticated)/circle-sessions/components/circle-session-detail-view.tsx
@@ -569,6 +569,9 @@ export function CircleSessionDetailView({
             );
             setActiveDialog(null);
           },
+          onError: () => {
+            setActiveDialog(null);
+          },
         },
       );
     } else if (activeDialog.mode === "edit") {
@@ -601,6 +604,9 @@ export function CircleSessionDetailView({
             toast.success(
               `保存しました: ${rowName} vs ${columnName} / ${outcomeLabel}`,
             );
+            setActiveDialog(null);
+          },
+          onError: () => {
             setActiveDialog(null);
           },
         },


### PR DESCRIPTION
## Summary

- `createMatch.mutate()` / `updateMatch.mutate()` のインライン呼び出しに `onError` ハンドラーを追加し、mutation 失敗時にダイアログが閉じるようにした
- #111 で修正済みの `deleteMatch` と同一パターンを適用し、3つの mutation すべてでエラーハンドリングを統一

Closes #188

## Verification

- `npx tsc --noEmit`: OK
- `npx eslint`: OK（対象ファイルにエラー・警告なし）
- 手動確認手順:
  1. 開催回の詳細ページで対局結果を追加 → DevTools で Network offline にしてエラーを発生させる → ダイアログが閉じ、エラートーストが表示されることを確認
  2. 既存の対局結果を編集 → 同様にエラーをシミュレート → ダイアログが閉じることを確認
  3. 正常系（追加・編集）が引き続き動作することを確認

## Review points

- React Query の仕様上、mutation レベルの `onError`（トースト表示）とインラインの `onError`（ダイアログ閉じ）は両方実行される
- `deleteMatch`（PR #190）と完全に同一のパターン
- フォローアップ: #191（エラーパスのテスト追加）

🤖 Generated with [Claude Code](https://claude.com/claude-code)