### PR TITLE
fix(invite): BR-011 1研究会1リンクのルールをサービス層で強制する (#236)

### DIFF
--- a/server/application/circle/circle-invite-link-service.ts
+++ b/server/application/circle/circle-invite-link-service.ts
@@ -61,6 +61,14 @@ export const createCircleInviteLinkService = (
       throw new ForbiddenError();
     }
 
+    // BR-011: 1研究会1有効リンク制約 — 既存の有効リンクがあればそれを返す（冪等方式）
+    const existingLinks =
+      await deps.circleInviteLinkRepository.listByCircleId(params.circleId);
+    const activeLink = existingLinks.find((link) => !isExpired(link));
+    if (activeLink) {
+      return activeLink;
+    }
+
     const generateToken = deps.generateToken ?? randomUUID;
     const generateId = deps.generateId ?? randomUUID;
 


### PR DESCRIPTION
## Summary

- `createInviteLink` で既存の有効リンク（未期限切れ）を確認し、存在する場合はそのリンクを返す冪等方式を実装
- BR-011「1つの研究会につき有効な招待リンクは同時に1つのみ」をサービス層で強制
- 2件のテストを追加（有効リンク存在時の返却、期限切れ時の新規作成）

Closes #236

## Test plan

- [x] `vitest run server/application/circle/circle-invite-link-service.test.ts` — 13 tests passed
- [x] `tsc --noEmit` — 型エラーなし
- [ ] 手動検証: 招待リンク作成 → 再度作成で同じリンクが返される
- [ ] 手動検証: 期限切れ後の再作成で新規リンクが生成される

## Review points

- 冪等方式（既存リンクを返す）vs 上書き方式（旧リンク削除+新規作成）の設計判断
- `listByCircleId` で全件取得後メモリフィルタ（#245 で改善予定）
- TOCTOU 競合条件はプロジェクト規模から許容（SQLiteシリアライズで部分軽減）

🤖 Generated with [Claude Code](https://claude.com/claude-code)