### PR TITLE
ci: add push to main trigger for CI workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,6 +1,8 @@
 name: CI
 
 on:
+  push:
+    branches: [main]
   pull_request:
     branches: [main]
 


### PR DESCRIPTION
## Summary

- CI ワークフローに `push` to `main` トリガーを追加
- admin override やレースコンディションでマージされた場合のテスト未検知を防止

Closes #260

## Test plan

- [ ] PR マージ後、main への push で CI が起動することを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)