### PR TITLE
fix: exclude e2e directory from Vitest test discovery

### DIFF
--- a/vitest.config.mts
+++ b/vitest.config.mts
@@ -16,6 +16,7 @@ export default defineConfig({
       "dist",
       "coverage",
       "**/*.integration.test.*",
+      "e2e",
     ],
   },
 });


### PR DESCRIPTION
## Summary

- Vitest が `e2e/` 配下の Playwright テストファイルを読み込み、`test.describe()` エラーで失敗する問題を修正
- `vitest.config.mts` の `exclude` 配列に `"e2e"` を追加

Closes #305

## Changes

`vitest.config.mts` に1行追加のみ:
```diff
+      "e2e",
```

## Verification

- `npm run test:run` → 55 files, 573 tests passed（回帰なし）
- `e2e/` 配下のファイルがテスト対象から除外されていることを確認
- 詳細: `.claude/artifacts/issue-305/verify.md`

## Follow-up

- #306: `exclude` に `configDefaults.exclude` をスプレッドするリファクタリング（既存問題、スコープ外）

🤖 Generated with [Claude Code](https://claude.com/claude-code)