### PR TITLE
fix(a11y): add required field visual indicators to forms (#68)

### DIFF
--- a/app/(authenticated)/circles/[circleId]/sessions/new/circle-session-create-form.tsx
+++ b/app/(authenticated)/circles/[circleId]/sessions/new/circle-session-create-form.tsx
@@ -136,7 +136,7 @@ export function CircleSessionCreateForm({
           <div className="flex flex-col gap-1.5">
             <label
               htmlFor="startsAt"
-              className="text-xs font-semibold text-(--brand-ink-muted)"
+              className="text-xs font-semibold text-(--brand-ink-muted) after:ml-0.5 after:text-red-600 after:content-['*']"
             >
               開始日時
             </label>
@@ -152,7 +152,7 @@ export function CircleSessionCreateForm({
           <div className="flex flex-col gap-1.5">
             <label
               htmlFor="endsAt"
-              className="text-xs font-semibold text-(--brand-ink-muted)"
+              className="text-xs font-semibold text-(--brand-ink-muted) after:ml-0.5 after:text-red-600 after:content-['*']"
             >
               終了日時
             </label>

--- a/app/(authenticated)/home/circle-create-form.tsx
+++ b/app/(authenticated)/home/circle-create-form.tsx
@@ -35,14 +35,24 @@ export default function CircleCreateForm() {
     <div className="w-full">
       <form
         onSubmit={handleSubmit}
-        className="flex w-full flex-col gap-3 sm:flex-row"
+        className="flex w-full flex-col gap-3"
       >
-        <Input
-          value={name}
-          onChange={(event) => setName(event.target.value)}
-          placeholder="研究会名"
-          className="bg-white"
-        />
+        <div className="flex flex-col gap-1.5">
+          <label
+            htmlFor="circle-name"
+            className="text-xs font-semibold text-(--brand-ink-muted) after:ml-0.5 after:text-red-600 after:content-['*']"
+          >
+            研究会名
+          </label>
+          <Input
+            id="circle-name"
+            value={name}
+            onChange={(event) => setName(event.target.value)}
+            placeholder="研究会名"
+            aria-required="true"
+            className="bg-white"
+          />
+        </div>
         <Button
           type="submit"
           className="bg-(--brand-moss) text-white hover:bg-(--brand-moss)/90"

--- a/app/components/credentials-login-form.tsx
+++ b/app/components/credentials-login-form.tsx
@@ -45,29 +45,39 @@ export default function CredentialsLoginForm() {
   return (
     <form className="space-y-3" onSubmit={handleSubmit}>
       <div className="space-y-2">
-        <label className="text-xs font-semibold text-(--brand-ink-muted)">
+        <label
+          htmlFor="email"
+          className="text-xs font-semibold text-(--brand-ink-muted) after:ml-0.5 after:text-red-600 after:content-['*']"
+        >
           メールアドレス
         </label>
         <Input
+          id="email"
           type="email"
           value={email}
           autoComplete="email"
           placeholder="demo1@example.com"
           onChange={(event) => setEmail(event.target.value)}
           required
+          aria-required="true"
         />
       </div>
       <div className="space-y-2">
-        <label className="text-xs font-semibold text-(--brand-ink-muted)">
+        <label
+          htmlFor="password"
+          className="text-xs font-semibold text-(--brand-ink-muted) after:ml-0.5 after:text-red-600 after:content-['*']"
+        >
           パスワード
         </label>
         <Input
+          id="password"
           type="password"
           value={password}
           autoComplete="current-password"
           placeholder="••••••••"
           onChange={(event) => setPassword(event.target.value)}
           required
+          aria-required="true"
         />
       </div>
       {errorMessage ? (

--- a/app/components/signup-form.tsx
+++ b/app/components/signup-form.tsx
@@ -77,10 +77,14 @@ export default function SignupForm() {
   return (
     <form className="space-y-3" onSubmit={handleSubmit}>
       <div className="space-y-2">
-        <label className="text-xs font-semibold text-(--brand-ink-muted)">
+        <label
+          htmlFor="display-name"
+          className="text-xs font-semibold text-(--brand-ink-muted)"
+        >
           表示名（任意）
         </label>
         <Input
+          id="display-name"
           type="text"
           value={name}
           autoComplete="name"
@@ -89,42 +93,57 @@ export default function SignupForm() {
         />
       </div>
       <div className="space-y-2">
-        <label className="text-xs font-semibold text-(--brand-ink-muted)">
+        <label
+          htmlFor="signup-email"
+          className="text-xs font-semibold text-(--brand-ink-muted) after:ml-0.5 after:text-red-600 after:content-['*']"
+        >
           メールアドレス
         </label>
         <Input
+          id="signup-email"
           type="email"
           value={email}
           autoComplete="email"
           placeholder="demo1@example.com"
           onChange={(event) => setEmail(event.target.value)}
           required
+          aria-required="true"
         />
       </div>
       <div className="space-y-2">
-        <label className="text-xs font-semibold text-(--brand-ink-muted)">
+        <label
+          htmlFor="signup-password"
+          className="text-xs font-semibold text-(--brand-ink-muted) after:ml-0.5 after:text-red-600 after:content-['*']"
+        >
           パスワード
         </label>
         <Input
+          id="signup-password"
           type="password"
           value={password}
           autoComplete="new-password"
           placeholder="••••••••"
           onChange={(event) => setPassword(event.target.value)}
           required
+          aria-required="true"
         />
       </div>
       <div className="space-y-2">
-        <label className="text-xs font-semibold text-(--brand-ink-muted)">
+        <label
+          htmlFor="signup-password-confirm"
+          className="text-xs font-semibold text-(--brand-ink-muted) after:ml-0.5 after:text-red-600 after:content-['*']"
+        >
           パスワード（確認）
         </label>
         <Input
+          id="signup-password-confirm"
           type="password"
           value={passwordConfirm}
           autoComplete="new-password"
           placeholder="••••••••"
           onChange={(event) => setPasswordConfirm(event.target.value)}
           required
+          aria-required="true"
         />
       </div>
       {errorMessage ? (


### PR DESCRIPTION
## Summary
- 必須フィールドのラベルに赤い `*` マーク（CSSの `::after` 疑似要素）を追加
- `htmlFor` / `id` 属性による label-input の関連付けを改善
- `aria-required="true"` を必須入力に追加
- 対象フォーム: セッション作成、研究会作成、ログイン、サインアップ

## Changed files
| File | Changes |
|------|---------|
| `circle-session-create-form.tsx` | 開始日時・終了日時ラベルに `*` 追加 |
| `circle-create-form.tsx` | ラベル付き入力に変更、`*` 追加、`aria-required` 追加 |
| `credentials-login-form.tsx` | メール・パスワードに `*`、`htmlFor`/`id`、`aria-required` 追加 |
| `signup-form.tsx` | 必須3フィールドに `*`、`htmlFor`/`id`、`aria-required` 追加（表示名は任意のため除外） |

## Test plan
- [ ] ログインフォームで必須フィールド（メール、パスワード）に `*` が表示される
- [ ] サインアップフォームで必須フィールドに `*` が表示され、任意の「表示名」には表示されない
- [ ] 研究会作成フォームで研究会名に `*` が表示される
- [ ] セッション作成フォームで開始日時・終了日時に `*` が表示される
- [ ] スクリーンリーダーで `aria-required` が正しく読み上げられる

Closes #68

🤖 Generated with [Claude Code](https://claude.com/claude-code)