### PR TITLE
fix: invite-link-provider の catch-all を NotFoundError のみに限定

### DIFF
--- a/server/presentation/providers/invite-link-provider.test.ts
+++ b/server/presentation/providers/invite-link-provider.test.ts
@@ -1,0 +1,83 @@
+import { beforeEach, describe, expect, test, vi } from "vitest";
+import { NotFoundError } from "@/server/domain/common/errors";
+
+const mockGetInviteLinkInfo = vi.fn();
+const mockGetSession = vi.fn();
+
+vi.mock("@/server/application/circle/circle-invite-link-service", () => ({
+  createCircleInviteLinkService: () => ({
+    getInviteLinkInfo: mockGetInviteLinkInfo,
+  }),
+}));
+
+vi.mock("@/server/application/authz/access-service", () => ({
+  createAccessService: () => ({}),
+}));
+
+vi.mock("@/server/infrastructure/auth/nextauth-session-service", () => ({
+  nextAuthSessionService: { getSession: mockGetSession },
+}));
+
+vi.mock(
+  "@/server/infrastructure/repository/circle/prisma-circle-invite-link-repository",
+  () => ({ prismaCircleInviteLinkRepository: {} }),
+);
+vi.mock(
+  "@/server/infrastructure/repository/circle/prisma-circle-repository",
+  () => ({ prismaCircleRepository: {} }),
+);
+vi.mock(
+  "@/server/infrastructure/repository/circle/prisma-circle-participation-repository",
+  () => ({ prismaCircleParticipationRepository: {} }),
+);
+vi.mock(
+  "@/server/infrastructure/repository/authz/prisma-authz-repository",
+  () => ({ prismaAuthzRepository: {} }),
+);
+
+// dynamic import after mocks are registered
+const { getInviteLinkPageData } = await import("./invite-link-provider");
+
+describe("getInviteLinkPageData", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  test("有効なトークンで InviteLinkPageData を返す", async () => {
+    mockGetInviteLinkInfo.mockResolvedValueOnce({
+      token: "valid-token",
+      circleName: "テスト研究会",
+      circleId: "circle-1",
+      expired: false,
+    });
+    mockGetSession.mockResolvedValueOnce({ user: { id: "user-1" } });
+
+    const result = await getInviteLinkPageData("valid-token");
+
+    expect(result).toEqual({
+      circleName: "テスト研究会",
+      circleId: "circle-1",
+      expired: false,
+      isAuthenticated: true,
+    });
+  });
+
+  test("NotFoundError の場合 null を返す", async () => {
+    mockGetInviteLinkInfo.mockRejectedValueOnce(
+      new NotFoundError("InviteLink"),
+    );
+
+    const result = await getInviteLinkPageData("unknown-token");
+
+    expect(result).toBeNull();
+  });
+
+  test("予期しないエラーは re-throw される", async () => {
+    const unexpected = new Error("DB connection failed");
+    mockGetInviteLinkInfo.mockRejectedValueOnce(unexpected);
+
+    await expect(getInviteLinkPageData("any-token")).rejects.toThrow(
+      unexpected,
+    );
+  });
+});

--- a/server/presentation/providers/invite-link-provider.ts
+++ b/server/presentation/providers/invite-link-provider.ts
@@ -1,5 +1,6 @@
 import { createCircleInviteLinkService } from "@/server/application/circle/circle-invite-link-service";
 import { createAccessService } from "@/server/application/authz/access-service";
+import { NotFoundError } from "@/server/domain/common/errors";
 import { nextAuthSessionService } from "@/server/infrastructure/auth/nextauth-session-service";
 import { prismaCircleInviteLinkRepository } from "@/server/infrastructure/repository/circle/prisma-circle-invite-link-repository";
 import { prismaCircleRepository } from "@/server/infrastructure/repository/circle/prisma-circle-repository";
@@ -26,8 +27,9 @@ export async function getInviteLinkPageData(
   let info;
   try {
     info = await circleInviteLinkService.getInviteLinkInfo({ token });
-  } catch {
-    return null;
+  } catch (e) {
+    if (e instanceof NotFoundError) return null;
+    throw e;
   }
 
   const session = await nextAuthSessionService.getSession();


### PR DESCRIPTION
## Summary
- 空の `catch` ブロックが全エラーを `null` に変換し、DB障害等の内部エラーも 404 として扱われていた問題を修正
- `NotFoundError` のみ `catch` して `null` を返し、予期しないエラーは re-throw するよう変更
- エラーハンドリングの挙動を検証するユニットテストを追加（3件）

Closes #369

## Test plan
- [x] `NotFoundError` の場合は `null` を返す
- [x] 予期しないエラー（DB障害等）は re-throw される
- [x] 有効なトークンでは正常に `InviteLinkPageData` を返す
- [x] `npm run dev` で招待リンクページの正常表示を確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)