### PR TITLE
fix(a11y): add role="alert" to form error messages (#222)

### DIFF
--- a/app/(authenticated)/home/circle-create-form.tsx
+++ b/app/(authenticated)/home/circle-create-form.tsx
@@ -72,7 +72,7 @@ export default function CircleCreateForm() {
         </p>
       ) : null}
       {createCircle.error ? (
-        <p className="mt-3 text-xs text-red-600">
+        <p role="alert" className="mt-3 text-xs text-red-600">
           {createCircle.error.message}
         </p>
       ) : null}

--- a/app/components/credentials-login-form.tsx
+++ b/app/components/credentials-login-form.tsx
@@ -85,7 +85,7 @@ export default function CredentialsLoginForm() {
         />
       </div>
       {errorMessage ? (
-        <p className="text-xs font-semibold text-red-600">{errorMessage}</p>
+        <p role="alert" className="text-xs font-semibold text-red-600">{errorMessage}</p>
       ) : null}
       <Button
         type="submit"

--- a/app/components/signup-form.tsx
+++ b/app/components/signup-form.tsx
@@ -151,7 +151,7 @@ export default function SignupForm() {
         />
       </div>
       {errorMessage ? (
-        <p className="text-xs font-semibold text-red-600">{errorMessage}</p>
+        <p role="alert" className="text-xs font-semibold text-red-600">{errorMessage}</p>
       ) : null}
       <Button
         type="submit"


### PR DESCRIPTION
## Summary

- エラーメッセージの `<p>` 要素に `role="alert"` を追加し、スクリーンリーダーが動的に表示されるエラーを即座に通知するようにした（WCAG 4.1.3）
- 対象: `circle-create-form.tsx`, `credentials-login-form.tsx`, `signup-form.tsx`
- リファレンス実装（`circle-session-create-form.tsx`）と一貫したパターン

## Test plan

- [ ] `npm run dev` で各フォームのエラーを発生させ、DevTools で `role="alert"` が付与されていることを確認
- [ ] VoiceOver でエラーメッセージが読み上げられることを確認
- [ ] `npx tsc --noEmit` が通ること

Closes #222

🤖 Generated with [Claude Code](https://claude.com/claude-code)