### PR TITLE
test: queryByXxx().toBeNull() を not.toBeInTheDocument() に置き換え

### DIFF
--- a/app/(authenticated)/circle-sessions/components/circle-session-detail-view.test.tsx
+++ b/app/(authenticated)/circle-sessions/components/circle-session-detail-view.test.tsx
@@ -129,7 +129,7 @@ describe("CircleSessionDetailView 複製ボタン", () => {
         />,
       );
 
-      expect(screen.queryByRole("button", { name: "セッションの複製" })).toBeNull();
+      expect(screen.queryByRole("button", { name: "セッションの複製" })).not.toBeInTheDocument();
     });
   });
 
@@ -245,7 +245,7 @@ async function openAddDialogForEmptyCell() {
     />,
   );
   const cell = document.querySelector('[data-cell-id="p1-p2"]');
-  expect(cell).not.toBeNull();
+  expect(cell).toBeInTheDocument();
   await user.click(cell!);
   return user;
 }
@@ -261,7 +261,7 @@ async function openEditDialogViaDropdown() {
     />,
   );
   const cell = document.querySelector('[data-cell-id="p1-p2"]');
-  expect(cell).not.toBeNull();
+  expect(cell).toBeInTheDocument();
   await user.click(cell!);
   const editItem = await screen.findByRole("menuitem", { name: "編集" });
   await user.click(editItem);
@@ -279,7 +279,7 @@ async function openDeleteDialogViaDropdown() {
     />,
   );
   const cell = document.querySelector('[data-cell-id="p1-p2"]');
-  expect(cell).not.toBeNull();
+  expect(cell).toBeInTheDocument();
   await user.click(cell!);
   const deleteItem = await screen.findByRole("menuitem", { name: "削除" });
   await user.click(deleteItem);
