### PR TITLE
fix: use ForbiddenError in remaining ownership assert functions

### DIFF
--- a/server/domain/services/authz/ownership.test.ts
+++ b/server/domain/services/authz/ownership.test.ts
@@ -7,6 +7,7 @@ import {
   assertCanRemoveCircleMember,
   assertCanRemoveCircleSessionMember,
   assertCanWithdraw,
+  assertCanWithdrawFromSession,
   assertSingleCircleOwner,
   assertSingleCircleSessionOwner,
   transferCircleOwnership,
@@ -276,6 +277,9 @@ describe("assertCanAddParticipantWithRole", () => {
 describe("assertCanWithdraw", () => {
   test("Owner は脱退できない", () => {
     expect(() => assertCanWithdraw(CircleRole.CircleOwner)).toThrow(
+      ForbiddenError,
+    );
+    expect(() => assertCanWithdraw(CircleRole.CircleOwner)).toThrow(
       "Owner cannot withdraw from circle. Use transferOwnership instead",
     );
   });
@@ -286,6 +290,31 @@ describe("assertCanWithdraw", () => {
 
   test("Member は脱退できる", () => {
     expect(() => assertCanWithdraw(CircleRole.CircleMember)).not.toThrow();
+  });
+});
+
+describe("assertCanWithdrawFromSession", () => {
+  test("Owner は脱退できない", () => {
+    expect(() =>
+      assertCanWithdrawFromSession(CircleSessionRole.CircleSessionOwner),
+    ).toThrow(ForbiddenError);
+    expect(() =>
+      assertCanWithdrawFromSession(CircleSessionRole.CircleSessionOwner),
+    ).toThrow(
+      "Owner cannot withdraw from session. Use transferOwnership instead",
+    );
+  });
+
+  test("Manager は脱退できる", () => {
+    expect(() =>
+      assertCanWithdrawFromSession(CircleSessionRole.CircleSessionManager),
+    ).not.toThrow();
+  });
+
+  test("Member は脱退できる", () => {
+    expect(() =>
+      assertCanWithdrawFromSession(CircleSessionRole.CircleSessionMember),
+    ).not.toThrow();
   });
 });
 
@@ -313,7 +342,13 @@ describe("assertCanRemoveCircleMember", () => {
 });
 
 describe("assertCanChangeCircleMemberRole", () => {
-  test("Owner への変更はエラー", () => {
+  test("Owner への変更は ForbiddenError", () => {
+    expect(() =>
+      assertCanChangeCircleMemberRole(
+        CircleRole.CircleMember,
+        CircleRole.CircleOwner,
+      ),
+    ).toThrow(ForbiddenError);
     expect(() =>
       assertCanChangeCircleMemberRole(
         CircleRole.CircleMember,
@@ -322,7 +357,13 @@ describe("assertCanChangeCircleMemberRole", () => {
     ).toThrow("Use transferOwnership to assign owner");
   });
 
-  test("Owner からの変更はエラー", () => {
+  test("Owner からの変更は ForbiddenError", () => {
+    expect(() =>
+      assertCanChangeCircleMemberRole(
+        CircleRole.CircleOwner,
+        CircleRole.CircleManager,
+      ),
+    ).toThrow(ForbiddenError);
     expect(() =>
       assertCanChangeCircleMemberRole(
         CircleRole.CircleOwner,
@@ -351,7 +392,12 @@ describe("assertCanChangeCircleMemberRole", () => {
 });
 
 describe("assertCanRemoveCircleSessionMember", () => {
-  test("Owner を削除しようとするとエラー", () => {
+  test("Owner を削除しようとすると ForbiddenError", () => {
+    expect(() =>
+      assertCanRemoveCircleSessionMember(
+        CircleSessionRole.CircleSessionOwner,
+      ),
+    ).toThrow(ForbiddenError);
     expect(() =>
       assertCanRemoveCircleSessionMember(
         CircleSessionRole.CircleSessionOwner,
@@ -377,7 +423,13 @@ describe("assertCanRemoveCircleSessionMember", () => {
 });
 
 describe("assertCanChangeCircleSessionMemberRole", () => {
-  test("Owner への変更はエラー", () => {
+  test("Owner への変更は ForbiddenError", () => {
+    expect(() =>
+      assertCanChangeCircleSessionMemberRole(
+        CircleSessionRole.CircleSessionMember,
+        CircleSessionRole.CircleSessionOwner,
+      ),
+    ).toThrow(ForbiddenError);
     expect(() =>
       assertCanChangeCircleSessionMemberRole(
         CircleSessionRole.CircleSessionMember,
@@ -386,7 +438,13 @@ describe("assertCanChangeCircleSessionMemberRole", () => {
     ).toThrow("Use transferOwnership to assign owner");
   });
 
-  test("Owner からの変更はエラー", () => {
+  test("Owner からの変更は ForbiddenError", () => {
+    expect(() =>
+      assertCanChangeCircleSessionMemberRole(
+        CircleSessionRole.CircleSessionOwner,
+        CircleSessionRole.CircleSessionManager,
+      ),
+    ).toThrow(ForbiddenError);
     expect(() =>
       assertCanChangeCircleSessionMemberRole(
         CircleSessionRole.CircleSessionOwner,

--- a/server/domain/services/authz/ownership.ts
+++ b/server/domain/services/authz/ownership.ts
@@ -100,7 +100,7 @@ export const transferCircleOwnership = (
 
 export const assertCanWithdraw = (targetRole: CircleRole): void => {
   if (targetRole === CircleRole.CircleOwner) {
-    throw new Error(
+    throw new ForbiddenError(
       "Owner cannot withdraw from circle. Use transferOwnership instead",
     );
   }
@@ -110,7 +110,7 @@ export const assertCanWithdrawFromSession = (
   targetRole: CircleSessionRole,
 ): void => {
   if (targetRole === CircleSessionRole.CircleSessionOwner) {
-    throw new Error(
+    throw new ForbiddenError(
       "Owner cannot withdraw from session. Use transferOwnership instead",
     );
   }
@@ -127,10 +127,10 @@ export const assertCanChangeCircleMemberRole = (
   newRole: CircleRole,
 ): void => {
   if (newRole === CircleRole.CircleOwner) {
-    throw new Error("Use transferOwnership to assign owner");
+    throw new ForbiddenError("Use transferOwnership to assign owner");
   }
   if (currentRole === CircleRole.CircleOwner) {
-    throw new Error("Use transferOwnership to change owner");
+    throw new ForbiddenError("Use transferOwnership to change owner");
   }
 };
 
@@ -138,7 +138,7 @@ export const assertCanRemoveCircleSessionMember = (
   targetRole: CircleSessionRole,
 ): void => {
   if (targetRole === CircleSessionRole.CircleSessionOwner) {
-    throw new Error("Use transferOwnership to remove owner");
+    throw new ForbiddenError("Use transferOwnership to remove owner");
   }
 };
 
@@ -147,10 +147,10 @@ export const assertCanChangeCircleSessionMemberRole = (
   newRole: CircleSessionRole,
 ): void => {
   if (newRole === CircleSessionRole.CircleSessionOwner) {
-    throw new Error("Use transferOwnership to assign owner");
+    throw new ForbiddenError("Use transferOwnership to assign owner");
   }
   if (currentRole === CircleSessionRole.CircleSessionOwner) {
-    throw new Error("Use transferOwnership to change owner");
+    throw new ForbiddenError("Use transferOwnership to change owner");
   }
 };
 


### PR DESCRIPTION
## Summary

- `ownership.ts` の残り5関数で `Error` → `ForbiddenError` に変更し、tRPC レスポンスが `FORBIDDEN` (403) を返すように修正
- `assertCanWithdrawFromSession` のテストケースを新規追加
- 既存テストに `ForbiddenError` 型チェックのアサーションを追加

Closes #279

## 変更対象関数

| 関数 | 変更内容 |
|------|----------|
| `assertCanWithdraw` | `Error` → `ForbiddenError` |
| `assertCanWithdrawFromSession` | `Error` → `ForbiddenError` |
| `assertCanChangeCircleMemberRole` | `Error` → `ForbiddenError` (2箇所) |
| `assertCanRemoveCircleSessionMember` | `Error` → `ForbiddenError` |
| `assertCanChangeCircleSessionMemberRole` | `Error` → `ForbiddenError` (2箇所) |

## Test plan

- [x] `npm run test:run -- server/domain/services/authz/ownership.test.ts` → 44 tests passed
- [ ] 全6関数で `toThrow(ForbiddenError)` 型チェックが含まれていること
- [ ] `ownership.ts` 内に generic `Error` の throw が残っていないこと

🤖 Generated with [Claude Code](https://claude.com/claude-code)