### PR TITLE
test: add order-preservation test for listByCircleId with same startsAt

### DIFF
--- a/server/infrastructure/repository/circle-session/prisma-circle-session-repository.test.ts
+++ b/server/infrastructure/repository/circle-session/prisma-circle-session-repository.test.ts
@@ -128,6 +128,53 @@ describe("Prisma CircleSession リポジトリ", () => {
     expect(sessions).toHaveLength(1);
   });
 
+  test("listByCircleId はPrismaから返された順序をそのまま保持する", async () => {
+    const prismaSessions = [
+      {
+        id: "session-a",
+        circleId: "circle-1",
+        title: "セッションA",
+        startsAt: new Date("2024-01-01T10:00:00Z"),
+        endsAt: new Date("2024-01-01T12:00:00Z"),
+        location: null,
+        note: "",
+        createdAt: new Date("2024-01-01T03:00:00Z"),
+      },
+      {
+        id: "session-b",
+        circleId: "circle-1",
+        title: "セッションB",
+        startsAt: new Date("2024-01-01T10:00:00Z"),
+        endsAt: new Date("2024-01-01T12:00:00Z"),
+        location: null,
+        note: "",
+        createdAt: new Date("2024-01-01T01:00:00Z"),
+      },
+      {
+        id: "session-c",
+        circleId: "circle-1",
+        title: "セッションC",
+        startsAt: new Date("2024-01-01T10:00:00Z"),
+        endsAt: new Date("2024-01-01T12:00:00Z"),
+        location: null,
+        note: "",
+        createdAt: new Date("2024-01-01T02:00:00Z"),
+      },
+    ] as PrismaCircleSession[];
+
+    mockedPrisma.circleSession.findMany.mockResolvedValueOnce(prismaSessions);
+
+    const sessions = await prismaCircleSessionRepository.listByCircleId(
+      circleId("circle-1"),
+    );
+
+    expect(sessions.map((session) => session.id)).toEqual([
+      circleSessionId("session-a"),
+      circleSessionId("session-b"),
+      circleSessionId("session-c"),
+    ]);
+  });
+
   test("save は upsert を呼ぶ", async () => {
     const session = createCircleSession({
       id: circleSessionId("session-1"),


### PR DESCRIPTION
## Summary

Closes #195

- `listByCircleId` が同一 `startsAt` を持つ複数セッションを返す際、Prisma から返された順序がマッピング層で保持されることを検証するテストケースを追加
- 既存テスト（`orderBy` 引数の形状検証）と補完関係にあり、二次キー `createdAt` 導入（#102）の意図を文書化

## Test plan

- [x] `npm run test:run -- server/infrastructure/repository/circle-session/prisma-circle-session-repository.test.ts` で全7テスト PASS
- [ ] テスト名がモック返却順序の保持を正しく表現していることを確認
- [ ] 既存テストに変更がないことを diff で確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)