### PR TITLE
fix(a11y): add `<main>` landmark to error pages

### DIFF
--- a/app/forbidden.tsx
+++ b/app/forbidden.tsx
@@ -3,7 +3,7 @@ import { Button } from "@/components/ui/button";
 
 export default function Forbidden() {
   return (
-    <div className="flex min-h-svh flex-col items-center justify-center px-6">
+    <main className="flex min-h-svh flex-col items-center justify-center px-6">
       <div className="max-w-md space-y-6 text-center">
         <h1 className="text-6xl font-bold text-(--brand-moss)">403</h1>
         <h2 className="text-2xl font-(--font-display) text-(--brand-ink)">
@@ -19,6 +19,6 @@ export default function Forbidden() {
           <Link href="/">ホームに戻る</Link>
         </Button>
       </div>
-    </div>
+    </main>
   );
 }

--- a/app/not-found.tsx
+++ b/app/not-found.tsx
@@ -3,7 +3,7 @@ import { Button } from "@/components/ui/button";
 
 export default function NotFound() {
   return (
-    <div className="flex min-h-svh flex-col items-center justify-center px-6">
+    <main className="flex min-h-svh flex-col items-center justify-center px-6">
       <div className="max-w-md space-y-6 text-center">
         <h1 className="text-6xl font-bold text-(--brand-moss)">404</h1>
         <h2 className="text-2xl font-(--font-display) text-(--brand-ink)">
@@ -19,6 +19,6 @@ export default function NotFound() {
           <Link href="/">ホームに戻る</Link>
         </Button>
       </div>
-    </div>
+    </main>
   );
 }


### PR DESCRIPTION
## Summary

Closes #216

- `app/forbidden.tsx` と `app/not-found.tsx` の外側コンテナを `<div>` → `<main>` に変更
- ルートレベルまたは `(public)` ルートグループで描画された場合にスクリーンリーダーのランドマークナビゲーションが機能するようになる
- WCAG 2.1 SC 1.3.1 (Info and Relationships, Level A)

## Known Trade-off

`(authenticated)` / `(public)` レイアウト内で描画された場合、レイアウトの `<main>` と本コンポーネントの `<main>` がネストする。issue の方針として許容済み。

## Verification

| Check | Result |
|-------|--------|
| `npx tsc --noEmit` | pass |
| `npm run lint` | pass |

### 手動検証手順

1. 存在しない URL にアクセスして 404 ページを表示 → `<main>` 要素が存在すること
2. 認可エラーで 403 ページを表示 → `<main>` 要素が存在すること
3. VoiceOver ランドマークナビゲーションで「メイン」ランドマークが検出されること

## Related Issues

- #218 エラーページの見出し階層を改善する（verify で発見、follow-up issue 作成済み）
- #219 `--brand-ink-muted` のコントラスト比を検証・改善する（verify で発見、follow-up issue 作成済み）

🤖 Generated with [Claude Code](https://claude.com/claude-code)