### PR TITLE
refactor: 日時フォーマットユーティリティの共通化 (#88)

### DIFF
--- a/app/(authenticated)/circle-sessions/components/circle-session-detail-view.tsx
+++ b/app/(authenticated)/circle-sessions/components/circle-session-detail-view.tsx
@@ -33,6 +33,7 @@ import {
   TableHeader,
   TableRow,
 } from "@/components/ui/table";
+import { formatDateForInput } from "@/lib/date-utils";
 import { trpc } from "@/lib/trpc/client";
 import type {
   CircleSessionDetailViewModel,
@@ -115,11 +116,6 @@ const roleConfigs: Record<CircleSessionRoleKey, RoleConfig> = {
     ],
   },
 };
-
-const pad2 = (value: number) => String(value).padStart(2, "0");
-
-const formatDateForInput = (date: Date) =>
-  `${date.getFullYear()}-${pad2(date.getMonth() + 1)}-${pad2(date.getDate())}`;
 
 const getTodayInputValue = () => formatDateForInput(new Date());
 

--- a/app/(authenticated)/home/page.tsx
+++ b/app/(authenticated)/home/page.tsx
@@ -5,18 +5,11 @@ import {
   SessionCalendar,
   type SessionExtendedProps,
 } from "@/components/calendar/session-calendar";
+import { formatDate, formatTime } from "@/lib/date-utils";
 import { trpc } from "@/lib/trpc/client";
 import type { EventInput } from "@fullcalendar/core";
 import Link from "next/link";
 import { useMemo } from "react";
