### PR TITLE
fix: delete session memberships when leaving a circle

### DIFF
--- a/server/infrastructure/repository/circle/prisma-circle-participation-repository.ts
+++ b/server/infrastructure/repository/circle/prisma-circle-participation-repository.ts
@@ -73,11 +73,19 @@ export const createPrismaCircleParticipationRepository = (
 
   async removeParticipation(circleId: CircleId, userId: UserId): Promise<void> {
     const persistedCircleId = toPersistenceId(circleId);
+    const persistedUserId = toPersistenceId(userId);
+
+    await client.circleSessionMembership.deleteMany({
+      where: {
+        userId: persistedUserId,
+        session: { circleId: persistedCircleId },
+      },
+    });
 
     await client.circleMembership.deleteMany({
       where: {
         circleId: persistedCircleId,
-        userId: toPersistenceId(userId),
+        userId: persistedUserId,
       },
     });
   },


### PR DESCRIPTION
## Summary

- 研究会脱退時に `CircleSessionMembership` を先行削除してから `CircleMembership` を削除するよう `removeParticipation` を修正
- 削除順序の検証テストとエラー伝播テストを追加

Closes #272

## Verification Steps

```bash
npm run test:run -- server/infrastructure/repository/circle/prisma-circle-participation-repository.test.ts
# 6 tests passed

npx tsc --noEmit
# no errors
```

## Remaining Limitations

- **トランザクション非使用**: 2つの `deleteMany` は原子的に実行されない。操作順序により最悪ケースは「セッションメンバーシップが消えたが研究会メンバーシップが残る」状態であり、再実行で回復可能。リファクタリングは #313 で対応予定。
- **クロスドメインリポジトリアクセス**: `CircleParticipationRepository` が `circleSessionMembership` を操作する越境は Plan で認識済みのトレードオフ。#313 でサービス層 + UnitOfWork パターンへの移行を予定。

## Review Points

- 削除順序（セッション → 研究会）の妥当性
- クロスドメインアクセスの許容範囲

🤖 Generated with [Claude Code](https://claude.com/claude-code)