### PR TITLE
fix: required属性とカスタムバリデーションの競合を解消 (#206)

### DIFF
--- a/app/(authenticated)/circles/[circleId]/sessions/new/circle-session-create-form.tsx
+++ b/app/(authenticated)/circles/[circleId]/sessions/new/circle-session-create-form.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import type { FormEvent } from "react";
-import { useEffect, useState } from "react";
+import { useEffect, useRef, useState } from "react";
 import { Plus } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
@@ -47,6 +47,7 @@ export function CircleSessionCreateForm({
   defaultLocation,
   defaultNote,
 }: CircleSessionCreateFormProps) {
+  const titleRef = useRef<HTMLInputElement>(null);
   const [title, setTitle] = useState(defaultTitle ?? "");
   const [titleError, setTitleError] = useState("");
   const [startsAt, setStartsAt] = useState(() =>
@@ -70,6 +71,7 @@ export function CircleSessionCreateForm({
     const trimmedTitle = title.trim();
     if (!trimmedTitle) {
       setTitleError("タイトルを入力してください");
+      titleRef.current?.focus();
       return;
     }
     if (!startsAt || !endsAt || createSession.isPending) {
@@ -98,16 +100,18 @@ export function CircleSessionCreateForm({
     <div className="w-full">
       <form
         onSubmit={handleSubmit}
+        noValidate
         className="flex w-full flex-col gap-4"
       >
         <div className="flex flex-col gap-1.5">
           <label
             htmlFor="title"
-            className="text-xs font-semibold text-(--brand-ink-muted)"
+            className="text-xs font-semibold text-(--brand-ink-muted) after:ml-0.5 after:text-red-600 after:content-['*']"
           >
             タイトル
           </label>
           <Input
+            ref={titleRef}
             id="title"
             value={title}
             onChange={(e) => {
@@ -115,11 +119,13 @@ export function CircleSessionCreateForm({
               setTitleError("");
             }}
             placeholder="第1回 定例研究会"
-            required
+            aria-required="true"
+            aria-invalid={titleError ? "true" : undefined}
+            aria-describedby={titleError ? "title-error" : undefined}
             className="bg-white"
           />
           {titleError && (
-            <p className="text-xs text-red-600" role="alert">
+            <p id="title-error" className="text-xs text-red-600" role="alert">
               {titleError}
             </p>
           )}
@@ -138,7 +144,7 @@ export function CircleSessionCreateForm({
               type="datetime-local"
               value={startsAt}
               onChange={(e) => setStartsAt(e.target.value)}
-              required
+              aria-required="true"
               className="bg-white"
             />
           </div>
@@ -154,7 +160,7 @@ export function CircleSessionCreateForm({
               type="datetime-local"
               value={endsAt}
               onChange={(e) => setEndsAt(e.target.value)}
-              required
+              aria-required="true"
               className="bg-white"
             />
           </div>


### PR DESCRIPTION
## Summary

- `required` を `aria-required="true"` に置換し、ブラウザ標準バリデーションとカスタムバリデーションの競合を解消
- `<form>` に `noValidate` を追加してブラウザ標準バリデーションを一括無効化
- `aria-invalid` / `aria-describedby` によるアクセシビリティ強化
- CSSの `::after` 疑似要素で必須マーク（`*`）を表示
- エラー時にタイトル入力にフォーカスを移動

Closes #206

## Verification Steps

1. `npm run dev` で開発サーバーを起動
2. テストアカウント（sota@example.com / demo-pass-1）でログイン
3. `/circles/demo/sessions/new` に移動
4. **空タイトルで送信** → ブラウザ標準ツールチップが出ず、カスタムエラーメッセージ「タイトルを入力してください」が表示され、フォーカスが移動すること
5. **スペースのみで送信** → 同じカスタムエラーメッセージが表示されること
6. **正常入力で送信** → 正常に作成されること
7. タイトルラベル横に赤い `*` が表示されていること

## Test Results

- 対象テスト: 12/12 passed
- 全体テスト: 441/441 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)