### PR TITLE
refactor: use configDefaults.exclude in Vitest config

### DIFF
--- a/vitest.config.mts
+++ b/vitest.config.mts
@@ -1,5 +1,5 @@
 import tsconfigPaths from "vite-tsconfig-paths";
-import { defineConfig } from "vitest/config";
+import { configDefaults, defineConfig } from "vitest/config";
 
 export default defineConfig({
   plugins: [tsconfigPaths()],
@@ -11,7 +11,7 @@ export default defineConfig({
       "**/*.{test,spec}.tsx",
     ],
     exclude: [
-      "node_modules",
+      ...configDefaults.exclude,
       ".next",
       "dist",
       "coverage",


### PR DESCRIPTION
## Summary

Closes #306

- `configDefaults.exclude` をスプレッドし、Vitest のデフォルト除外パターン（`**/node_modules/**`, `**/.git/**`）を自動継承
- 手動で列挙していた `node_modules` を削除し、DRY に
- プロジェクト固有パターン（`.next`, `dist`, `coverage`, `**/*.integration.test.*`, `e2e`）はそのまま維持

## Test plan

- [x] `npm run test:run` — 55 test files, 573 tests passed（変更前後で差異なし）
- [x] `npx tsc --noEmit` — 型エラーなし
- [x] `vitest.config.mts` の差分が issue #306 の提案通りであることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)