### PR TITLE
fix(a11y): add required field indicators to match recording dialog

### DIFF
--- a/app/(authenticated)/circle-sessions/components/circle-session-detail-view.tsx
+++ b/app/(authenticated)/circle-sessions/components/circle-session-detail-view.tsx
@@ -1102,10 +1102,14 @@ export function CircleSessionDetailView({
           ) : null}
 
           <form onSubmit={handleDialogSubmit}>
-            <label className="block text-xs font-semibold text-(--brand-ink)">
+            <label
+              htmlFor="match-outcome"
+              className="block text-xs font-semibold text-(--brand-ink-muted) after:ml-0.5 after:text-red-600 after:content-['*']"
+            >
               結果
             </label>
             <select
+              id="match-outcome"
               className="mt-2 w-full rounded-lg border border-border/60 bg-white px-3 py-2 text-sm text-(--brand-ink) shadow-xs focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring/30"
               value={selectedOutcome}
               onChange={(event) =>
@@ -1120,10 +1124,14 @@ export function CircleSessionDetailView({
               ))}
             </select>
             <div className="mt-4">
-              <label className="text-xs font-semibold text-(--brand-ink)">
+              <label
+                htmlFor="match-date"
+                className="block text-xs font-semibold text-(--brand-ink-muted) after:ml-0.5 after:text-red-600 after:content-['*']"
+              >
                 対局日
               </label>
               <input
+                id="match-date"
                 type="date"
                 className="mt-2 w-full rounded-lg border border-border/60 bg-white px-3 py-2 text-sm text-(--brand-ink) shadow-xs focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring/30"
                 value={selectedDate}


### PR DESCRIPTION
## Summary

Closes #66

対局記録ダイアログの必須フィールド（結果・対局日）に視覚的な必須マーク（`*`）を追加し、ラベルとフォームコントロールの関連付けを修正。

- 「結果」「対局日」ラベルに赤い `*` マークを追加（CSS `::after`）
- `htmlFor`/`id` 属性によるラベル-入力の正しい関連付け
- プロジェクト全体の必須フィールドパターン（PR #223）との一貫性を確保

## Verification Steps

1. 開催回詳細ページで対局記録ダイアログを開く
2. 「結果」と「対局日」ラベルに赤い `*` マークが表示されること
3. ラベルクリックで対応するコントロールにフォーカスが移ること
4. `npx tsc --noEmit` → Pass
5. `npm run lint` → Pass

## Related

- Follow-up issue: #224（必須フィールド凡例の追加）

🤖 Generated with [Claude Code](https://claude.com/claude-code)