### PR TITLE
fix(a11y): add aria-labelledby to account page sections

### DIFF
--- a/app/(authenticated)/account/page.tsx
+++ b/app/(authenticated)/account/page.tsx
@@ -178,8 +178,8 @@ export default function AccountPage() {
     <div className="mx-auto flex w-full max-w-2xl flex-col gap-8">
       <h1 className="text-2xl font-bold text-(--brand-ink)">アカウント設定</h1>
 
-      <section className="rounded-2xl border border-border/60 bg-white/85 p-6 shadow-sm">
-        <h2 className="mb-4 text-lg font-semibold text-(--brand-ink)">
+      <section aria-labelledby="section-profile" className="rounded-2xl border border-border/60 bg-white/85 p-6 shadow-sm">
+        <h2 id="section-profile" className="mb-4 text-lg font-semibold text-(--brand-ink)">
           プロフィール
         </h2>
         {meQuery.isLoading ? (
@@ -193,8 +193,8 @@ export default function AccountPage() {
       </section>
 
       {meQuery.data?.hasPassword && (
-        <section className="rounded-2xl border border-border/60 bg-white/85 p-6 shadow-sm">
-          <h2 className="mb-4 text-lg font-semibold text-(--brand-ink)">
+        <section aria-labelledby="section-password" className="rounded-2xl border border-border/60 bg-white/85 p-6 shadow-sm">
+          <h2 id="section-password" className="mb-4 text-lg font-semibold text-(--brand-ink)">
             パスワードの変更
           </h2>
           <PasswordForm />


### PR DESCRIPTION
Closes #300

## Summary

- アカウント設定ページの `<section>` 要素に `aria-labelledby` を追加し、対応する `<h2>` に `id` を設定
- スクリーンリーダーのランドマークナビゲーションでセクション名が表示されるようになる

## Changes

- `<section>` に `aria-labelledby="section-profile"` / `aria-labelledby="section-password"` を追加
- `<h2>` に `id="section-profile"` / `id="section-password"` を追加

## Verification

- [x] `npx tsc --noEmit` — Pass
- [x] `npm run lint` — Pass
- [x] アクセシビリティレビュー — 全項目 Pass

### 手動確認手順

1. VoiceOver（Cmd+F5）→ VO+U → ランドマーク一覧に「プロフィール, region」「パスワードの変更, region」が表示される
2. DevTools で `document.querySelectorAll('#section-profile').length === 1` を確認
3. 見た目に変化がないことを目視確認

## Follow-up Issues

- #309 — ローディング状態に `aria-busy` を追加
- #310 — フォームエラーサマリーとフォーカス管理を追加
- #311 — 送信ボタンに `aria-busy` を追加

🤖 Generated with [Claude Code](https://claude.com/claude-code)