-
-const pad2 = (value: number) => String(value).padStart(2, "0");
-
-const formatDate = (date: Date) =>
-  `${date.getFullYear()}/${pad2(date.getMonth() + 1)}/${pad2(date.getDate())}`;
-
-const formatTime = (date: Date) =>
-  `${pad2(date.getHours())}:${pad2(date.getMinutes())}`;
 
 export default function Home() {
   const sessionsQuery =

--- a/components/calendar/event-with-tooltip.test.tsx
+++ b/components/calendar/event-with-tooltip.test.tsx
@@ -3,7 +3,7 @@ import type { EventContentArg } from "@fullcalendar/core";
 import type { EventImpl } from "@fullcalendar/core/internal";
 import { cleanup, render, screen } from "@testing-library/react";
 import { afterEach, describe, expect, it } from "vitest";
-import { EventWithTooltip, formatTooltipDateTime } from "./session-calendar";
+import { EventWithTooltip } from "./session-calendar";
 
 afterEach(() => {
   cleanup();
@@ -154,28 +154,5 @@ describe("EventWithTooltip", () => {
     const srOnly = screen.getByText(/2025\/03\/10/);
     expect(srOnly.className).toContain("sr-only");
     expect(srOnly.textContent).toBe(", 2025/03/10 10:00 - 12:30");
-  });
-});
-
-describe("formatTooltipDateTime", () => {
-  it("string 型の日付入力で正しいフォーマットを返す", () => {
-    const result = formatTooltipDateTime(
-      "2025-06-01T09:00:00",
-      "2025-06-01T11:30:00",
-    );
-    expect(result).toBe("2025/06/01 09:00 - 11:30");
-  });
-
-  it("Date 型の日付入力で正しいフォーマットを返す", () => {
-    const result = formatTooltipDateTime(
-      new Date(2025, 0, 15, 14, 0),
-      new Date(2025, 0, 15, 16, 0),
-    );
-    expect(result).toBe("2025/01/15 14:00 - 16:00");
-  });
-
-  it("不正な日付文字列の場合 NaN を含む文字列を返す", () => {
-    const result = formatTooltipDateTime("invalid-date", "also-invalid");
-    expect(result).toContain("NaN");
   });
 });

--- a/components/calendar/session-calendar.tsx
+++ b/components/calendar/session-calendar.tsx
@@ -11,6 +11,7 @@ import {
   TooltipContent,
   TooltipTrigger,
 } from "@/components/ui/tooltip";
+import { formatTooltipDateTime } from "@/lib/date-utils";
 
 const FC_PLUGINS = [dayGridPlugin, interactionPlugin];
 
@@ -18,24 +19,6 @@ export type SessionExtendedProps = {
   startsAt: string | Date;
   endsAt: string | Date;
 };
-
-export function formatTooltipDateTime(
-  startsAt: string | Date,
-  endsAt: string | Date,
-): string {
-  const toDate = (v: string | Date): Date =>
-    v instanceof Date ? v : new Date(v);
-
-  const start = toDate(startsAt);
-  const end = toDate(endsAt);
-
-  const pad2 = (n: number) => String(n).padStart(2, "0");
-  const date = `${start.getFullYear()}/${pad2(start.getMonth() + 1)}/${pad2(start.getDate())}`;
-  const startTime = `${pad2(start.getHours())}:${pad2(start.getMinutes())}`;
-  const endTime = `${pad2(end.getHours())}:${pad2(end.getMinutes())}`;
-
-  return `${date} ${startTime} - ${endTime}`;
-}
 
 function isValidDateValue(value: unknown): value is string | Date {
   return typeof value === "string" || value instanceof Date;

--- a/lib/date-utils.test.ts
+++ b/lib/date-utils.test.ts
@@ -1,0 +1,78 @@
+import { describe, expect, it } from "vitest";
+import {
+  formatDate,
+  formatTime,
+  formatDateTimeRange,
+  formatDateForInput,
+  formatDateTimeForInput,
+  formatTooltipDateTime,
+} from "./date-utils";
+
+describe("formatDate", () => {
+  it("YYYY/MM/DD 形式で返す", () => {
+    expect(formatDate(new Date(2025, 0, 5))).toBe("2025/01/05");
+  });
+
+  it("月・日を2桁ゼロ埋めする", () => {
+    expect(formatDate(new Date(2025, 11, 31))).toBe("2025/12/31");
+  });
+});
+
+describe("formatTime", () => {
+  it("HH:MM 形式で返す", () => {
+    expect(formatTime(new Date(2025, 0, 1, 9, 5))).toBe("09:05");
+  });
+
+  it("時・分を2桁ゼロ埋めする", () => {
+    expect(formatTime(new Date(2025, 0, 1, 14, 30))).toBe("14:30");
+  });
+});
+
+describe("formatDateTimeRange", () => {
+  it("日付と時間範囲を結合して返す", () => {
+    const start = new Date(2025, 0, 15, 14, 0);
+    const end = new Date(2025, 0, 15, 16, 30);
+    expect(formatDateTimeRange(start, end)).toBe("2025/01/15 14:00 - 16:30");
+  });
+});
+
+describe("formatDateForInput", () => {
+  it("YYYY-MM-DD 形式で返す", () => {
+    expect(formatDateForInput(new Date(2025, 0, 5))).toBe("2025-01-05");
+  });
+
+  it("月・日を2桁ゼロ埋めする", () => {
+    expect(formatDateForInput(new Date(2025, 11, 31))).toBe("2025-12-31");
+  });
+});
+
+describe("formatDateTimeForInput", () => {
+  it("YYYY-MM-DDThh:mm 形式で返す", () => {
+    expect(formatDateTimeForInput(new Date(2025, 0, 15, 9, 5))).toBe(
+      "2025-01-15T09:05",
+    );
+  });
+});
+
+describe("formatTooltipDateTime", () => {
+  it("string 型の日付入力で正しいフォーマットを返す", () => {
+    const result = formatTooltipDateTime(
+      "2025-06-01T09:00:00",
+      "2025-06-01T11:30:00",
+    );
+    expect(result).toBe("2025/06/01 09:00 - 11:30");
+  });
+
+  it("Date 型の日付入力で正しいフォーマットを返す", () => {
+    const result = formatTooltipDateTime(
+      new Date(2025, 0, 15, 14, 0),
+      new Date(2025, 0, 15, 16, 0),
+    );
+    expect(result).toBe("2025/01/15 14:00 - 16:00");
+  });
+
+  it("不正な日付文字列の場合 NaN を含む文字列を返す", () => {
+    const result = formatTooltipDateTime("invalid-date", "also-invalid");
+    expect(result).toContain("NaN");
+  });
+});

--- a/lib/date-utils.ts
+++ b/lib/date-utils.ts
@@ -1,0 +1,29 @@
+const pad2 = (value: number) => String(value).padStart(2, "0");
+
+export const formatDate = (date: Date) =>
+  `${date.getFullYear()}/${pad2(date.getMonth() + 1)}/${pad2(date.getDate())}`;
+
+export const formatTime = (date: Date) =>
+  `${pad2(date.getHours())}:${pad2(date.getMinutes())}`;
+
+export const formatDateTimeRange = (startsAt: Date, endsAt: Date) =>
+  `${formatDate(startsAt)} ${formatTime(startsAt)} - ${formatTime(endsAt)}`;
+
+export const formatDateForInput = (date: Date) =>
+  `${date.getFullYear()}-${pad2(date.getMonth() + 1)}-${pad2(date.getDate())}`;
+
+export const formatDateTimeForInput = (date: Date) =>
+  `${formatDateForInput(date)}T${pad2(date.getHours())}:${pad2(date.getMinutes())}`;
+
+export function formatTooltipDateTime(
+  startsAt: string | Date,
+  endsAt: string | Date,
+): string {
+  const toDate = (v: string | Date): Date =>
+    v instanceof Date ? v : new Date(v);
+
+  const start = toDate(startsAt);
+  const end = toDate(endsAt);
+
+  return `${formatDate(start)} ${formatTime(start)} - ${formatTime(end)}`;
+}

--- a/server/presentation/providers/circle-overview-provider.ts
+++ b/server/presentation/providers/circle-overview-provider.ts
@@ -1,3 +1,4 @@
+import { formatDateTimeRange } from "@/lib/date-utils";
 import { CircleRole } from "@/server/domain/services/authz/roles";
 import { circleId, userId } from "@/server/domain/common/ids";
 import type { ServiceContainer } from "@/server/application/service-container";
@@ -14,17 +15,6 @@ const roleKeyByDto: Record<CircleRole, CircleRoleKey> = {
   [CircleRole.CircleManager]: "manager",
   [CircleRole.CircleMember]: "member",
 };
-
-const pad2 = (value: number) => String(value).padStart(2, "0");
-
-const formatDate = (date: Date) =>
-  `${date.getFullYear()}/${pad2(date.getMonth() + 1)}/${pad2(date.getDate())}`;
-
-const formatTime = (date: Date) =>
-  `${pad2(date.getHours())}:${pad2(date.getMinutes())}`;
-
-const formatDateTimeRange = (startsAt: Date, endsAt: Date) =>
-  `${formatDate(startsAt)} ${formatTime(startsAt)} - ${formatTime(endsAt)}`;
 
 const toSessionViewModel = (session: {
   id: string;

--- a/server/presentation/providers/trpc-circle-session-detail-provider.ts
+++ b/server/presentation/providers/trpc-circle-session-detail-provider.ts
@@ -1,3 +1,8 @@
+import {
+  formatDateForInput,
+  formatDateTimeForInput,
+  formatDateTimeRange,
+} from "@/lib/date-utils";
 import { CircleSessionRole } from "@/server/domain/services/authz/roles";
 import { userId } from "@/server/domain/common/ids";
 import { appRouter } from "@/server/presentation/trpc/router";
@@ -10,23 +15,6 @@ import type {
   CircleSessionRoleKey,
   CircleSessionDetailViewModel,
 } from "@/server/presentation/view-models/circle-session-detail";
-
-const pad2 = (value: number) => String(value).padStart(2, "0");
-
-const formatDateForInput = (date: Date) =>
-  `${date.getFullYear()}-${pad2(date.getMonth() + 1)}-${pad2(date.getDate())}`;
-
-const formatDateTimeForInput = (date: Date) =>
-  `${formatDateForInput(date)}T${pad2(date.getHours())}:${pad2(date.getMinutes())}`;
-
-const formatDate = (date: Date) =>
-  `${date.getFullYear()}/${pad2(date.getMonth() + 1)}/${pad2(date.getDate())}`;
-
-const formatTime = (date: Date) =>
-  `${pad2(date.getHours())}:${pad2(date.getMinutes())}`;
-
-const formatDateTimeRange = (startsAt: Date, endsAt: Date) =>
-  `${formatDate(startsAt)} ${formatTime(startsAt)} - ${formatTime(endsAt)}`;
 
 const roleKeyByDto: Record<CircleSessionRole, CircleSessionRoleKey> = {
   [CircleSessionRole.CircleSessionOwner]: "owner",


### PR DESCRIPTION
## Summary

- `lib/date-utils.ts` に `pad2`（非export）、`formatDate`、`formatTime`、`formatDateTimeRange`、`formatDateForInput`、`formatDateTimeForInput`、`formatTooltipDateTime` を集約
- 5箇所に重複していたローカル定義を削除し、共通モジュールからの import に置き換え
- `lib/date-utils.test.ts` に全6公開関数のユニットテスト（11ケース）を追加

## Test plan

- [x] `npm run test:run -- lib/date-utils.test.ts` — 11 tests passed
- [x] `npm run test:run -- components/calendar/event-with-tooltip.test.tsx` — 9 tests passed
- [x] `npx tsc --noEmit` — 型エラーなし
- [ ] ホーム画面の開催回一覧で日時表示を確認
- [ ] カレンダーのツールチップ日時表示を確認
- [ ] 開催回詳細画面の日時表示・日付入力デフォルト値を確認
- [ ] 研究会概要画面のスケジュール表示を確認

Closes #88

🤖 Generated with [Claude Code](https://claude.com/claude-code)