### PR TITLE
ci: lint・型チェック・ユニットテストを CI に追加

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,6 +13,8 @@ jobs:
   lint:
     runs-on: ubuntu-latest
     timeout-minutes: 10
+    env:
+      DATABASE_URL: postgresql://dummy:dummy@localhost:5432/dummy
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
       - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
@@ -25,6 +27,8 @@ jobs:
   typecheck:
     runs-on: ubuntu-latest
     timeout-minutes: 10
+    env:
+      DATABASE_URL: postgresql://dummy:dummy@localhost:5432/dummy
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
       - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0


### PR DESCRIPTION
## Summary

Closes #259

- CI ワークフローに **lint**（ESLint）、**typecheck**（tsc --noEmit）、**unit-test**（Vitest）の3ジョブを追加
- 既存の integration-test と合わせて4ジョブが並列実行される
- 既存の integration-test ジョブは変更なし

## Test plan

- [ ] GitHub Actions の UI で 4 ジョブ（lint, typecheck, unit-test, integration-test）が並列起動されることを確認
- [ ] 各ジョブが正常に完了（緑チェック）することを確認
- [ ] Checks タブで各ジョブが個別に表示されていることを確認

## Security notes

- 全アクションは SHA ピン留め済み（`@SHA # vX.Y.Z` 形式）
- `permissions: contents: read` でワークフローレベルの最小権限を維持
- `DATABASE_URL` はダミー値のみ使用

🤖 Generated with [Claude Code](https://claude.com/claude-code)