### PR TITLE
ci: pin GitHub Actions to commit SHAs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,8 +14,8 @@ jobs:
     env:
       DATABASE_URL: postgresql://dummy:dummy@localhost:5432/dummy
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-node@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
         with:
           node-version: 24
           cache: npm


### PR DESCRIPTION
Closes #258

## Summary

- `actions/checkout@v4` → `@34e114876b0b11c390a56381ad16ebd13914f8d5` (v4.3.1)
- `actions/setup-node@v4` → `@49933ea5288caeca8642d1e84afbd3f7d6820020` (v4.4.0)

Mutable major version tags (`@v4`) are vulnerable to supply chain attacks. SHA pinning ensures immutable references with version comments for readability.

## Verification

- [ ] SHA verified via GitHub API (`git/ref/tags/v4.3.1`, `git/ref/tags/v4.4.0`)
- [ ] CI workflow runs successfully on this PR
- [ ] Format: `@<sha> # <tag>` consistent across both actions

## Follow-up

- #263: Add Dependabot configuration for automatic SHA updates

🤖 Generated with [Claude Code](https://claude.com/claude-code)