### PR TITLE
test: getByXxx().toBeDefined() を toBeInTheDocument() に置き換え

### DIFF
--- a/app/(authenticated)/circle-sessions/components/circle-session-detail-view.test.tsx
+++ b/app/(authenticated)/circle-sessions/components/circle-session-detail-view.test.tsx
@@ -119,7 +119,7 @@ describe("CircleSessionDetailView 複製ボタン", () => {
         />,
       );
 
-      expect(screen.getByRole("button", { name: "セッションの複製" })).toBeDefined();
+      expect(screen.getByRole("button", { name: "セッションの複製" })).toBeInTheDocument();
     });
 
     it("canCreateCircleSession: false の場合、複製ボタンが表示されない", () => {
@@ -306,7 +306,7 @@ describe("CircleSessionDetailView mutation エラーパス", () => {
       const user = await openAddDialogForEmptyCell();
 
       const dialog = await screen.findByRole("dialog");
-      expect(dialog).toBeDefined();
+      expect(dialog).toBeInTheDocument();
 
       const submitButton = within(dialog).getByRole("button", { name: "追加" });
       await user.click(submitButton);
@@ -337,7 +337,7 @@ describe("CircleSessionDetailView mutation エラーパス", () => {
       const user = await openEditDialogViaDropdown();
 
       const dialog = await screen.findByRole("dialog");
-      expect(dialog).toBeDefined();
+      expect(dialog).toBeInTheDocument();
 
       const submitButton = within(dialog).getByRole("button", { name: "保存" });
       await user.click(submitButton);
@@ -368,7 +368,7 @@ describe("CircleSessionDetailView mutation エラーパス", () => {
       const user = await openDeleteDialogViaDropdown();
 
       const dialog = await screen.findByRole("alertdialog");
-      expect(dialog).toBeDefined();
+      expect(dialog).toBeInTheDocument();
 
       const deleteButton = within(dialog).getByRole("button", { name: "削除" });
       await user.click(deleteButton);

--- a/app/(authenticated)/circle-sessions/components/match-dialog.test.tsx
+++ b/app/(authenticated)/circle-sessions/components/match-dialog.test.tsx
@@ -76,7 +76,7 @@ describe("MatchDialog", () => {
       const dialog = screen.getByRole("dialog");
       expect(
         within(dialog).getByRole("button", { name: /削除/ }),
-      ).toBeDefined();
+      ).toBeInTheDocument();
     });
 
     it("onRequestDelete が undefined の場合、削除ボタンが表示されない", () => {
@@ -130,7 +130,7 @@ describe("MatchDialog", () => {
         />,
       );
 
-      expect(screen.getByText("対象の対局結果")).toBeDefined();
+      expect(screen.getByText("対象の対局結果")).toBeInTheDocument();
     });
 
     it("送信ボタンのラベルが「保存」である", () => {
@@ -143,7 +143,7 @@ describe("MatchDialog", () => {
       const dialog = screen.getByRole("dialog");
       expect(
         within(dialog).getByRole("button", { name: "保存" }),
-      ).toBeDefined();
+      ).toBeInTheDocument();
     });
 
     it("対局選択ドロップダウンの変更で handleMatchSelectChange が呼ばれる", async () => {
@@ -218,7 +218,7 @@ describe("MatchDialog", () => {
       const dialog = screen.getByRole("dialog");
       expect(
         within(dialog).getByRole("button", { name: "追加" }),
-      ).toBeDefined();
+      ).toBeInTheDocument();
     });
   });
 
@@ -230,7 +230,7 @@ describe("MatchDialog", () => {
         />,
       );
 
-      expect(screen.getByText("テストタイトル")).toBeDefined();
+      expect(screen.getByText("テストタイトル")).toBeInTheDocument();
     });
 
     it("対局者名（dialogRowName × dialogColumnName）が表示される", () => {
@@ -243,7 +243,7 @@ describe("MatchDialog", () => {
         />,
       );
 
-      expect(screen.getByText("藤井太郎 × 羽生次郎")).toBeDefined();
+      expect(screen.getByText("藤井太郎 × 羽生次郎")).toBeInTheDocument();
     });
 
     it("キャンセルボタンクリック時に closeDialog が呼ばれる", async () => {
@@ -274,7 +274,7 @@ describe("MatchDialog", () => {
       const submitButton = within(dialog).getByRole("button", {
         name: "処理中…",
       });
-      expect(submitButton).toBeDefined();
+      expect(submitButton).toBeInTheDocument();
       expect(submitButton.hasAttribute("disabled")).toBe(true);
     });
 
@@ -289,7 +289,7 @@ describe("MatchDialog", () => {
       const submitButton = within(dialog).getByRole("button", {
         name: "処理中…",
       });
-      expect(submitButton).toBeDefined();
+      expect(submitButton).toBeInTheDocument();
       expect(submitButton.hasAttribute("disabled")).toBe(true);
     });
 

--- a/app/(authenticated)/circles/components/circle-overview-view.test.tsx
+++ b/app/(authenticated)/circles/components/circle-overview-view.test.tsx
@@ -64,7 +64,7 @@ describe("CircleOverviewView ロールベース表示制御", () => {
 
     const calendar = screen.getByTestId("calendar");
     expect(calendar.dataset.createHref).toBe("/circles/circle-1/sessions/new");
-    expect(screen.getByTestId("create-link")).toBeDefined();
+    expect(screen.getByTestId("create-link")).toBeInTheDocument();
   });
 
   it("manager の場合、createSessionHref がカレンダーに渡される", () => {
@@ -77,7 +77,7 @@ describe("CircleOverviewView ロールベース表示制御", () => {
 
     const calendar = screen.getByTestId("calendar");
     expect(calendar.dataset.createHref).toBe("/circles/circle-1/sessions/new");
-    expect(screen.getByTestId("create-link")).toBeDefined();
+    expect(screen.getByTestId("create-link")).toBeInTheDocument();
   });
 
   it("member の場合、createSessionHref が null になる", () => {


### PR DESCRIPTION
## Summary

- `getByXxx().toBeDefined()` を `getByXxx().toBeInTheDocument()` に置き換え（3ファイル、14箇所）
- `getBy` は要素が見つからなければ throw するため `toBeDefined()` は冗長。`toBeInTheDocument()` によりセマンティックな意図が明確になり、エラーメッセージも改善される

Closes #392

## Test plan

- [ ] `npm run test:run` で全テストがパスすることを確認
- [ ] 変更対象の3ファイルのテストが正常に動作することを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)