### PR TITLE
fix: フォント読み込み時のちらつき(FOUT)を防止

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -1,15 +1,15 @@
 import "./globals.css";
 
+import { Toaster } from "@/components/ui/sonner";
 import { Metadata } from "next";
 import { Shippori_Mincho_B1, Zen_Maru_Gothic } from "next/font/google";
-import { Toaster } from "@/components/ui/sonner";
 import Providers from "./providers";
 
 const zenMaru = Zen_Maru_Gothic({
   subsets: ["latin"],
   weight: ["400", "500", "700"],
   variable: "--font-body",
-  display: "swap",
+  display: "block",
   fallback: ["Hiragino Kaku Gothic ProN", "Yu Gothic", "sans-serif"],
 });
 
@@ -17,7 +17,7 @@ const shippori = Shippori_Mincho_B1({
   subsets: ["latin"],
   weight: ["400", "700"],
   variable: "--font-display",
-  display: "swap",
+  display: "block",
   fallback: ["Hiragino Mincho ProN", "Yu Mincho", "serif"],
 });
 


### PR DESCRIPTION
## Summary

- `display: "swap"` を `display: "block"` に変更し、Webフォント読み込み完了までテキストを非表示にすることでFOUT（Flash of Unstyled Text）を解消

Closes #363

## Test plan

- [ ] ブラウザキャッシュをクリアしてホーム画面にアクセスし、フォントスワップによるちらつきが発生しないことを確認
- [ ] 低速回線（DevTools Network throttling）でもちらつきなく表示されることを確認
- [ ] フォント読み込み完了後、正しいWebフォント（Zen Maru Gothic / Shippori Mincho B1）が適用されていることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)