### PR TITLE
refactor: ログインレート制限設定の一元化と noop rate limiter 導入

### DIFF
--- a/app/api/auth/[...nextauth]/route.ts
+++ b/app/api/auth/[...nextauth]/route.ts
@@ -1,13 +1,11 @@
+import { LOGIN_RATE_LIMIT_CONFIG } from "@/server/infrastructure/auth/auth-config";
 import { createNextAuthHandler } from "@/server/infrastructure/auth/nextauth-handler";
 import { createInMemoryRateLimiter } from "@/server/infrastructure/rate-limit/in-memory-rate-limiter";
 import { prismaUserRepository } from "@/server/infrastructure/repository/user/prisma-user-repository";
 
 const handler = createNextAuthHandler({
   userRepository: prismaUserRepository,
-  loginRateLimiter: createInMemoryRateLimiter({
-    maxAttempts: 5,
-    windowMs: 60_000,
-  }),
+  loginRateLimiter: createInMemoryRateLimiter(LOGIN_RATE_LIMIT_CONFIG),
 });
 
 export { handler as GET, handler as POST };

--- a/server/infrastructure/auth/auth-config.ts
+++ b/server/infrastructure/auth/auth-config.ts
@@ -1,0 +1,7 @@
+import type { InMemoryRateLimiterConfig } from "@/server/infrastructure/rate-limit/in-memory-rate-limiter";
+
+export const LOGIN_RATE_LIMIT_CONFIG: Readonly<InMemoryRateLimiterConfig> =
+  Object.freeze({
+    maxAttempts: 5,
+    windowMs: 60_000,
+  });

--- a/server/infrastructure/auth/nextauth-session-service.ts
+++ b/server/infrastructure/auth/nextauth-session-service.ts
@@ -1,15 +1,12 @@
 import { getServerSession } from "next-auth";
 import type { SessionService } from "@/server/domain/services/auth/session-service";
 import { createAuthOptions } from "./nextauth-handler";
-import { createInMemoryRateLimiter } from "@/server/infrastructure/rate-limit/in-memory-rate-limiter";
+import { noopRateLimiter } from "@/server/infrastructure/rate-limit/noop-rate-limiter";
 import { prismaUserRepository } from "@/server/infrastructure/repository/user/prisma-user-repository";
 
 const authOptions = createAuthOptions({
   userRepository: prismaUserRepository,
-  loginRateLimiter: createInMemoryRateLimiter({
-    maxAttempts: 5,
-    windowMs: 60_000,
-  }),
+  loginRateLimiter: noopRateLimiter,
 });
 
 export const nextAuthSessionService: SessionService = {

--- a/server/infrastructure/rate-limit/noop-rate-limiter.ts
+++ b/server/infrastructure/rate-limit/noop-rate-limiter.ts
@@ -1,0 +1,11 @@
+import type { RateLimiter } from "@/server/application/common/rate-limiter";
+
+/**
+ * 何もしない RateLimiter 実装。authorize コールバックが呼ばれないコンテキスト
+ * （例: getServerSession によるセッション検証）でのみ使用すること。
+ */
+export const noopRateLimiter: RateLimiter = {
+  check() {},
+  recordFailure() {},
+  reset() {},
+};


### PR DESCRIPTION
## Summary

Closes #329

- `LOGIN_RATE_LIMIT_CONFIG` 共有定数を `auth-config.ts` に抽出し、DRY 違反を解消
- `nextauth-session-service.ts` の不要な `InMemoryRateLimiter` を `noopRateLimiter` に置換
- `route.ts` のインライン設定値を共有定数に統一

## Changes

| File | Action | Description |
|------|--------|-------------|
| `server/infrastructure/auth/auth-config.ts` | New | `LOGIN_RATE_LIMIT_CONFIG` 共有定数（`Readonly` + `Object.freeze`） |
| `server/infrastructure/rate-limit/noop-rate-limiter.ts` | New | `RateLimiter` の No-op 実装（JSDoc で使用コンテキストを明記） |
| `app/api/auth/[...nextauth]/route.ts` | Modified | 共有定数を使用 |
| `server/infrastructure/auth/nextauth-session-service.ts` | Modified | `noopRateLimiter` を使用 |

## Test plan

- [x] `npm run test:run` — 55 files, 597 tests passed
- [x] `npx tsc --noEmit` — No errors
- [x] `npm run lint` — No errors
- [ ] `LOGIN_RATE_LIMIT_CONFIG` の設定値が `{ maxAttempts: 5, windowMs: 60_000 }` であることを確認
- [ ] `noopRateLimiter` が `nextauth-session-service.ts` でのみ使用されていることを確認
- [ ] `getServerSession` が `authorize` を呼ばないことの理解を確認

## Follow-up

- #331: `AuthDeps.loginRateLimiter` をオプショナルにして noop デフォルト化

🤖 Generated with [Claude Code](https://claude.com/claude-code)