### PR TITLE
refactor: remove @default(now()) from MatchHistory.createdAt

### DIFF
--- a/prisma/migrations/20260217132007_remove_match_history_created_at_default/migration.sql
+++ b/prisma/migrations/20260217132007_remove_match_history_created_at_default/migration.sql
@@ -1,0 +1,2 @@
+-- AlterTable
+ALTER TABLE "MatchHistory" ALTER COLUMN "createdAt" DROP DEFAULT;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -169,7 +169,7 @@ model MatchHistory {
   matchId   String
   editorId  String
   action    MatchHistoryAction
-  createdAt DateTime           @default(now())
+  createdAt DateTime
 
   // スナップショット（編集時点）
   player1Id String


### PR DESCRIPTION
## Summary

Closes #341

- Remove `@default(now())` from `MatchHistory.createdAt` in Prisma schema
- Add migration to drop the database-level default
- Domain factory `createMatchHistory()` already provides `createdAt` explicitly, so no application code changes needed

Consistent with the pattern established in #337 / #340 for `Match.createdAt`.

## Verification

- All 603 tests pass (`npm run test:run`)
- Type check passes (`npx tsc --noEmit`) — `createdAt` is now required in `MatchHistoryCreateInput`, ensuring compile-time safety
- Single insert path (`prismaMatchHistoryRepository.add` → `mapMatchHistoryToPersistence`) confirmed to supply `createdAt` explicitly
- No raw SQL usage in the codebase; zero risk of unhandled insert paths

## Test plan

- [ ] `npm run test:run` passes
- [ ] `npx tsc --noEmit` passes
- [ ] `npm run db:reset` completes successfully (migration + seed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)