### PR TITLE
fix(a11y): add required field legend text to all forms

### DIFF
--- a/app/(authenticated)/circle-sessions/components/circle-session-detail-view.tsx
+++ b/app/(authenticated)/circle-sessions/components/circle-session-detail-view.tsx
@@ -1102,6 +1102,10 @@ export function CircleSessionDetailView({
           ) : null}
 
           <form onSubmit={handleDialogSubmit}>
+            <p className="mb-3 text-xs text-(--brand-ink-muted)">
+              <span className="text-red-600" aria-hidden="true">*</span>{" "}
+              は必須項目です
+            </p>
             <label
               htmlFor="match-outcome"
               className="block text-xs font-semibold text-(--brand-ink-muted) after:ml-0.5 after:text-red-600 after:content-['*']"

--- a/app/(authenticated)/circles/[circleId]/sessions/new/circle-session-create-form.tsx
+++ b/app/(authenticated)/circles/[circleId]/sessions/new/circle-session-create-form.tsx
@@ -104,6 +104,10 @@ export function CircleSessionCreateForm({
         noValidate
         className="flex w-full flex-col gap-4"
       >
+        <p className="text-xs text-(--brand-ink-muted)">
+          <span className="text-red-600" aria-hidden="true">*</span>{" "}
+          は必須項目です
+        </p>
         <div className="flex flex-col gap-1.5">
           <label
             htmlFor="title"

--- a/app/(authenticated)/home/circle-create-form.tsx
+++ b/app/(authenticated)/home/circle-create-form.tsx
@@ -37,6 +37,10 @@ export default function CircleCreateForm() {
         onSubmit={handleSubmit}
         className="flex w-full flex-col gap-3"
       >
+        <p className="text-xs text-(--brand-ink-muted)">
+          <span className="text-red-600" aria-hidden="true">*</span>{" "}
+          は必須項目です
+        </p>
         <div className="flex flex-col gap-1.5">
           <label
             htmlFor="circle-name"

--- a/app/components/credentials-login-form.tsx
+++ b/app/components/credentials-login-form.tsx
@@ -44,6 +44,10 @@ export default function CredentialsLoginForm() {
 
   return (
     <form className="space-y-3" onSubmit={handleSubmit}>
+      <p className="text-xs text-(--brand-ink-muted)">
+        <span className="text-red-600" aria-hidden="true">*</span>{" "}
+        は必須項目です
+      </p>
       <div className="space-y-2">
         <label
           htmlFor="email"

--- a/app/components/signup-form.tsx
+++ b/app/components/signup-form.tsx
@@ -76,6 +76,10 @@ export default function SignupForm() {
 
   return (
     <form className="space-y-3" onSubmit={handleSubmit}>
+      <p className="text-xs text-(--brand-ink-muted)">
+        <span className="text-red-600" aria-hidden="true">*</span>{" "}
+        は必須項目です
+      </p>
       <div className="space-y-2">
         <label
           htmlFor="display-name"


### PR DESCRIPTION
## Summary

Closes #224

- 必須フィールドインジケータ（`*`）の意味を説明する凡例テキスト「* は必須項目です」を全5フォームの先頭に追加
- WCAG 3.3.2（Labels or Instructions, Level A）のベストプラクティスに準拠

## Changes

対象フォーム:
- `circle-session-detail-view.tsx` — 対局記録ダイアログ
- `circle-session-create-form.tsx` — セッション作成フォーム
- `circle-create-form.tsx` — 研究会作成フォーム
- `credentials-login-form.tsx` — ログインフォーム
- `signup-form.tsx` — サインアップフォーム

## Test plan

- [ ] 各フォームを開き、先頭に「* は必須項目です」の凡例テキストが表示されることを確認
- [ ] 凡例テキストのスタイル（`text-xs`, `text-(--brand-ink-muted)`）が他のフォーム要素と調和していることを確認
- [ ] `aria-hidden="true"` により `*` 記号がスクリーンリーダーに読み上げられないことを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)