### PR TITLE
test: add unit tests for SessionCalendar hover feedback logic (#200)

### DIFF
--- a/components/calendar/session-calendar-hover.test.ts
+++ b/components/calendar/session-calendar-hover.test.ts
@@ -1,0 +1,70 @@
+import { describe, expect, it } from "vitest";
+import { buildSessionDates, getDayCellClassNames } from "./session-calendar";
+
+describe("buildSessionDates", () => {
+  it("events が undefined → 空 Set を返す", () => {
+    const result = buildSessionDates(undefined);
+    expect(result.size).toBe(0);
+  });
+
+  it("events が空配列 → 空 Set を返す", () => {
+    const result = buildSessionDates([]);
+    expect(result.size).toBe(0);
+  });
+
+  it("start が Date オブジェクト → toISOString().slice(0, 10) で日付文字列を生成", () => {
+    const result = buildSessionDates([
+      { start: new Date(2025, 0, 15, 14, 0) },
+    ]);
+    expect(result.has("2025-01-15")).toBe(true);
+    expect(result.size).toBe(1);
+  });
+
+  it("start が ISO文字列 → .slice(0, 10) で日付文字列を生成", () => {
+    const result = buildSessionDates([
+      { start: "2025-03-10T09:00:00" },
+    ]);
+    expect(result.has("2025-03-10")).toBe(true);
+    expect(result.size).toBe(1);
+  });
+
+  it("複数イベント → すべての日付を含む Set を返す", () => {
+    const result = buildSessionDates([
+      { start: "2025-01-15T14:00:00" },
+      { start: new Date(2025, 2, 10, 10, 0) },
+      { start: "2025-06-01T09:00:00" },
+    ]);
+    expect(result.size).toBe(3);
+    expect(result.has("2025-01-15")).toBe(true);
+    expect(result.has("2025-03-10")).toBe(true);
+    expect(result.has("2025-06-01")).toBe(true);
+  });
+
+  it("start が Date でも string でもない → 空文字列がセットに含まれる", () => {
+    const result = buildSessionDates([
+      { start: 12345 as unknown as string },
+    ]);
+    expect(result.has("")).toBe(true);
+    expect(result.size).toBe(1);
+  });
+});
+
+describe("getDayCellClassNames", () => {
+  it("hasDateClick が false → 空配列を返す", () => {
+    const sessionDates = new Set(["2025-01-15"]);
+    const result = getDayCellClassNames("2025-01-15", sessionDates, false);
+    expect(result).toEqual([]);
+  });
+
+  it("hasDateClick が true + sessionDates にその日付が含まれる → 空配列を返す", () => {
+    const sessionDates = new Set(["2025-01-15"]);
+    const result = getDayCellClassNames("2025-01-15", sessionDates, true);
+    expect(result).toEqual([]);
+  });
+
+  it("hasDateClick が true + sessionDates にその日付が含まれない → ['fc-day-clickable']", () => {
+    const sessionDates = new Set(["2025-01-15"]);
+    const result = getDayCellClassNames("2025-02-01", sessionDates, true);
+    expect(result).toEqual(["fc-day-clickable"]);
+  });
+});

--- a/components/calendar/session-calendar.tsx
+++ b/components/calendar/session-calendar.tsx
@@ -76,6 +76,26 @@ type SessionCalendarProps = {
   onDateClick?: (arg: DateClickArg) => void;
 };
 
+export function buildSessionDates(events?: EventInput[]): Set<string> {
+  if (!events) return new Set<string>();
+  return new Set(
+    events.map((e) => {
+      const d = e.start;
+      if (d instanceof Date) return d.toISOString().slice(0, 10);
+      return typeof d === "string" ? d.slice(0, 10) : "";
+    }),
+  );
+}
+
+export function getDayCellClassNames(
+  dateStr: string,
+  sessionDates: Set<string>,
+  hasDateClick: boolean,
+): string[] {
+  if (!hasDateClick) return [];
+  return sessionDates.has(dateStr) ? [] : ["fc-day-clickable"];
+}
+
 export function SessionCalendar({
   events,
   onDateClick,
@@ -86,16 +106,7 @@ export function SessionCalendar({
     onDateClickRef.current = onDateClick;
   }, [onDateClick]);
 
-  const sessionDates = useMemo(() => {
-    if (!events) return new Set<string>();
-    return new Set(
-      events.map((e) => {
-        const d = e.start;
-        if (d instanceof Date) return d.toISOString().slice(0, 10);
-        return typeof d === "string" ? d.slice(0, 10) : "";
-      }),
-    );
-  }, [events]);
+  const sessionDates = useMemo(() => buildSessionDates(events), [events]);
 
   useEffect(() => {
     if (!onDateClick) return;
@@ -235,9 +246,8 @@ export function SessionCalendar({
         events={events}
         dateClick={onDateClick}
         dayCellClassNames={(arg) => {
-          if (!onDateClick) return [];
           const dateStr = arg.date.toISOString().slice(0, 10);
-          return sessionDates.has(dateStr) ? [] : ["fc-day-clickable"];
+          return getDayCellClassNames(dateStr, sessionDates, !!onDateClick);
         }}
         eventContent={(arg) => <EventWithTooltip arg={arg} />}
       />


### PR DESCRIPTION
## Summary

- `buildSessionDates` と `getDayCellClassNames` を `SessionCalendar` コンポーネントから純粋関数として抽出
- ホバーフィードバック判定ロジックに対する 9 件のユニットテストを追加
- コンポーネントの外部から見た振る舞いに変更なし

Closes #200

## Test plan

- [ ] `npm run test:run -- components/calendar/session-calendar-hover.test.ts` → 9/9 パス
- [ ] `npm run test:run -- components/calendar/` → 既存テスト含め全パス
- [ ] `npx tsc --noEmit` → 本PR起因のエラーなし
- [ ] `npm run lint` → 本PR起因の警告なし

🤖 Generated with [Claude Code](https://claude.com/claude-code)