### PR TITLE
fix: map owner removal error to FORBIDDEN (#271)

### DIFF
--- a/server/application/circle/circle-participation-service.test.ts
+++ b/server/application/circle/circle-participation-service.test.ts
@@ -1,6 +1,7 @@
 import { beforeEach, describe, expect, test, vi } from "vitest";
 import { createCircleParticipationService } from "@/server/application/circle/circle-participation-service";
 import { createAccessServiceStub } from "@/server/application/test-helpers/access-service-stub";
+import { ForbiddenError } from "@/server/domain/common/errors";
 import type { CircleParticipationRepository } from "@/server/domain/models/circle/circle-participation-repository";
 import type { CircleRepository } from "@/server/domain/models/circle/circle-repository";
 import { circleId, userId } from "@/server/domain/common/ids";
@@ -388,7 +389,7 @@ describe("Circle 参加関係サービス", () => {
   test("removeParticipation は Owner の削除を拒否する", async () => {
     vi.mocked(
       circleParticipationRepository.listByCircleId,
-    ).mockResolvedValueOnce([
+    ).mockResolvedValue([
       {
         circleId: circleId("circle-1"),
         userId: userId("user-1"),
@@ -397,6 +398,13 @@ describe("Circle 参加関係サービス", () => {
       },
     ]);
 
+    await expect(
+      service.removeParticipation({
+        actorId: "user-actor",
+        circleId: circleId("circle-1"),
+        userId: userId("user-1"),
+      }),
+    ).rejects.toThrow(ForbiddenError);
     await expect(
       service.removeParticipation({
         actorId: "user-actor",

--- a/server/domain/services/authz/ownership.test.ts
+++ b/server/domain/services/authz/ownership.test.ts
@@ -12,6 +12,7 @@ import {
   transferCircleOwnership,
   transferCircleSessionOwnership,
 } from "@/server/domain/services/authz/ownership";
+import { ForbiddenError } from "@/server/domain/common/errors";
 import { userId } from "@/server/domain/common/ids";
 import {
   CircleRole,
@@ -289,10 +290,13 @@ describe("assertCanWithdraw", () => {
 });
 
 describe("assertCanRemoveCircleMember", () => {
-  test("Owner を削除しようとするとエラー", () => {
-    expect(() => assertCanRemoveCircleMember(CircleRole.CircleOwner)).toThrow(
-      "Use transferOwnership to remove owner",
-    );
+  test("Owner を削除しようとすると ForbiddenError", () => {
+    expect(() =>
+      assertCanRemoveCircleMember(CircleRole.CircleOwner),
+    ).toThrow(ForbiddenError);
+    expect(() =>
+      assertCanRemoveCircleMember(CircleRole.CircleOwner),
+    ).toThrow("Use transferOwnership to remove owner");
   });
 
   test("Manager を削除できる", () => {

--- a/server/domain/services/authz/ownership.ts
+++ b/server/domain/services/authz/ownership.ts
@@ -1,3 +1,4 @@
+import { ForbiddenError } from "@/server/domain/common/errors";
 import type { UserId } from "@/server/domain/common/ids";
 import { assertDifferentIds } from "@/server/domain/common/validation";
 import {
@@ -117,7 +118,7 @@ export const assertCanWithdrawFromSession = (
 
 export const assertCanRemoveCircleMember = (targetRole: CircleRole): void => {
   if (targetRole === CircleRole.CircleOwner) {
-    throw new Error("Use transferOwnership to remove owner");
+    throw new ForbiddenError("Use transferOwnership to remove owner");
   }
 };
 


### PR DESCRIPTION
## Summary

- `assertCanRemoveCircleMember` が plain `Error` を throw していたため、`toTrpcError` で `BAD_REQUEST` にフォールバックしていた
- Owner 削除拒否は認可エラーであり `FORBIDDEN` が適切なため、`ForbiddenError` に変更
- テストにエラー型・メッセージの両方を検証するアサーションを追加

Closes #271

## Test plan

- [ ] `npm run test:run -- server/domain/services/authz/ownership.test.ts` — 41 tests passed
- [ ] `npm run test:run -- server/application/circle/circle-participation-service.test.ts` — 15 tests passed
- [ ] `ForbiddenError` → `toTrpcError` → `FORBIDDEN` のマッピングパスを手動確認

## Follow-up issues

- #279 — 残りの assert 関数で同様の `Error` → `ForbiddenError` 変更
- #280 — `toTrpcError` フォールバックを `INTERNAL_SERVER_ERROR` に変更

🤖 Generated with [Claude Code](https://claude.com/claude-code)