### PR TITLE
test: add mutation error path tests for circle-session-detail-view

### DIFF
--- a/app/(authenticated)/circle-sessions/components/circle-session-detail-view.test.tsx
+++ b/app/(authenticated)/circle-sessions/components/circle-session-detail-view.test.tsx
@@ -1,11 +1,39 @@
 // @vitest-environment jsdom
 import type { CircleSessionDetailViewModel } from "@/server/presentation/view-models/circle-session-detail";
-import { cleanup, render, screen } from "@testing-library/react";
+import { cleanup, render, screen, within } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
-import { afterEach, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { CircleSessionDetailView } from "./circle-session-detail-view";
 
 const pushMock = vi.fn();
+const refreshMock = vi.fn();
+
+type MutationBehavior = "idle" | "success" | "error";
+let matchCreateBehavior: MutationBehavior = "idle";
+let matchUpdateBehavior: MutationBehavior = "idle";
+let matchDeleteBehavior: MutationBehavior = "idle";
+
+function makeMutationMock(getBehavior: () => MutationBehavior) {
+  return (options?: { onSuccess?: () => void; onError?: () => void }) => {
+    const mutateFn = vi.fn(
+      (_data: unknown, inline?: { onSuccess?: () => void }) => {
+        const behavior = getBehavior();
+        if (behavior === "success") {
+          options?.onSuccess?.();
+          inline?.onSuccess?.();
+        } else if (behavior === "error") {
+          options?.onError?.();
+        }
+      },
+    );
+    return {
+      mutate: mutateFn,
+      isPending: false,
+      data: null,
+      error: null,
+    };
+  };
+}
 
 vi.mock("@/lib/trpc/client", () => ({
   trpc: {
@@ -21,28 +49,13 @@ vi.mock("@/lib/trpc/client", () => ({
     },
     matches: {
       create: {
-        useMutation: () => ({
-          mutate: vi.fn(),
-          isPending: false,
-          data: null,
-          error: null,
-        }),
+        useMutation: makeMutationMock(() => matchCreateBehavior),
       },
       update: {
-        useMutation: () => ({
-          mutate: vi.fn(),
-          isPending: false,
-          data: null,
-          error: null,
-        }),
+        useMutation: makeMutationMock(() => matchUpdateBehavior),
       },
       delete: {
-        useMutation: () => ({
-          mutate: vi.fn(),
-          isPending: false,
-          data: null,
-          error: null,
-        }),
+        useMutation: makeMutationMock(() => matchDeleteBehavior),
       },
     },
   },
@@ -53,7 +66,7 @@ vi.mock("next/navigation", () => ({
     push: pushMock,
     replace: vi.fn(),
     prefetch: vi.fn(),
-    refresh: vi.fn(),
+    refresh: refreshMock,
   }),
 }));
 
@@ -67,6 +80,10 @@ vi.mock("sonner", () => ({
 afterEach(() => {
   cleanup();
   pushMock.mockClear();
+  refreshMock.mockClear();
+  matchCreateBehavior = "idle";
+  matchUpdateBehavior = "idle";
+  matchDeleteBehavior = "idle";
 });
 
 function buildDetail(
@@ -199,6 +216,170 @@ describe("CircleSessionDetailView 複製ボタン", () => {
       const params = new URLSearchParams(url.split("?")[1]);
       expect(params.get("location")).toBe("将棋会館");
       expect(params.get("note")).toBe("持ち物: 将棋盤");
+    });
+  });
+});
+
+const twoParticipations = [
+  { id: "p1", name: "藤井太郎" },
+  { id: "p2", name: "羽生次郎" },
+];
+
+const oneMatch = [
+  { id: "match-1", player1Id: "p1", player2Id: "p2", outcome: "P1_WIN" as const },
+];
+
+async function openAddDialogForEmptyCell() {
+  const user = userEvent.setup();
+  render(
+    <CircleSessionDetailView
+      detail={buildDetail({
+        participations: twoParticipations,
+        matches: [],
+      })}
+    />,
+  );
+  const cell = document.querySelector('[data-cell-id="p1-p2"]');
+  expect(cell).not.toBeNull();
+  await user.click(cell!);
+  return user;
+}
+
+async function openEditDialogViaDropdown() {
+  const user = userEvent.setup();
+  render(
+    <CircleSessionDetailView
+      detail={buildDetail({
+        participations: twoParticipations,
+        matches: oneMatch,
+      })}
+    />,
+  );
+  const cell = document.querySelector('[data-cell-id="p1-p2"]');
+  expect(cell).not.toBeNull();
+  await user.click(cell!);
+  const editItem = await screen.findByRole("menuitem", { name: "編集" });
+  await user.click(editItem);
+  return user;
+}
+
+async function openDeleteDialogViaDropdown() {
+  const user = userEvent.setup();
+  render(
+    <CircleSessionDetailView
+      detail={buildDetail({
+        participations: twoParticipations,
+        matches: oneMatch,
+      })}
+    />,
+  );
+  const cell = document.querySelector('[data-cell-id="p1-p2"]');
+  expect(cell).not.toBeNull();
+  await user.click(cell!);
+  const deleteItem = await screen.findByRole("menuitem", { name: "削除" });
+  await user.click(deleteItem);
+  return user;
+}
+
+describe("CircleSessionDetailView mutation エラーパス", () => {
+  let toastModule: { toast: { success: ReturnType<typeof vi.fn>; error: ReturnType<typeof vi.fn> } };
+
+  beforeEach(async () => {
+    toastModule = await import("sonner") as typeof toastModule;
+    toastModule.toast.success.mockClear();
+    toastModule.toast.error.mockClear();
+  });
+
+  describe("createMatch", () => {
+    it("エラー時にダイアログが閉じ、エラートーストが表示される", async () => {
+      matchCreateBehavior = "error";
+      const user = await openAddDialogForEmptyCell();
+
+      const dialog = await screen.findByRole("dialog");
+      expect(dialog).toBeDefined();
+
+      const submitButton = within(dialog).getByRole("button", { name: "追加" });
+      await user.click(submitButton);
+
+      expect(screen.queryByRole("dialog")).toBeNull();
+      expect(toastModule.toast.error).toHaveBeenCalledWith(
+        "対局結果の追加に失敗しました",
+      );
+    });
+
+    it("成功時にダイアログが閉じ、成功トーストと router.refresh が呼ばれる", async () => {
+      matchCreateBehavior = "success";
+      const user = await openAddDialogForEmptyCell();
+
+      const dialog = await screen.findByRole("dialog");
+      const submitButton = within(dialog).getByRole("button", { name: "追加" });
+      await user.click(submitButton);
+
+      expect(screen.queryByRole("dialog")).toBeNull();
+      expect(toastModule.toast.success).toHaveBeenCalledOnce();
+      expect(refreshMock).toHaveBeenCalled();
+    });
+  });
+
+  describe("updateMatch", () => {
+    it("エラー時にダイアログが閉じ、エラートーストが表示される", async () => {
+      matchUpdateBehavior = "error";
+      const user = await openEditDialogViaDropdown();
+
+      const dialog = await screen.findByRole("dialog");
+      expect(dialog).toBeDefined();
+
+      const submitButton = within(dialog).getByRole("button", { name: "保存" });
+      await user.click(submitButton);
+
+      expect(screen.queryByRole("dialog")).toBeNull();
+      expect(toastModule.toast.error).toHaveBeenCalledWith(
+        "対局結果の更新に失敗しました",
+      );
+    });
+
+    it("成功時にダイアログが閉じ、成功トーストと router.refresh が呼ばれる", async () => {
+      matchUpdateBehavior = "success";
+      const user = await openEditDialogViaDropdown();
+
+      const dialog = await screen.findByRole("dialog");
+      const submitButton = within(dialog).getByRole("button", { name: "保存" });
+      await user.click(submitButton);
+
+      expect(screen.queryByRole("dialog")).toBeNull();
+      expect(toastModule.toast.success).toHaveBeenCalledOnce();
+      expect(refreshMock).toHaveBeenCalled();
+    });
+  });
+
+  describe("deleteMatch", () => {
+    it("エラー時にダイアログが閉じ、エラートーストが表示される", async () => {
+      matchDeleteBehavior = "error";
+      const user = await openDeleteDialogViaDropdown();
+
+      const dialog = await screen.findByRole("alertdialog");
+      expect(dialog).toBeDefined();
+
+      const deleteButton = within(dialog).getByRole("button", { name: "削除" });
+      await user.click(deleteButton);
+
+      expect(screen.queryByRole("alertdialog")).toBeNull();
+      expect(toastModule.toast.error).toHaveBeenCalledWith(
+        "対局結果の削除に失敗しました",
+      );
+    });
+
+    it("成功時にダイアログが閉じ、成功トーストと router.refresh が呼ばれる", async () => {
+      matchDeleteBehavior = "success";
+      const user = await openDeleteDialogViaDropdown();
+
+      const dialog = await screen.findByRole("alertdialog");
+      const deleteButton = within(dialog).getByRole("button", { name: "削除" });
+      await user.click(deleteButton);
+
+      expect(screen.queryByRole("alertdialog")).toBeNull();
+      expect(toastModule.toast.success).toHaveBeenCalledOnce();
+      expect(refreshMock).toHaveBeenCalled();
     });
   });
 });


### PR DESCRIPTION
## Summary

- createMatch / updateMatch / deleteMatch の mutation エラーパスに対するテストを6件追加（各 mutation にエラー・成功の2パターン）
- `makeMutationMock` ヘルパーを導入し、TanStack Query のコールバック呼び出し順序を正確に再現するモックにリファクタリング
- 既存テスト（複製ボタン）との互換性を維持

Closes #191

## Test plan

- [ ] `npm run test:run -- app/(authenticated)/circle-sessions/components/circle-session-detail-view.test.tsx` で全12テスト（既存6 + 新規6）が通過すること
- [ ] 新規テストがエラートーストのメッセージ内容まで検証していること
- [ ] 既存テストにリグレッションがないこと

🤖 Generated with [Claude Code](https://claude.com/claude-code)