### PR TITLE
fix: 編集ダイアログの削除ボタンに AlertDialog 確認を適用

### DIFF
--- a/app/(authenticated)/circle-sessions/components/circle-session-detail-view.tsx
+++ b/app/(authenticated)/circle-sessions/components/circle-session-detail-view.tsx
@@ -578,6 +578,14 @@ export function CircleSessionDetailView({
         outcomeOptions={outcomeOptions}
         createMatchIsPending={createMatch.isPending}
         updateMatchIsPending={updateMatch.isPending}
+        onRequestDelete={
+          activeDialog?.mode === "edit"
+            ? () =>
+                setActiveDialog((prev) =>
+                  prev ? { ...prev, mode: "delete" } : null,
+                )
+            : undefined
+        }
         handleMatchSelectChange={handleMatchSelectChange}
         handleDialogSubmit={handleDialogSubmit}
         setSelectedOutcome={setSelectedOutcome}

--- a/app/(authenticated)/circle-sessions/components/match-dialog.tsx
+++ b/app/(authenticated)/circle-sessions/components/match-dialog.tsx
@@ -7,6 +7,7 @@ import {
   DialogHeader,
   DialogTitle,
 } from "@/components/ui/dialog";
+import { Trash2 } from "lucide-react";
 import type { FormEvent } from "react";
 import {
   getMatchOutcome,
@@ -27,6 +28,7 @@ type MatchDialogProps = {
   outcomeOptions: Array<{ value: RowOutcome; label: string }>;
   createMatchIsPending: boolean;
   updateMatchIsPending: boolean;
+  onRequestDelete: (() => void) | undefined;
   handleMatchSelectChange: (nextIndex: number) => void;
   handleDialogSubmit: (event: FormEvent<HTMLFormElement>) => void;
   setSelectedOutcome: (outcome: RowOutcome) => void;
@@ -47,6 +49,7 @@ export function MatchDialog({
   outcomeOptions,
   createMatchIsPending,
   updateMatchIsPending,
+  onRequestDelete,
   handleMatchSelectChange,
   handleDialogSubmit,
   setSelectedOutcome,
@@ -157,6 +160,17 @@ export function MatchDialog({
             />
           </div>
           <DialogFooter className="mt-6">
+            {onRequestDelete ? (
+              <Button
+                type="button"
+                variant="destructive"
+                className="mr-auto"
+                onClick={onRequestDelete}
+              >
+                <Trash2 className="size-4" aria-hidden="true" />
+                削除
+              </Button>
+            ) : null}
             <Button
               type="button"
               variant="outline"


### PR DESCRIPTION
## Summary

Closes #122

編集ダイアログフッターの削除ボタンが `handleDelete` を直接呼び出しており、AlertDialog による確認をバイパスしていたバグを修正。

- `MatchDialog` に `onRequestDelete` コールバック prop を追加
- 編集モード時のみフッター左端に削除ボタン（赤・ゴミ箱アイコン付き）を表示
- クリックで `activeDialog.mode` を `"delete"` に遷移させ、既存の AlertDialog 確認フローを経由するように変更

## Changed files

- `circle-session-detail-view.tsx`: `onRequestDelete` を edit モード時のみ渡す
- `match-dialog.tsx`: `onRequestDelete` prop を受け取り、フッターに削除ボタンを描画

## Test plan

- [x] 対局編集ダイアログのフッター左端に「削除」ボタンが表示される
- [x] 「削除」クリック → AlertDialog 確認ダイアログが表示される
- [x] 確認ダイアログでキャンセル → 元のセルにフォーカスが戻る
- [x] 新規追加ダイアログでは「削除」ボタンが表示されない
- [x] `npm run test:run` 全テスト通過
- [x] `npx tsc --noEmit` 型チェック通過

## Follow-up issues

- #376 MatchDialog コンポーネントのテストを追加
- #377 DialogFooter のモバイル表示でタブ順序と視覚的順序が不一致
- #378 ダークモードでの destructive ボタンのコントラスト比を確認・改善

🤖 Generated with [Claude Code](https://claude.com/claude-code)