### PR TITLE
fix: 空白のみタイトルでエラーメッセージを表示 (#100)

### DIFF
--- a/app/(authenticated)/circles/[circleId]/sessions/new/circle-session-create-form.test.tsx
+++ b/app/(authenticated)/circles/[circleId]/sessions/new/circle-session-create-form.test.tsx
@@ -196,4 +196,31 @@ describe("CircleSessionCreateForm", () => {
     const endsAtInput = screen.getByLabelText("終了日時") as HTMLInputElement;
     expect(endsAtInput.value).toBe("2025-08-20T18:00");
   });
+
+  it("空白のみのタイトルで送信するとエラーメッセージが表示される", async () => {
+    const user = userEvent.setup();
+    render(<CircleSessionCreateForm circleId={circleId} />);
+
+    const titleInput = screen.getByLabelText("タイトル");
+    await user.type(titleInput, "   ");
+
+    await user.click(screen.getByRole("button", { name: /予定を作成/ }));
+
+    const alert = screen.getByRole("alert");
+    expect(alert.textContent).toBe("タイトルを入力してください");
+    expect(mutateMock).not.toHaveBeenCalled();
+  });
+
+  it("タイトル入力時にエラーメッセージがクリアされる", async () => {
+    const user = userEvent.setup();
+    render(<CircleSessionCreateForm circleId={circleId} />);
+
+    const titleInput = screen.getByLabelText("タイトル");
+    await user.type(titleInput, "   ");
+    await user.click(screen.getByRole("button", { name: /予定を作成/ }));
+    expect(screen.getByRole("alert")).toBeTruthy();
+
+    await user.type(titleInput, "テスト");
+    expect(screen.queryByRole("alert")).toBeNull();
+  });
 });

--- a/app/(authenticated)/circles/[circleId]/sessions/new/circle-session-create-form.tsx
+++ b/app/(authenticated)/circles/[circleId]/sessions/new/circle-session-create-form.tsx
@@ -48,6 +48,7 @@ export function CircleSessionCreateForm({
   defaultNote,
 }: CircleSessionCreateFormProps) {
   const [title, setTitle] = useState(defaultTitle ?? "");
+  const [titleError, setTitleError] = useState("");
   const [startsAt, setStartsAt] = useState(() =>
     toDatetimeLocal(defaultStartsAt, DEFAULT_START_TIME),
   );
@@ -67,7 +68,11 @@ export function CircleSessionCreateForm({
   const handleSubmit = (event: FormEvent<HTMLFormElement>) => {
     event.preventDefault();
     const trimmedTitle = title.trim();
-    if (!trimmedTitle || !startsAt || !endsAt || createSession.isPending) {
+    if (!trimmedTitle) {
+      setTitleError("タイトルを入力してください");
+      return;
+    }
+    if (!startsAt || !endsAt || createSession.isPending) {
       return;
     }
     createSession.mutate({
@@ -105,11 +110,19 @@ export function CircleSessionCreateForm({
           <Input
             id="title"
             value={title}
-            onChange={(e) => setTitle(e.target.value)}
+            onChange={(e) => {
+              setTitle(e.target.value);
+              setTitleError("");
+            }}
             placeholder="第1回 定例研究会"
             required
             className="bg-white"
           />
+          {titleError && (
+            <p className="text-xs text-red-600" role="alert">
+              {titleError}
+            </p>
+          )}
         </div>
 
         <div className="grid gap-4 sm:grid-cols-2">


### PR DESCRIPTION
## Summary

- 開催回作成フォームで、タイトルに空白のみ入力して送信した際にエラーメッセージ「タイトルを入力してください」を表示するよう修正
- エラーメッセージはタイトル入力時に自動でクリアされる
- テスト2件追加（空白タイトルのエラー表示、入力時のエラークリア）

Closes #100

## Test plan

- [ ] `npm run test:run -- circle-session-create-form.test.tsx` で全12テスト合格を確認
- [ ] `npx tsc --noEmit` で型エラーなしを確認
- [ ] 手動: タイトル欄にスペースのみ入力 → 送信 → エラーメッセージ表示を確認
- [ ] 手動: エラー表示後にタイトル入力 → エラーメッセージ消去を確認

## Related issues

- #204 aria-describedby/aria-invalid追加（改善）
- #205 全角スペース対応（改善）
- #206 required属性との競合解消（改善）

🤖 Generated with [Claude Code](https://claude.com/claude-code)