### PR TITLE
fix: change toTrpcError fallback error code to INTERNAL_SERVER_ERROR

### DIFF
--- a/server/presentation/trpc/errors.ts
+++ b/server/presentation/trpc/errors.ts
@@ -28,7 +28,7 @@ export const toTrpcError = (error: unknown): TRPCError => {
     return new TRPCError({ code: "NOT_FOUND", message });
   }
 
-  return new TRPCError({ code: "BAD_REQUEST", message });
+  return new TRPCError({ code: "INTERNAL_SERVER_ERROR", message });
 };
 
 export const handleTrpcError = async <T>(

--- a/server/presentation/trpc/router.test.ts
+++ b/server/presentation/trpc/router.test.ts
@@ -903,7 +903,7 @@ describe("tRPC router", () => {
 
     await expect(
       caller.users.memberships.list({ userId: "user-1" }),
-    ).rejects.toMatchObject({ code: "BAD_REQUEST" });
+    ).rejects.toMatchObject({ code: "INTERNAL_SERVER_ERROR" });
   });
 
 });


### PR DESCRIPTION
## Summary

- `toTrpcError` のフォールバックエラーコードを `BAD_REQUEST` → `INTERNAL_SERVER_ERROR` に変更
- 未分類エラーはサーバー内部の問題である可能性が高く、RFC 9110 に準拠した適切なステータスコードに修正

Closes #280

## Changes

- `server/presentation/trpc/errors.ts`: フォールバックの `BAD_REQUEST` → `INTERNAL_SERVER_ERROR`
- `server/presentation/trpc/router.test.ts`: テストの期待値を更新

## Verification

- `npx tsc --noEmit`: 型エラーなし
- `npm run test:run`: 515/515 テスト通過
- 既存のメッセージパターンマッチ（Unauthorized, Forbidden, not found）に影響なし

## Review points

- verify.md で指摘した情報漏洩リスク（500レスポンスでの生メッセージ転送）は既存の問題として #283 で追跡
- `toTrpcError` のユニットテスト不足は #284 で追跡

🤖 Generated with [Claude Code](https://claude.com/claude-code)