### PR TITLE
fix: sanitize TRPCError pass-through for INTERNAL_SERVER_ERROR code

### DIFF
--- a/server/presentation/trpc/errors.ts
+++ b/server/presentation/trpc/errors.ts
@@ -6,6 +6,13 @@ const toMessage = (error: unknown): string =>
 
 export const toTrpcError = (error: unknown): TRPCError => {
   if (error instanceof TRPCError) {
+    if (error.code === "INTERNAL_SERVER_ERROR") {
+      console.error("TRPCError with INTERNAL_SERVER_ERROR:", error);
+      return new TRPCError({
+        code: "INTERNAL_SERVER_ERROR",
+        message: "Internal server error",
+      });
+    }
     return error;
   }
 


### PR DESCRIPTION
Closes #287

## Summary

- `INTERNAL_SERVER_ERROR` コードを持つ `TRPCError` のメッセージをサニタイズし、機密情報（DB接続文字列、ファイルパス等）のクライアントへの漏洩を防止
- 元のエラーは `console.error` でサーバーサイドにログ出力（Vercel function logs）
- 非 `INTERNAL_SERVER_ERROR` の `TRPCError` は従来通りパススルー

## Verification

- `npm run test:run -- server/presentation/trpc/errors.test.ts` — 14 tests pass（既存13 + 新規1）
- 新規テスト: サニタイズ動作、元メッセージの非漏洩、`console.error` 呼び出しを検証

## Review points

- `cause` は既存の fallback パスと同様に意図的に省略
- tRPC デフォルトの `getErrorShape` によるスタックトレース露出は Vercel の `NODE_ENV=production` で緩和済み

🤖 Generated with [Claude Code](https://claude.com/claude-code)