### PR TITLE
refactor: remove redundant client-side sort in session detail provider

### DIFF
--- a/server/domain/models/match/match-repository.ts
+++ b/server/domain/models/match/match-repository.ts
@@ -3,6 +3,7 @@ import type { CircleSessionId, MatchId } from "@/server/domain/common/ids";
 
 export type MatchRepository = {
   findById(id: MatchId): Promise<Match | null>;
+  /** Returns matches ordered by createdAt ascending. */
   listByCircleSessionId(circleSessionId: CircleSessionId): Promise<Match[]>;
   save(match: Match): Promise<void>;
 };

--- a/server/presentation/providers/trpc-circle-session-detail-provider.ts
+++ b/server/presentation/providers/trpc-circle-session-detail-provider.ts
@@ -125,7 +125,6 @@ export const trpcCircleSessionDetailProvider: CircleSessionDetailProvider = {
 
     const matchViewModels: CircleSessionMatch[] = matches
       .filter((match) => match.deletedAt == null)
-      .sort((a, b) => a.createdAt.getTime() - b.createdAt.getTime())
       .map((match) => ({
         id: match.id,
         player1Id: match.player1Id,


### PR DESCRIPTION
## Summary

Closes #338

- `trpc-circle-session-detail-provider.ts` から冗長な `.sort()` を削除
- `MatchRepository` インターフェースに `createdAt asc` のソート順契約を JSDoc で明示化

リポジトリ層（`prisma-match-repository.ts`）が既に `orderBy: { createdAt: "asc" }` で並べ替え済みであり、`Array.filter` は配列順序を保持するため、プロバイダー層での追加ソートは不要だった。

## Verification Steps

1. `server/presentation/providers/trpc-circle-session-detail-provider.ts` の差分が `.sort()` 行の削除のみであることを確認
2. `server/infrastructure/repository/match/prisma-match-repository.ts:27` に `orderBy: { createdAt: "asc" }` が存在することを確認
3. `npx tsc --noEmit` — passed
4. `npm run test:run` — 56 files, 603 tests passed
5. 既存テスト `prisma-match-repository.test.ts:73-76` が `orderBy` パラメータを検証済み

## Review Points

- `MatchRepository` の JSDoc が実装と一致しているか
- ソート順の契約がインターフェースレベルで十分に明示されているか

🤖 Generated with [Claude Code](https://claude.com/claude-code)