### PR TITLE
refactor: unify match mutation onError pattern to mutation-level

### DIFF
--- a/app/(authenticated)/circle-sessions/components/circle-session-detail-view.tsx
+++ b/app/(authenticated)/circle-sessions/components/circle-session-detail-view.tsx
@@ -424,6 +424,7 @@ export function CircleSessionDetailView({
       router.refresh();
     },
     onError: () => {
+      setActiveDialog(null);
       toast.error("対局結果の追加に失敗しました");
     },
   });
@@ -433,6 +434,7 @@ export function CircleSessionDetailView({
       router.refresh();
     },
     onError: () => {
+      setActiveDialog(null);
       toast.error("対局結果の更新に失敗しました");
     },
   });
@@ -442,6 +444,7 @@ export function CircleSessionDetailView({
       router.refresh();
     },
     onError: () => {
+      setActiveDialog(null);
       toast.error("対局結果の削除に失敗しました");
     },
   });
@@ -569,9 +572,6 @@ export function CircleSessionDetailView({
             );
             setActiveDialog(null);
           },
-          onError: () => {
-            setActiveDialog(null);
-          },
         },
       );
     } else if (activeDialog.mode === "edit") {
@@ -604,9 +604,6 @@ export function CircleSessionDetailView({
             toast.success(
               `保存しました: ${rowName} vs ${columnName} / ${outcomeLabel}`,
             );
-            setActiveDialog(null);
-          },
-          onError: () => {
             setActiveDialog(null);
           },
         },
@@ -643,9 +640,6 @@ export function CircleSessionDetailView({
           toast.success(
             `削除しました: ${rowName} vs ${columnName} / ${outcomeLabel}`,
           );
-          setActiveDialog(null);
-        },
-        onError: () => {
           setActiveDialog(null);
         },
       },


### PR DESCRIPTION
## Summary

Closes #189

- `createMatch`, `updateMatch`, `deleteMatch` の `onError` パターンを mutation 定義レベルに統一
- インラインの `onError` コールバックから `setActiveDialog(null)` を削除し、mutation レベルの `onError` に集約
- `deleteSession` の既存パターン（mutation レベルに副作用を集約）と一致させた

## Changes

- 3行追加（mutation レベル `onError` に `setActiveDialog(null)` 追加）
- 9行削除（インライン `onError` コールバック3箇所を削除）
- 動作変更なし（純粋な構造的リファクタリング）

## Test plan

- [ ] `npx tsc --noEmit` — 型チェック通過
- [ ] `npx eslint` — lint エラーなし
- [ ] 対局追加ダイアログでエラー発生時、ダイアログが閉じトーストが表示される
- [ ] 対局編集ダイアログでエラー発生時、同様の挙動
- [ ] 対局削除ダイアログでエラー発生時、同様の挙動
- [ ] 正常系（追加・編集・削除）が既存通り動作する
- [ ] `deleteSession` の動作に影響がない

🤖 Generated with [Claude Code](https://claude.com/claude-code)