### PR TITLE
feat: add loading.tsx skeletons for progressive rendering (#344)

### DIFF
--- a/app/(authenticated)/circle-sessions/[circleSessionId]/loading.tsx
+++ b/app/(authenticated)/circle-sessions/[circleSessionId]/loading.tsx
@@ -1,0 +1,77 @@
+import { Skeleton } from "@/components/ui/skeleton";
+
+export default function CircleSessionDetailLoading() {
+  return (
+    <div
+      className="mx-auto flex w-full max-w-6xl flex-col gap-8"
+      role="status"
+      aria-label="読み込み中"
+    >
+      <span className="sr-only">セッションの詳細を読み込み中です</span>
+      {/* Header Card */}
+      <div className="rounded-3xl border border-border/60 bg-white/90 p-8 shadow-sm">
+        <div className="flex flex-wrap items-start justify-between gap-6">
+          {/* Left Side */}
+          <div className="min-w-60 flex-1">
+            {/* Title + Role Badge */}
+            <div className="mt-3 flex flex-wrap items-baseline gap-3">
+              <Skeleton className="h-9 w-2/5" />
+              <Skeleton className="h-5 w-16 rounded-full" />
+            </div>
+            {/* DateTime + Location */}
+            <Skeleton className="mt-3 h-4 w-3/5" />
+            {/* Memo */}
+            <Skeleton className="mt-3 h-3 w-2/5" />
+          </div>
+
+          {/* Right Side: Action Buttons */}
+          <div className="flex w-full flex-col gap-4 sm:w-auto sm:min-w-60 sm:max-w-[320px]">
+            <div className="flex flex-wrap gap-3">
+              <Skeleton className="h-9 w-28 rounded-md" />
+              <Skeleton className="h-9 w-20 rounded-md" />
+            </div>
+          </div>
+        </div>
+      </div>
+
+      {/* Match Results Table Card */}
+      <div className="grid gap-6 lg:grid-cols-1">
+        <div className="rounded-2xl border border-border/60 bg-white/90 p-6 shadow-sm">
+          {/* Header */}
+          <div className="flex flex-wrap items-start justify-between gap-4">
+            <div>
+              <Skeleton className="h-4 w-20" />
+              <Skeleton className="mt-2 h-3 w-44" />
+            </div>
+            <Skeleton className="h-3 w-16" />
+          </div>
+
+          {/* Table Skeleton */}
+          <div className="relative mt-4 rounded-2xl border border-border/60 bg-white/70 p-4">
+            {/* Table Header Row */}
+            <div className="flex gap-2 border-b border-border/60 pb-3">
+              <Skeleton className="h-4 w-20 shrink-0" />
+              {Array.from({ length: 4 }).map((_, i) => (
+                <Skeleton key={i} className="h-4 w-14 shrink-0" />
+              ))}
+              <Skeleton className="h-4 w-16 shrink-0" />
+            </div>
+            {/* Table Body Rows */}
+            {Array.from({ length: 4 }).map((_, rowIdx) => (
+              <div
+                key={rowIdx}
+                className="flex gap-2 border-b border-border/60 py-3 last:border-b-0"
+              >
+                <Skeleton className="h-4 w-20 shrink-0" />
+                {Array.from({ length: 4 }).map((_, colIdx) => (
+                  <Skeleton key={colIdx} className="h-4 w-14 shrink-0" />
+                ))}
+                <Skeleton className="h-4 w-16 shrink-0" />
+              </div>
+            ))}
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/app/(authenticated)/circles/[circleId]/loading.tsx
+++ b/app/(authenticated)/circles/[circleId]/loading.tsx
@@ -1,0 +1,68 @@
+import { Skeleton } from "@/components/ui/skeleton";
+
+export default function CircleDetailLoading() {
+  return (
+    <div
+      className="mx-auto flex w-full max-w-6xl flex-col gap-8"
+      role="status"
+      aria-label="読み込み中"
+    >
+      <span className="sr-only">研究会の詳細を読み込み中です</span>
+      {/* Hero Card */}
+      <div className="rounded-3xl border border-border/60 bg-white/90 p-8 shadow-sm">
+        <div className="flex flex-wrap items-start justify-between gap-6">
+          <div className="min-w-60 flex-1">
+            {/* Title + Role Badge */}
+            <div className="mt-3 flex flex-wrap items-baseline gap-3">
+              <Skeleton className="h-9 w-2/5" />
+              <Skeleton className="h-5 w-16 rounded-full" />
+            </div>
+            {/* Schedule text */}
+            <Skeleton className="mt-3 h-4 w-3/5" />
+            {/* Next session card */}
+            <div className="mt-4">
+              <Skeleton className="mb-2 h-3 w-16" />
+              <Skeleton className="h-14 w-full rounded-2xl" />
+            </div>
+          </div>
+        </div>
+      </div>
+
+      {/* 2-Column Grid */}
+      <div className="grid gap-6 lg:grid-cols-[1.1fr_0.9fr]">
+        {/* Calendar Card */}
+        <div className="rounded-2xl border border-border/60 bg-white/90 p-6 shadow-sm">
+          <div className="mb-4 flex items-center justify-between">
+            <Skeleton className="h-4 w-24" />
+            <Skeleton className="h-8 w-20 rounded-md" />
+          </div>
+          <Skeleton className="h-64 w-full rounded-xl" />
+        </div>
+
+        {/* Members Card */}
+        <div className="flex flex-col gap-6">
+          <div className="rounded-2xl border border-border/60 bg-white/90 p-6 shadow-sm">
+            <div className="flex items-center justify-between">
+              <Skeleton className="h-4 w-24" />
+              <div className="flex items-center gap-2">
+                <Skeleton className="h-4 w-16" />
+                <Skeleton className="h-8 w-20 rounded-md" />
+              </div>
+            </div>
+            <div className="mt-4 space-y-3">
+              {Array.from({ length: 4 }).map((_, i) => (
+                <div
+                  key={i}
+                  className="flex items-center justify-between gap-4 rounded-xl border border-border/60 bg-white/70 p-4"
+                >
+                  <Skeleton className="h-4 w-24" />
+                  <Skeleton className="h-5 w-16 rounded-full" />
+                </div>
+              ))}
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/components/ui/skeleton.tsx
+++ b/components/ui/skeleton.tsx
@@ -4,7 +4,11 @@ function Skeleton({ className, ...props }: React.ComponentProps<"div">) {
   return (
     <div
       data-slot="skeleton"
-      className={cn("bg-accent animate-pulse rounded-md", className)}
+      aria-hidden="true"
+      className={cn(
+        "bg-accent animate-pulse motion-reduce:animate-none rounded-md",
+        className,
+      )}
       {...props}
     />
   );


### PR DESCRIPTION
## Summary

- サーバーサイドデータ取得中の白画面を解消するため、Skeleton ベースの `loading.tsx` を追加
- `circles/[circleId]` と `circle-sessions/[circleSessionId]` の2ルートが対象
- Skeleton コンポーネントのアクセシビリティを改善（`aria-hidden`, `motion-reduce:animate-none`）

Closes #344

## Changes

| File | Description |
|------|-------------|
| `app/(authenticated)/circles/[circleId]/loading.tsx` | 研究会詳細ページの Skeleton UI（Hero, Calendar, Members） |
| `app/(authenticated)/circle-sessions/[circleSessionId]/loading.tsx` | セッション詳細ページの Skeleton UI（Header, Match Table） |
| `components/ui/skeleton.tsx` | `aria-hidden="true"` + `motion-reduce:animate-none` 追加 |

## Accessibility

- `role="status"` + `aria-label="読み込み中"` でスクリーンリーダー対応
- sr-only テキストで読み込み対象を明示
- `prefers-reduced-motion: reduce` 時にアニメーション停止

## Test plan

- [ ] `npm run dev` → `/circles/demo` 遷移時に Skeleton UI が表示されること
- [ ] セッション詳細ページ遷移時に Skeleton UI が表示されること
- [ ] DevTools > Rendering > prefers-reduced-motion: reduce → アニメーション停止
- [ ] VoiceOver で「読み込み中」とアナウンスされること
- [ ] `npx tsc --noEmit` パス
- [ ] `npm run lint` パス

🤖 Generated with [Claude Code](https://claude.com/claude-code)