### PR TITLE
fix: 編集ダイアログの対局日が DB の値と異なる (#380)

### DIFF
--- a/app/(authenticated)/circle-sessions/components/circle-session-detail-view.test.tsx
+++ b/app/(authenticated)/circle-sessions/components/circle-session-detail-view.test.tsx
@@ -230,6 +230,7 @@ const oneMatch = [
     player1Id: "p1",
     player2Id: "p2",
     outcome: "P1_WIN" as const,
+    createdAtInput: "2025-01-01",
   },
 ];
 

--- a/app/(authenticated)/circle-sessions/components/circle-session-detail-view.tsx
+++ b/app/(authenticated)/circle-sessions/components/circle-session-detail-view.tsx
@@ -11,7 +11,6 @@ import {
   AlertDialogTitle,
 } from "@/components/ui/alert-dialog";
 import { Button } from "@/components/ui/button";
-import { formatDateForInput } from "@/lib/date-utils";
 import { trpc } from "@/lib/trpc/client";
 import type {
   CircleSessionDetailViewModel,
@@ -26,13 +25,11 @@ import { MatchDeleteDialog } from "./match-delete-dialog";
 import { MatchDialog } from "./match-dialog";
 import { MatchMatrixTable } from "./match-matrix-table";
 import {
-  addDays,
   convertRowOutcomeToApiOutcome,
   getOutcomeLabel,
   getPairMatches,
   getRowOutcomeValue,
   getTodayInputValue,
-  parseDateInput,
   type ActiveDialog,
   type DialogMode,
   type RowOutcome,
@@ -108,11 +105,6 @@ export function CircleSessionDetailView({
   const participations = detail.participations;
   const matches = detail.matches;
   const todayInputValue = getTodayInputValue();
-  const baseDateInput = detail.sessionDateInput || todayInputValue;
-  const sessionBaseDate = parseDateInput(baseDateInput);
-  const matchDatesByIndex = matches.map((_, index) =>
-    formatDateForInput(addDays(sessionBaseDate, index)),
-  );
   const getParticipationName = (id: string) => {
     const participationsById = Object.fromEntries(
       participations.map((participation) => [participation.id, participation]),
@@ -219,7 +211,7 @@ export function CircleSessionDetailView({
 
     setSelectedMatchIndex(entry.index);
     setSelectedOutcome(getRowOutcomeValue(rowId, entry.match));
-    setSelectedDate(matchDatesByIndex[entry.index] ?? baseDateInput);
+    setSelectedDate(entry.match.createdAtInput);
   };
 
   const initializeDialogState = (

--- a/app/(authenticated)/circle-sessions/components/match-utils.ts
+++ b/app/(authenticated)/circle-sessions/components/match-utils.ts
@@ -18,17 +18,6 @@ export type ActiveDialog = {
 
 export const getTodayInputValue = () => formatDateForInput(new Date());
 
-export const addDays = (date: Date, amount: number) =>
-  new Date(date.getFullYear(), date.getMonth(), date.getDate() + amount);
-
-export const parseDateInput = (value: string) => {
-  const [year, month, day] = value.split("-").map(Number);
-  if (!year || !month || !day) {
-    return new Date();
-  }
-  return new Date(year, month - 1, day);
-};
-
 export const convertRowOutcomeToApiOutcome = (
   rowOutcome: RowOutcome,
   rowId: string,

--- a/server/presentation/providers/circle-session-detail-provider.ts
+++ b/server/presentation/providers/circle-session-detail-provider.ts
@@ -125,6 +125,7 @@ export async function getCircleSessionDetailViewModel(
       player1Id: match.player1Id,
       player2Id: match.player2Id,
       outcome: match.outcome,
+      createdAtInput: formatDateForInput(match.createdAt),
     }));
 
   const participationViewModels = mergeParticipationIds(

--- a/server/presentation/view-models/circle-session-detail.ts
+++ b/server/presentation/view-models/circle-session-detail.ts
@@ -16,6 +16,7 @@ export type CircleSessionMatch = {
   player1Id: string;
   player2Id: string;
   outcome: CircleSessionMatchOutcome;
+  createdAtInput: string;
 };
 
 export type CircleSessionDetailViewModel = {


### PR DESCRIPTION
## Summary

- ビューモデル (`CircleSessionMatch`) に `createdAtInput` フィールドを追加し、プロバイダーで DB の `createdAt` を input 形式にマッピング
- フロントエンドのセッション開始日+インデックスによる日付算出ロジックを削除し、DB 値を直接使用
- 不要になった `addDays`, `parseDateInput` ユーティリティを削除

Closes #380

## Test plan

- [x] `npx tsc --noEmit` — 型チェック pass
- [x] `npm run test:run` — 全テスト pass（606 tests）
- [x] `npm run lint` — lint pass
- [x] 手動確認: 対局の編集ダイアログを開き、対局日が DB の `createdAt` と一致すること

## Related issues

- #381 編集ダイアログの日付プリフィルに対する行動テストを追加
- #382 formatDateForInput のタイムゾーンを JST に固定する

🤖 Generated with [Claude Code](https://claude.com/claude-code)