@@ -311,7 +311,7 @@ describe("CircleSessionDetailView mutation エラーパス", () => {
       const submitButton = within(dialog).getByRole("button", { name: "追加" });
       await user.click(submitButton);
 
-      expect(screen.queryByRole("dialog")).toBeNull();
+      expect(screen.queryByRole("dialog")).not.toBeInTheDocument();
       expect(toastModule.toast.error).toHaveBeenCalledWith(
         "対局結果の追加に失敗しました",
       );
@@ -325,7 +325,7 @@ describe("CircleSessionDetailView mutation エラーパス", () => {
       const submitButton = within(dialog).getByRole("button", { name: "追加" });
       await user.click(submitButton);
 
-      expect(screen.queryByRole("dialog")).toBeNull();
+      expect(screen.queryByRole("dialog")).not.toBeInTheDocument();
       expect(toastModule.toast.success).toHaveBeenCalledOnce();
       expect(refreshMock).toHaveBeenCalled();
     });
@@ -342,7 +342,7 @@ describe("CircleSessionDetailView mutation エラーパス", () => {
       const submitButton = within(dialog).getByRole("button", { name: "保存" });
       await user.click(submitButton);
 
-      expect(screen.queryByRole("dialog")).toBeNull();
+      expect(screen.queryByRole("dialog")).not.toBeInTheDocument();
       expect(toastModule.toast.error).toHaveBeenCalledWith(
         "対局結果の更新に失敗しました",
       );
@@ -356,7 +356,7 @@ describe("CircleSessionDetailView mutation エラーパス", () => {
       const submitButton = within(dialog).getByRole("button", { name: "保存" });
       await user.click(submitButton);
 
-      expect(screen.queryByRole("dialog")).toBeNull();
+      expect(screen.queryByRole("dialog")).not.toBeInTheDocument();
       expect(toastModule.toast.success).toHaveBeenCalledOnce();
       expect(refreshMock).toHaveBeenCalled();
     });
@@ -373,7 +373,7 @@ describe("CircleSessionDetailView mutation エラーパス", () => {
       const deleteButton = within(dialog).getByRole("button", { name: "削除" });
       await user.click(deleteButton);
 
-      expect(screen.queryByRole("alertdialog")).toBeNull();
+      expect(screen.queryByRole("alertdialog")).not.toBeInTheDocument();
       expect(toastModule.toast.error).toHaveBeenCalledWith(
         "対局結果の削除に失敗しました",
       );
@@ -387,7 +387,7 @@ describe("CircleSessionDetailView mutation エラーパス", () => {
       const deleteButton = within(dialog).getByRole("button", { name: "削除" });
       await user.click(deleteButton);
 
-      expect(screen.queryByRole("alertdialog")).toBeNull();
+      expect(screen.queryByRole("alertdialog")).not.toBeInTheDocument();
       expect(toastModule.toast.success).toHaveBeenCalledOnce();
       expect(refreshMock).toHaveBeenCalled();
     });

--- a/app/(authenticated)/circle-sessions/components/match-dialog.test.tsx
+++ b/app/(authenticated)/circle-sessions/components/match-dialog.test.tsx
@@ -92,7 +92,7 @@ describe("MatchDialog", () => {
       const dialog = screen.getByRole("dialog");
       expect(
         within(dialog).queryByRole("button", { name: /削除/ }),
-      ).toBeNull();
+      ).not.toBeInTheDocument();
     });
 
     it("削除ボタンクリック時に onRequestDelete コールバックが1回呼ばれる", async () => {
@@ -205,7 +205,7 @@ describe("MatchDialog", () => {
         />,
       );
 
-      expect(screen.queryByText("対象の対局結果")).toBeNull();
+      expect(screen.queryByText("対象の対局結果")).not.toBeInTheDocument();
     });
 
     it("送信ボタンのラベルが「追加」である", () => {
@@ -300,7 +300,7 @@ describe("MatchDialog", () => {
         />,
       );
 
-      expect(screen.queryByRole("dialog")).toBeNull();
+      expect(screen.queryByRole("dialog")).not.toBeInTheDocument();
     });
   });
 });

--- a/app/(authenticated)/circles/[circleId]/sessions/new/circle-session-create-form.test.tsx
+++ b/app/(authenticated)/circles/[circleId]/sessions/new/circle-session-create-form.test.tsx
@@ -219,6 +219,6 @@ describe("CircleSessionCreateForm", () => {
     expect(screen.getByRole("alert")).toBeTruthy();
 
     await user.type(titleInput, "テスト");
-    expect(screen.queryByRole("alert")).toBeNull();
+    expect(screen.queryByRole("alert")).not.toBeInTheDocument();
   });
 });

--- a/app/(authenticated)/circles/components/circle-overview-view.test.tsx
+++ b/app/(authenticated)/circles/components/circle-overview-view.test.tsx
@@ -90,7 +90,7 @@ describe("CircleOverviewView ロールベース表示制御", () => {
 
     const calendar = screen.getByTestId("calendar");
     expect(calendar.dataset.createHref).toBe("");
-    expect(screen.queryByTestId("create-link")).toBeNull();
+    expect(screen.queryByTestId("create-link")).not.toBeInTheDocument();
   });
 
   it("viewerRole が null の場合、createSessionHref が null になる", () => {
@@ -103,7 +103,7 @@ describe("CircleOverviewView ロールベース表示制御", () => {
 
     const calendar = screen.getByTestId("calendar");
     expect(calendar.dataset.createHref).toBe("");
-    expect(screen.queryByTestId("create-link")).toBeNull();
+    expect(screen.queryByTestId("create-link")).not.toBeInTheDocument();
   });
 
   it("getCreateSessionHref が未指定の場合、owner でも null になる", () => {
@@ -113,6 +113,6 @@ describe("CircleOverviewView ロールベース表示制御", () => {
 
     const calendar = screen.getByTestId("calendar");
     expect(calendar.dataset.createHref).toBe("");
-    expect(screen.queryByTestId("create-link")).toBeNull();
+    expect(screen.queryByTestId("create-link")).not.toBeInTheDocument();
   });
 });

--- a/components/calendar/event-with-tooltip.test.tsx
+++ b/components/calendar/event-with-tooltip.test.tsx
@@ -43,7 +43,7 @@ describe("EventWithTooltip", () => {
     render(<EventWithTooltip {...buildArg()} />);
 
     const trigger = screen.getByText("月例会");
-    expect(trigger.closest("[aria-label]")).toBeNull();
+    expect(trigger.closest("[aria-label]")).not.toBeInTheDocument();
   });
 
   it("日時データがない場合 sr-only スパンを含まない", () => {
@@ -58,7 +58,7 @@ describe("EventWithTooltip", () => {
 
     render(<EventWithTooltip {...arg} />);
 
-    expect(screen.queryByText(/\d{4}\/\d{2}\/\d{2}/)).toBeNull();
+    expect(screen.queryByText(/\d{4}\/\d{2}\/\d{2}/)).not.toBeInTheDocument();
   });
 
   it("startsAt が number の場合ツールチップなし（タイトルのみ）", () => {
@@ -73,8 +73,8 @@ describe("EventWithTooltip", () => {
 
     render(<EventWithTooltip {...arg} />);
 
-    expect(screen.getByText("テスト")).not.toBeNull();
-    expect(screen.queryByText(/\d{4}\/\d{2}\/\d{2}/)).toBeNull();
+    expect(screen.getByText("テスト")).toBeInTheDocument();
+    expect(screen.queryByText(/\d{4}\/\d{2}\/\d{2}/)).not.toBeInTheDocument();
   });
 
   it("startsAt が object（非Date）の場合ツールチップなし", () => {
@@ -92,8 +92,8 @@ describe("EventWithTooltip", () => {
 
     render(<EventWithTooltip {...arg} />);
 
-    expect(screen.getByText("テスト")).not.toBeNull();
-    expect(screen.queryByText(/\d{4}\/\d{2}\/\d{2}/)).toBeNull();
+    expect(screen.getByText("テスト")).toBeInTheDocument();
+    expect(screen.queryByText(/\d{4}\/\d{2}\/\d{2}/)).not.toBeInTheDocument();
   });
 
   it("endsAt が number の場合ツールチップなし", () => {
@@ -108,8 +108,8 @@ describe("EventWithTooltip", () => {
 
     render(<EventWithTooltip {...arg} />);
 
-    expect(screen.getByText("テスト")).not.toBeNull();
-    expect(screen.queryByText(/\d{4}\/\d{2}\/\d{2}/)).toBeNull();
+    expect(screen.getByText("テスト")).toBeInTheDocument();
+    expect(screen.queryByText(/\d{4}\/\d{2}\/\d{2}/)).not.toBeInTheDocument();
   });
 
   it("startsAt が undefined の場合ツールチップなし", () => {
@@ -124,8 +124,8 @@ describe("EventWithTooltip", () => {
 
     render(<EventWithTooltip {...arg} />);
 
-    expect(screen.getByText("テスト")).not.toBeNull();
-    expect(screen.queryByText(/\d{4}\/\d{2}\/\d{2}/)).toBeNull();
+    expect(screen.getByText("テスト")).toBeInTheDocument();
+    expect(screen.queryByText(/\d{4}\/\d{2}\/\d{2}/)).not.toBeInTheDocument();
   });
 
   it("startsAt が null の場合ツールチップなし", () => {
@@ -140,8 +140,8 @@ describe("EventWithTooltip", () => {
 
     render(<EventWithTooltip {...arg} />);
 
-    expect(screen.getByText("テスト")).not.toBeNull();
-    expect(screen.queryByText(/\d{4}\/\d{2}\/\d{2}/)).toBeNull();
+    expect(screen.getByText("テスト")).toBeInTheDocument();
+    expect(screen.queryByText(/\d{4}\/\d{2}\/\d{2}/)).not.toBeInTheDocument();
   });
 
   it("Date 型の startsAt / endsAt で正しくレンダリングされる", () => {


### PR DESCRIPTION
## Summary

- テストコード5ファイル・全29箇所で `.toBeNull()` / `.not.toBeNull()` を `not.toBeInTheDocument()` / `.toBeInTheDocument()` に置き換え
- `@testing-library/jest-dom` のマッチャーを活用し、DOM要素の存在/非存在チェックの意図を明確化
- プロダクションコードへの変更なし

Closes #391

## Test plan

- [x] 対象5ファイルの全54テストがパス（`npx vitest run`）
- [x] サーバー側テストの `.toBeNull()`（ドメインモデルのプロパティチェック）は置き換え対象外であることを確認
- [ ] CI パス確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)