### PR TITLE
refactor: add secondary sort key to circle session list (#102)

### DIFF
--- a/server/infrastructure/repository/circle-session/prisma-circle-session-repository.test.ts
+++ b/server/infrastructure/repository/circle-session/prisma-circle-session-repository.test.ts
@@ -123,7 +123,7 @@ describe("Prisma CircleSession リポジトリ", () => {
 
     expect(mockedPrisma.circleSession.findMany).toHaveBeenCalledWith({
       where: { circleId: "circle-1" },
-      orderBy: { startsAt: "asc" },
+      orderBy: [{ startsAt: "asc" }, { createdAt: "asc" }],
     });
     expect(sessions).toHaveLength(1);
   });

--- a/server/infrastructure/repository/circle-session/prisma-circle-session-repository.ts
+++ b/server/infrastructure/repository/circle-session/prisma-circle-session-repository.ts
@@ -44,7 +44,7 @@ export const createPrismaCircleSessionRepository = (
   async listByCircleId(circleId: CircleId): Promise<CircleSession[]> {
     const sessions = await client.circleSession.findMany({
       where: { circleId: toPersistenceId(circleId) },
-      orderBy: { startsAt: "asc" },
+      orderBy: [{ startsAt: "asc" }, { createdAt: "asc" }],
     });
 
     return sessions.map(mapCircleSessionToDomain);


### PR DESCRIPTION
## Summary

- `listByCircleId` の `orderBy` に `createdAt: "asc"` を二次ソートキーとして追加
- `scheduledAt`（`startsAt`）が同一の場合でもソート順が決定的になる

Closes #102

## Test plan

- [x] 既存ユニットテスト全パス（6 tests passed）
- [ ] `orderBy` が `[{ startsAt: "asc" }, { createdAt: "asc" }]` に変更されていることを確認
- [ ] `createdAt` が non-nullable であることを確認（NULL リスクなし）

## Follow-up

- #195: 同一 `startsAt` でのソート順を検証するテストケースの追加

🤖 Generated with [Claude Code](https://claude.com/claude-code)