### PR TITLE
refactor(invite): remove unused listByCircleId (#250)

### DIFF
--- a/server/application/circle/circle-invite-link-service.test.ts
+++ b/server/application/circle/circle-invite-link-service.test.ts
@@ -9,7 +9,6 @@ import { circleId, circleInviteLinkId, userId } from "@/server/domain/common/ids
 const circleInviteLinkRepository = {
   findByToken: vi.fn(),
   findActiveByCircleId: vi.fn(),
-  listByCircleId: vi.fn(),
   save: vi.fn(),
 } satisfies CircleInviteLinkRepository;
 

--- a/server/application/service-container.test.ts
+++ b/server/application/service-container.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, test, vi } from "vitest";
 import { createServiceContainer } from "@/server/application/service-container";
 import { matchHistoryId } from "@/server/domain/common/ids";
+import type { CircleInviteLinkRepository } from "@/server/domain/models/circle/circle-invite-link-repository";
 
 const createStub = () => ({
   findById: vi.fn(),
@@ -78,9 +79,8 @@ describe("Service container", () => {
     const circleInviteLinkRepository = {
       findByToken: vi.fn(),
       findActiveByCircleId: vi.fn(),
-      listByCircleId: vi.fn(),
       save: vi.fn(),
-    };
+    } satisfies CircleInviteLinkRepository;
 
     const container = createServiceContainer({
       circleRepository,

--- a/server/domain/models/circle/circle-invite-link-repository.ts
+++ b/server/domain/models/circle/circle-invite-link-repository.ts
@@ -4,6 +4,5 @@ import type { CircleInviteLink } from "@/server/domain/models/circle/circle-invi
 export type CircleInviteLinkRepository = {
   findByToken(token: string): Promise<CircleInviteLink | null>;
   findActiveByCircleId(circleId: CircleId): Promise<CircleInviteLink | null>;
-  listByCircleId(circleId: CircleId): Promise<CircleInviteLink[]>;
   save(link: CircleInviteLink): Promise<void>;
 };

--- a/server/infrastructure/repository/circle/prisma-circle-invite-link-repository.ts
+++ b/server/infrastructure/repository/circle/prisma-circle-invite-link-repository.ts
@@ -35,15 +35,6 @@ export const createPrismaCircleInviteLinkRepository = (
     return found ? mapCircleInviteLinkToDomain(found) : null;
   },
 
-  async listByCircleId(circleId: CircleId): Promise<CircleInviteLink[]> {
-    const links = await client.circleInviteLink.findMany({
-      where: { circleId: toPersistenceId(circleId) },
-      orderBy: { createdAt: "desc" },
-    });
-
-    return links.map(mapCircleInviteLinkToDomain);
-  },
-
   async save(link: CircleInviteLink): Promise<void> {
     const data = mapCircleInviteLinkToPersistence(link);
 


### PR DESCRIPTION
## Summary

- Remove unused `listByCircleId` from `CircleInviteLinkRepository` interface, Prisma implementation, and test mocks
- Add missing `satisfies CircleInviteLinkRepository` to `service-container.test.ts` mock for compile-time safety

Closes #250

## Background

Issue #245 replaced the only call site of `listByCircleId` with `findActiveByCircleId`. This PR removes the now-dead method, leaving the repository with a clean minimal interface: `findByToken`, `findActiveByCircleId`, `save`.

## Verification

- `npx tsc --noEmit`: passed
- `npm run test:run`: all tests passed
- Zero remaining references to `CircleInviteLinkRepository.listByCircleId` in codebase
- Other repositories' `listByCircleId` methods (CircleParticipationRepository, CircleSessionRepository) are unaffected

## Review points

- The `satisfies` addition to `service-container.test.ts` is a pre-existing inconsistency fix bundled with this cleanup

🤖 Generated with [Claude Code](https://claude.com/claude-code)