### PR TITLE
feat: add rate limiting to credentials authentication (#322)

### DIFF
--- a/app/api/auth/[...nextauth]/route.ts
+++ b/app/api/auth/[...nextauth]/route.ts
@@ -1,8 +1,13 @@
 import { createNextAuthHandler } from "@/server/infrastructure/auth/nextauth-handler";
+import { createInMemoryRateLimiter } from "@/server/infrastructure/rate-limit/in-memory-rate-limiter";
 import { prismaUserRepository } from "@/server/infrastructure/repository/user/prisma-user-repository";
 
 const handler = createNextAuthHandler({
   userRepository: prismaUserRepository,
+  loginRateLimiter: createInMemoryRateLimiter({
+    maxAttempts: 5,
+    windowMs: 60_000,
+  }),
 });
 
 export { handler as GET, handler as POST };

--- a/server/infrastructure/auth/nextauth-handler.test.ts
+++ b/server/infrastructure/auth/nextauth-handler.test.ts
@@ -1,5 +1,7 @@
 import { afterEach, describe, expect, test, vi } from "vitest";
 import type { JWT } from "next-auth/jwt";
+import type { RateLimiter } from "@/server/application/common/rate-limiter";
+import { TooManyRequestsError } from "@/server/domain/common/errors";
 import type { UserRepository } from "@/server/domain/models/user/user-repository";
 
 const prismaValue = vi.hoisted(() => ({
@@ -9,6 +11,7 @@ const nextAuthMock = vi.hoisted(() => vi.fn());
 const prismaAdapterMock = vi.hoisted(() => vi.fn());
 const credentialsMock = vi.hoisted(() => vi.fn());
 const googleMock = vi.hoisted(() => vi.fn());
+const verifyPasswordMock = vi.hoisted(() => vi.fn());
 
 vi.mock("@/server/infrastructure/db", () => prismaValue);
 vi.mock("next-auth", () => ({ default: nextAuthMock }));
@@ -17,6 +20,9 @@ vi.mock("next-auth/providers/credentials", () => ({
   default: credentialsMock,
 }));
 vi.mock("next-auth/providers/google", () => ({ default: googleMock }));
+vi.mock("@/server/infrastructure/auth/password", () => ({
+  verifyPassword: verifyPasswordMock,
+}));
 
 import { prisma } from "@/server/infrastructure/db";
 import NextAuth from "next-auth";
@@ -40,6 +46,15 @@ const createMockUserRepository = (
   findPasswordHashById: vi.fn(),
   findPasswordChangedAt: vi.fn(),
   updatePasswordHash: vi.fn(),
+  ...overrides,
+});
+
+const createMockRateLimiter = (
+  overrides: Partial<RateLimiter> = {},
+): RateLimiter => ({
+  check: vi.fn(),
+  recordFailure: vi.fn(),
+  reset: vi.fn(),
   ...overrides,
 });
 
@@ -72,7 +87,10 @@ describe("NextAuth ハンドラ", () => {
     vi.mocked(NextAuth).mockReturnValue("handler");
 
     const mockRepo = createMockUserRepository();
-    const handler = createNextAuthHandler({ userRepository: mockRepo });
+    const handler = createNextAuthHandler({
+      userRepository: mockRepo,
+      loginRateLimiter: createMockRateLimiter(),
+    });
 
     expect(handler).toBe("handler");
     expect(PrismaAdapter).toHaveBeenCalledWith(prisma);
@@ -105,7 +123,10 @@ describe("NextAuth ハンドラ", () => {
 
 describe("JWT コールバック", () => {
   const mockRepo = createMockUserRepository();
-  const options = createAuthOptions({ userRepository: mockRepo });
+  const options = createAuthOptions({
+    userRepository: mockRepo,
+    loginRateLimiter: createMockRateLimiter(),
+  });
   const jwtCallback = options.callbacks!.jwt! as (params: {
     token: JWT;
     user?: { id: string };
@@ -200,7 +221,10 @@ describe("JWT コールバック", () => {
 
 describe("session コールバック", () => {
   const mockRepo = createMockUserRepository();
-  const options = createAuthOptions({ userRepository: mockRepo });
+  const options = createAuthOptions({
+    userRepository: mockRepo,
+    loginRateLimiter: createMockRateLimiter(),
+  });
   const sessionCallback = options.callbacks!.session! as unknown as (params: {
     session: { user?: { id?: string } };
     token: JWT;
@@ -222,5 +246,148 @@ describe("session コールバック", () => {
     const result = sessionCallback({ session, token });
 
     expect(result.user?.id).toBeUndefined();
+  });
+});
+
+describe("authorize コールバック（レート制限）", () => {
+  const extractAuthorize = (
+    mockRepo: UserRepository,
+    mockRateLimiter: RateLimiter,
+  ) => {
+    credentialsMock.mockClear();
+    createAuthOptions({
+      userRepository: mockRepo,
+      loginRateLimiter: mockRateLimiter,
+    });
+    return credentialsMock.mock.calls[0][0].authorize as (
+      credentials: { email: string; password: string } | undefined,
+    ) => Promise<{ id: string; email: string } | null>;
+  };
+
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
+  test("レート制限超過時は null を返しDBクエリしない", async () => {
+    const mockRepo = createMockUserRepository();
+    const mockRateLimiter = createMockRateLimiter({
+      check: vi.fn().mockImplementation(() => {
+        throw new TooManyRequestsError();
+      }),
+    });
+    const authorize = extractAuthorize(mockRepo, mockRateLimiter);
+
+    const result = await authorize({
+      email: "test@example.com",
+      password: "password",
+    });
+
+    expect(result).toBeNull();
+    expect(mockRateLimiter.check).toHaveBeenCalledWith("test@example.com");
+    expect(mockRepo.findByEmail).not.toHaveBeenCalled();
+  });
+
+  test("ユーザーが見つからない場合は recordFailure を呼ぶ", async () => {
+    const mockRepo = createMockUserRepository({
+      findByEmail: vi.fn().mockResolvedValue(null),
+    });
+    const mockRateLimiter = createMockRateLimiter();
+    const authorize = extractAuthorize(mockRepo, mockRateLimiter);
+
+    const result = await authorize({
+      email: "test@example.com",
+      password: "password",
+    });
+
+    expect(result).toBeNull();
+    expect(mockRateLimiter.recordFailure).toHaveBeenCalledWith(
+      "test@example.com",
+    );
+  });
+
+  test("パスワード不一致時は recordFailure を呼ぶ", async () => {
+    const mockRepo = createMockUserRepository({
+      findByEmail: vi
+        .fn()
+        .mockResolvedValue({ id: "user-1", email: "test@example.com" }),
+      findPasswordHashById: vi.fn().mockResolvedValue("hashed-password"),
+    });
+    verifyPasswordMock.mockReturnValue(false);
+    const mockRateLimiter = createMockRateLimiter();
+    const authorize = extractAuthorize(mockRepo, mockRateLimiter);
+
+    const result = await authorize({
+      email: "test@example.com",
+      password: "wrong-password",
+    });
+
+    expect(result).toBeNull();
+    expect(mockRateLimiter.recordFailure).toHaveBeenCalledWith(
+      "test@example.com",
+    );
+  });
+
+  test("認証成功時は reset を呼びユーザーを返す", async () => {
+    const mockRepo = createMockUserRepository({
+      findByEmail: vi.fn().mockResolvedValue({
+        id: "user-1",
+        email: "test@example.com",
+        name: "Test User",
+        image: null,
+      }),
+      findPasswordHashById: vi.fn().mockResolvedValue("hashed-password"),
+    });
+    verifyPasswordMock.mockReturnValue(true);
+    const mockRateLimiter = createMockRateLimiter();
+    const authorize = extractAuthorize(mockRepo, mockRateLimiter);
+
+    const result = await authorize({
+      email: "test@example.com",
+      password: "correct-password",
+    });
+
+    expect(result).toEqual({
+      id: "user-1",
+      email: "test@example.com",
+      name: "Test User",
+      image: undefined,
+    });
+    expect(mockRateLimiter.reset).toHaveBeenCalledWith("test@example.com");
+    expect(mockRateLimiter.recordFailure).not.toHaveBeenCalled();
+  });
+
+  test("check() が TooManyRequestsError 以外をスローした場合はそのまま再スローする", async () => {
+    const mockRepo = createMockUserRepository();
+    const mockRateLimiter = createMockRateLimiter({
+      check: vi.fn().mockImplementation(() => {
+        throw new Error("unexpected failure");
+      }),
+    });
+    const authorize = extractAuthorize(mockRepo, mockRateLimiter);
+
+    await expect(
+      authorize({ email: "test@example.com", password: "password" }),
+    ).rejects.toThrow("unexpected failure");
+  });
+
+  test("パスワードハッシュが無い場合は recordFailure を呼ぶ", async () => {
+    const mockRepo = createMockUserRepository({
+      findByEmail: vi
+        .fn()
+        .mockResolvedValue({ id: "user-1", email: "test@example.com" }),
+      findPasswordHashById: vi.fn().mockResolvedValue(null),
+    });
+    const mockRateLimiter = createMockRateLimiter();
+    const authorize = extractAuthorize(mockRepo, mockRateLimiter);
+
+    const result = await authorize({
+      email: "test@example.com",
+      password: "password",
+    });
+
+    expect(result).toBeNull();
+    expect(mockRateLimiter.recordFailure).toHaveBeenCalledWith(
+      "test@example.com",
+    );
   });
 });


### PR DESCRIPTION
## Summary

- `authorize` コールバックにメールアドレスベースのレート制限を追加（5回/60秒）
- メールの `toLowerCase()` 正規化で大文字小文字バイパスを防止
- `AuthDeps` に `RateLimiter` を注入する設計で既存パターンと統一

Closes #322

## 変更ファイル

| ファイル | 内容 |
|---------|------|
| `nextauth-handler.ts` | authorize 内にレート制限チェック・recordFailure・reset を追加 |
| `route.ts` | `InMemoryRateLimiter` インスタンスを DI |
| `nextauth-session-service.ts` | `createAuthOptions` の新シグネチャに対応 |
| `nextauth-handler.test.ts` | レート制限関連テスト 6 件追加（計 17 件） |

## Test plan

- [x] `npm run test:run -- server/infrastructure/auth/nextauth-handler.test.ts` → 17件全パス
- [x] `npx tsc --noEmit` → 型エラーなし
- [ ] `npm run dev` → 5回連続失敗後、6回目が拒否されることを手動確認
- [ ] 60秒後に正しいパスワードでログイン成功を確認

## Known limitations（フォローアップ Issue 作成済み）

- #326 InMemoryRateLimiter のサーバーレス環境対応
- #327 タイミングサイドチャネル緩和
- #328 メモリ上限・定期クリーンアップ
- #329 設定値の一元化・session-service の不要インスタンス整理

🤖 Generated with [Claude Code](https://claude.com/claude-code)