### PR TITLE
docs: add security guideline for DomainError message content

### DIFF
--- a/server/presentation/trpc/errors.ts
+++ b/server/presentation/trpc/errors.ts
@@ -9,6 +9,9 @@ export const toTrpcError = (error: unknown): TRPCError => {
     return error;
   }
 
+  // SECURITY: DomainError messages are sent to the client verbatim.
+  // Ensure all DomainError subclasses use static, client-safe messages only.
+  // Do not include dynamic data (IDs, emails, SQL, etc.) in DomainError messages.
   if (error instanceof DomainError) {
     return new TRPCError({ code: error.code, message: error.message });
   }


### PR DESCRIPTION
Closes #288

## Summary
- `server/presentation/trpc/errors.ts` の `DomainError` 分岐にセキュリティガイドラインコメントを追加
- `DomainError` メッセージがクライアントにそのまま転送される仕様を明記し、静的・安全なメッセージのみ使用するよう開発者に警告

## Why
`toTrpcError` は `DomainError` の `message` をそのまま `TRPCError` に渡してクライアントに返す。現在の全サブクラスは安全な固定文字列を使用しているが、将来の回帰リスクを防ぐためコメントで慣習を文書化する。

## Verification
- [x] `npm run test:run -- server/presentation/trpc/errors.test.ts`: 13 tests passed
- [x] `npx tsc --noEmit`: pass
- [x] 全27箇所の DomainError throw サイトを監査済み — 全て静的文字列、動的データなし
- [x] コメント追加のみ、ロジック変更なし

## Related
- Follow-up: #290 (DomainError メッセージの自動検証テスト)

🤖 Generated with [Claude Code](https://claude.com/claude-code)