### PR TITLE
fix: JWT コールバックのフェイルオープンをフェイルクローズドに変更

### DIFF
--- a/server/infrastructure/auth/nextauth-handler.test.ts
+++ b/server/infrastructure/auth/nextauth-handler.test.ts
@@ -207,7 +207,7 @@ describe("JWT コールバック", () => {
     expect(mockRepo.findPasswordChangedAt).not.toHaveBeenCalled();
   });
 
-  test("DB障害時はトークンをそのまま返す（フェイルオープン）", async () => {
+  test("DB障害時は空トークンを返す（フェイルクローズド）", async () => {
     vi.mocked(mockRepo.findPasswordChangedAt).mockRejectedValue(
       new Error("Connection refused"),
     );
@@ -215,7 +215,7 @@ describe("JWT コールバック", () => {
     const token = { id: "user-1", iat: 1700000000 } as JWT;
     const result = await jwtCallback({ token });
 
-    expect(result.id).toBe("user-1");
+    expect(result.id).toBeUndefined();
   });
 });
 

--- a/server/infrastructure/auth/nextauth-handler.ts
+++ b/server/infrastructure/auth/nextauth-handler.ts
@@ -117,8 +117,10 @@ export const createAuthOptions = (deps: AuthDeps): AuthOptions => ({
               return {} as typeof token;
             }
           }
-        } catch {
-          // Fail open: DB障害時は既存セッションを維持する
+        } catch (error) {
+          // Fail closed: DB障害時はセッションを無効化する
+          console.error("[auth] passwordChangedAt check failed", error);
+          return {} as typeof token;
         }
       }
 


### PR DESCRIPTION
## Summary

Closes #321

- JWTコールバックの `findPasswordChangedAt` 例外時の動作をフェイルオープン（既存トークン維持）からフェイルクローズド（空トークン返却）に変更
- DB障害時のデバッグ用にエラーログを追加
- テストの期待値を更新（`result.id` が `undefined` であることを検証）

## Security

空トークン返却後の下流伝播を確認済み:
1. `session` コールバック: `token.id` が undefined → `session.user.id` 未設定
2. `nextauth-session-service.ts`: `!user.id` → null 返却
3. `session.ts`: `!userId` → `UnauthorizedError`

バイパス経路なし。

## Test plan

- [x] `npm run test:run` — 55 test files, 597 tests passed
- [x] `npx tsc --noEmit` — 型チェック通過
- [x] `nextauth-handler.test.ts` — 17 tests passed
  - 「DB障害時は空トークンを返す（フェイルクローズド）」テスト通過
- [ ] 手動確認: DB障害シミュレーション時にセッションが無効化されること

## Follow-up issues

- #333 Add end-to-end test for DB failure session invalidation chain
- #334 Replace `{} as typeof token` type assertion with type-safe invalidation pattern

🤖 Generated with [Claude Code](https://claude.com/claude-code)