### PR TITLE
feat: add loading.tsx skeleton for account page

### DIFF
--- a/app/(authenticated)/account/loading.tsx
+++ b/app/(authenticated)/account/loading.tsx
@@ -1,0 +1,51 @@
+import { Skeleton } from "@/components/ui/skeleton";
+
+export default function AccountLoading() {
+  return (
+    <div
+      className="mx-auto flex w-full max-w-2xl flex-col gap-8"
+      role="status"
+      aria-label="読み込み中"
+    >
+      <span className="sr-only">アカウント設定を読み込み中です</span>
+
+      <Skeleton className="h-8 w-40" />
+
+      {/* Profile Section */}
+      <div className="rounded-2xl border border-border/60 bg-white/85 p-6 shadow-sm">
+        <Skeleton className="mb-4 h-6 w-24" />
+        <div className="flex flex-col gap-4">
+          <div className="flex flex-col gap-1.5">
+            <Skeleton className="h-3 w-16" />
+            <Skeleton className="h-9 w-full rounded-md" />
+          </div>
+          <div className="flex flex-col gap-1.5">
+            <Skeleton className="h-3 w-24" />
+            <Skeleton className="h-9 w-full rounded-md" />
+          </div>
+          <Skeleton className="h-9 w-16 self-start rounded-md" />
+        </div>
+      </div>
+
+      {/* Password Section */}
+      <div className="rounded-2xl border border-border/60 bg-white/85 p-6 shadow-sm">
+        <Skeleton className="mb-4 h-6 w-32" />
+        <div className="flex flex-col gap-4">
+          <div className="flex flex-col gap-1.5">
+            <Skeleton className="h-3 w-24" />
+            <Skeleton className="h-9 w-full rounded-md" />
+          </div>
+          <div className="flex flex-col gap-1.5">
+            <Skeleton className="h-3 w-36" />
+            <Skeleton className="h-9 w-full rounded-md" />
+          </div>
+          <div className="flex flex-col gap-1.5">
+            <Skeleton className="h-3 w-36" />
+            <Skeleton className="h-9 w-full rounded-md" />
+          </div>
+          <Skeleton className="h-9 w-32 self-start rounded-md" />
+        </div>
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary

- アカウントページ (`/account`) に `loading.tsx` スケルトンUIを追加
- プロフィールセクション（2フィールド + 保存ボタン）とパスワードセクション（3フィールド + 変更ボタン）のスケルトンを実装
- 既存の `loading.tsx` パターン（`role="status"`, `aria-label`, `sr-only`）に準拠

Closes #354

## Verification

1. `npm run dev` でローカル起動
2. `/account` にナビゲーションし、スケルトンが表示されることを確認
3. スケルトンのレイアウトが `account/page.tsx` のプロフィール・パスワードセクションと一致するか目視確認
4. `npx tsc --noEmit` — PASS
5. `npx eslint` — PASS

## Review Points

- パスワードセクションはローディング中に `hasPassword` 判定不可のため、スケルトンでは常に表示する方針
- カードスタイルは `bg-white/85`（page.tsx に準拠、他の loading.tsx の `bg-white/90` ではない）

🤖 Generated with [Claude Code](https://claude.com/claude-code)