### PR TITLE
fix(date): add defensive Invalid Date guard to formatTooltipDateTime

### DIFF
--- a/lib/date-utils.test.ts
+++ b/lib/date-utils.test.ts
@@ -71,8 +71,26 @@ describe("formatTooltipDateTime", () => {
     expect(result).toBe("2025/01/15 14:00 - 16:00");
   });
 
-  it("不正な日付文字列の場合 NaN を含む文字列を返す", () => {
+  it("不正な日付文字列の場合、空文字列を返す", () => {
     const result = formatTooltipDateTime("invalid-date", "also-invalid");
-    expect(result).toContain("NaN");
+    expect(result).toBe("");
+  });
+
+  it("開始日のみ不正な場合、空文字列を返す", () => {
+    const result = formatTooltipDateTime("invalid-date", "2025-01-15T12:00:00");
+    expect(result).toBe("");
+  });
+
+  it("終了日のみ不正な場合、空文字列を返す", () => {
+    const result = formatTooltipDateTime("2025-01-15T10:00:00", "not-a-date");
+    expect(result).toBe("");
+  });
+
+  it("不正なDateオブジェクトの場合、空文字列を返す", () => {
+    const result = formatTooltipDateTime(
+      new Date("invalid"),
+      new Date("invalid"),
+    );
+    expect(result).toBe("");
   });
 });

--- a/lib/date-utils.ts
+++ b/lib/date-utils.ts
@@ -25,5 +25,7 @@ export function formatTooltipDateTime(
   const start = toDate(startsAt);
   const end = toDate(endsAt);
 
+  if (isNaN(start.getTime()) || isNaN(end.getTime())) return "";
+
   return `${formatDate(start)} ${formatTime(start)} - ${formatTime(end)}`;
 }


### PR DESCRIPTION
## Summary

Closes #145

- `formatTooltipDateTime` に `isNaN(date.getTime())` ガードを追加し、不正な日付入力時に空文字列を返すよう修正
- 片側のみ不正な入力、不正な Date オブジェクトのエッジケーステストを3件追加（11 → 14 tests）

## 変更ファイル

| ファイル | 変更内容 |
|---|---|
| `lib/date-utils.ts` | `toDate` 変換後に Invalid Date チェックを追加（1行） |
| `lib/date-utils.test.ts` | エッジケーステスト3件追加、既存テストの期待値を修正 |

## 検証手順

- [x] `npm run test:run -- lib/date-utils.test.ts` — 14 tests passed
- [x] `npx tsc --noEmit` — 型エラーなし
- [ ] `npm run dev` → カレンダーのツールチップ表示が正常であることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)