### PR TITLE
test: 編集ダイアログの日付プリフィルに対する行動テストを追加

### DIFF
--- a/app/(authenticated)/circle-sessions/components/circle-session-detail-view.test.tsx
+++ b/app/(authenticated)/circle-sessions/components/circle-session-detail-view.test.tsx
@@ -393,3 +393,15 @@ describe("CircleSessionDetailView mutation エラーパス", () => {
     });
   });
 });
+
+describe("編集ダイアログの日付プリフィル", () => {
+  it("編集ダイアログを開くと対局日にcreatedAtInputの値がプリフィルされる", async () => {
+    await openEditDialogViaDropdown();
+
+    const dialog = await screen.findByRole("dialog");
+    const dateInput = within(dialog).getByLabelText(
+      "対局日",
+    ) as HTMLInputElement;
+    expect(dateInput.value).toBe(oneMatch[0].createdAtInput);
+  });
+});


### PR DESCRIPTION
## Summary

- 編集ダイアログを開いた際に、日付入力フィールドが `match.createdAtInput` の値でプリフィルされることを検証する行動テストを追加
- #380 の修正に対する回帰防止テスト

Closes #381

## Test plan

- [ ] `npm run test:run -- app/(authenticated)/circle-sessions/components/circle-session-detail-view.test.tsx` で 13 件全テストが PASS
- [ ] 新規テスト「編集ダイアログを開くと対局日にcreatedAtInputの値がプリフィルされる」が含まれていること

## Verification

- verify.md の結果: 13 tests passed（既存12 + 新規1）
- コードレビュー済み: テストブロックの配置を適切なスコープに修正

## Follow-up

- #388: `@testing-library/jest-dom` を vitest セットアップに追加（`toHaveValue` マッチャー利用のため）

🤖 Generated with [Claude Code](https://claude.com/claude-code)