### PR TITLE
fix: formatDateForInput のタイムゾーンを JST に固定する

### DIFF
--- a/lib/date-utils.test.ts
+++ b/lib/date-utils.test.ts
@@ -37,19 +37,40 @@ describe("formatDateTimeRange", () => {
 });
 
 describe("formatDateForInput", () => {
-  it("YYYY-MM-DD 形式で返す", () => {
-    expect(formatDateForInput(new Date(2025, 0, 5))).toBe("2025-01-05");
+  it("YYYY-MM-DD 形式（JST）で返す", () => {
+    // 2025-01-05T10:00:00Z = 2025-01-05T19:00:00+09:00
+    expect(formatDateForInput(new Date("2025-01-05T10:00:00Z"))).toBe(
+      "2025-01-05",
+    );
   });
 
   it("月・日を2桁ゼロ埋めする", () => {
-    expect(formatDateForInput(new Date(2025, 11, 31))).toBe("2025-12-31");
+    // 2025-12-31T00:00:00Z = 2025-12-31T09:00:00+09:00
+    expect(formatDateForInput(new Date("2025-12-31T00:00:00Z"))).toBe(
+      "2025-12-31",
+    );
+  });
+
+  it("JST 深夜帯で日付がずれない（UTC では前日でも JST では当日）", () => {
+    // 2025-01-14T15:30:00Z = 2025-01-15T00:30:00+09:00
+    expect(formatDateForInput(new Date("2025-01-14T15:30:00Z"))).toBe(
+      "2025-01-15",
+    );
   });
 });
 
 describe("formatDateTimeForInput", () => {
-  it("YYYY-MM-DDThh:mm 形式で返す", () => {
-    expect(formatDateTimeForInput(new Date(2025, 0, 15, 9, 5))).toBe(
+  it("YYYY-MM-DDThh:mm 形式（JST）で返す", () => {
+    // 2025-01-15T00:05:00Z = 2025-01-15T09:05:00+09:00
+    expect(formatDateTimeForInput(new Date("2025-01-15T00:05:00Z"))).toBe(
       "2025-01-15T09:05",
+    );
+  });
+
+  it("JST 深夜帯で日付・時刻がずれない", () => {
+    // 2025-01-14T15:30:00Z = 2025-01-15T00:30:00+09:00
+    expect(formatDateTimeForInput(new Date("2025-01-14T15:30:00Z"))).toBe(
+      "2025-01-15T00:30",
     );
   });
 });

--- a/lib/date-utils.ts
+++ b/lib/date-utils.ts
@@ -10,10 +10,17 @@ export const formatDateTimeRange = (startsAt: Date, endsAt: Date) =>
   `${formatDate(startsAt)} ${formatTime(startsAt)} - ${formatTime(endsAt)}`;
 
 export const formatDateForInput = (date: Date) =>
-  `${date.getFullYear()}-${pad2(date.getMonth() + 1)}-${pad2(date.getDate())}`;
+  date.toLocaleDateString("sv-SE", { timeZone: "Asia/Tokyo" });
 
-export const formatDateTimeForInput = (date: Date) =>
-  `${formatDateForInput(date)}T${pad2(date.getHours())}:${pad2(date.getMinutes())}`;
+export const formatDateTimeForInput = (date: Date) => {
+  const timePart = date.toLocaleTimeString("en-GB", {
+    timeZone: "Asia/Tokyo",
+    hour: "2-digit",
+    minute: "2-digit",
+    hour12: false,
+  });
+  return `${formatDateForInput(date)}T${timePart}`;
+};
 
 export function formatTooltipDateTime(
   startsAt: string | Date,


### PR DESCRIPTION
## Summary

- `formatDateForInput` を `toLocaleDateString("sv-SE", { timeZone: "Asia/Tokyo" })` に置き換え、JST 固定化
- `formatDateTimeForInput` の時刻部分も `toLocaleTimeString("en-GB", { timeZone: "Asia/Tokyo" })` で JST 固定化
- JST 深夜帯の日付ずれを再現するテストケースを追加

Closes #382

## Test plan

- [x] `npm run test:run -- lib/date-utils.test.ts` — 16 tests passed
- [x] `TZ=UTC npm run test:run -- lib/date-utils.test.ts` — UTC 環境でも全テスト pass
- [x] `npx tsc --noEmit` — 型エラーなし
- [ ] Vercel デプロイ後、JST 深夜帯作成データの編集ダイアログで日付が正しいことを確認

## Follow-up

- #384: `formatDate`, `formatTime` 等の表示用関数にも同じ TZ 依存問題が残る（スコープ外として別 issue 化済み）

🤖 Generated with [Claude Code](https://claude.com/claude-code)