### PR TITLE
refactor: extract test schema SQL path to shared constant

### DIFF
--- a/server/test-utils/constants.ts
+++ b/server/test-utils/constants.ts
@@ -1,0 +1,3 @@
+import { resolve } from "node:path";
+
+export const TEST_SCHEMA_SQL_PATH = resolve(process.cwd(), "tmp/test-schema.sql");

--- a/server/test-utils/integration-global-setup.ts
+++ b/server/test-utils/integration-global-setup.ts
@@ -1,14 +1,15 @@
 import { execSync } from "node:child_process";
 import { mkdirSync } from "node:fs";
-import { resolve } from "node:path";
+import { dirname, resolve } from "node:path";
 
-const outputPath = resolve(process.cwd(), "tmp/test-schema.sql");
+import { TEST_SCHEMA_SQL_PATH } from "./constants";
+
 const schemaPath = resolve(process.cwd(), "prisma/schema.prisma");
 
 export async function setup() {
-  mkdirSync(resolve(process.cwd(), "tmp"), { recursive: true });
+  mkdirSync(dirname(TEST_SCHEMA_SQL_PATH), { recursive: true });
   execSync(
-    `npx prisma migrate diff --from-empty --to-schema ${schemaPath} --script > ${outputPath}`,
+    `npx prisma migrate diff --from-empty --to-schema ${schemaPath} --script > ${TEST_SCHEMA_SQL_PATH}`,
     { stdio: ["pipe", "pipe", "pipe"] },
   );
 }

--- a/server/test-utils/prisma-test-client.ts
+++ b/server/test-utils/prisma-test-client.ts
@@ -2,12 +2,11 @@ import { PGlite } from "@electric-sql/pglite";
 import { PrismaClient } from "@/generated/prisma/client";
 import { PrismaPGlite } from "pglite-prisma-adapter";
 import { readFileSync } from "node:fs";
-import { resolve } from "node:path";
 
-const SCHEMA_SQL_PATH = resolve(process.cwd(), "tmp/test-schema.sql");
+import { TEST_SCHEMA_SQL_PATH } from "./constants";
 
 export function getSchemaSql(): string {
-  return readFileSync(SCHEMA_SQL_PATH, "utf-8");
+  return readFileSync(TEST_SCHEMA_SQL_PATH, "utf-8");
 }
 
 export type TestPrismaContext = {


### PR DESCRIPTION
## Summary

Closes #255

- `tmp/test-schema.sql` パスリテラルが2ファイルで重複していた問題を解消
- `server/test-utils/constants.ts` に `TEST_SCHEMA_SQL_PATH` を定義し、両ファイルからインポート
- `integration-global-setup.ts` の `mkdirSync` を `dirname(TEST_SCHEMA_SQL_PATH)` に改善し、パスとの暗黙的結合を解消

## Changes

| File | Change |
|------|--------|
| `server/test-utils/constants.ts` | **新規** — `TEST_SCHEMA_SQL_PATH` 定数を定義 |
| `server/test-utils/integration-global-setup.ts` | 定数をインポート、`mkdirSync` を `dirname()` ベースに変更 |
| `server/test-utils/prisma-test-client.ts` | 定数をインポート、不要な `resolve` import を削除 |

## Verification

- [x] `npm run test:run` — 496 tests passed
- [x] `npx tsc --noEmit` — 型チェック合格
- [x] 文字列リテラル `"tmp/test-schema.sql"` が `constants.ts` 以外に存在しないことを確認

🤖 Generated with [Claude Code](https://claude.ai/claude-code)