### PR TITLE
test: DOM プロパティ直接アクセスを jest-dom マッチャーに置き換え (#393)

### DIFF
--- a/app/(authenticated)/circles/[circleId]/sessions/new/circle-session-create-form.test.tsx
+++ b/app/(authenticated)/circles/[circleId]/sessions/new/circle-session-create-form.test.tsx
@@ -191,7 +191,7 @@ describe("CircleSessionCreateForm", () => {
     await user.click(screen.getByRole("button", { name: /予定を作成/ }));
 
     const alert = screen.getByRole("alert");
-    expect(alert.textContent).toBe("タイトルを入力してください");
+    expect(alert).toHaveTextContent("タイトルを入力してください");
     expect(mutateMock).not.toHaveBeenCalled();
   });
 
@@ -205,7 +205,7 @@ describe("CircleSessionCreateForm", () => {
     await user.click(screen.getByRole("button", { name: /予定を作成/ }));
 
     const alert = screen.getByRole("alert");
-    expect(alert.textContent).toBe("タイトルを入力してください");
+    expect(alert).toHaveTextContent("タイトルを入力してください");
     expect(mutateMock).not.toHaveBeenCalled();
   });
 

--- a/components/calendar/event-with-tooltip.test.tsx
+++ b/components/calendar/event-with-tooltip.test.tsx
@@ -35,8 +35,8 @@ describe("EventWithTooltip", () => {
     render(<EventWithTooltip {...buildArg()} />);
 
     const srOnly = screen.getByText(/2025\/01\/15/);
-    expect(srOnly.className).toContain("sr-only");
-    expect(srOnly.textContent).toBe(", 2025/01/15 14:00 - 16:00");
+    expect(srOnly).toHaveClass("sr-only");
+    expect(srOnly).toHaveTextContent(", 2025/01/15 14:00 - 16:00");
   });
 
   it("aria-label 属性を使用しない", () => {
@@ -157,7 +157,7 @@ describe("EventWithTooltip", () => {
     );
 
     const srOnly = screen.getByText(/2025\/03\/10/);
-    expect(srOnly.className).toContain("sr-only");
-    expect(srOnly.textContent).toBe(", 2025/03/10 10:00 - 12:30");
+    expect(srOnly).toHaveClass("sr-only");
+    expect(srOnly).toHaveTextContent(", 2025/03/10 10:00 - 12:30");
   });
 });

--- a/components/calendar/session-calendar-keyboard.test.tsx
+++ b/components/calendar/session-calendar-keyboard.test.tsx
@@ -109,9 +109,9 @@ describe("SessionCalendar keyboard navigation", () => {
     const cells = getCells();
     cells.forEach((cell, i) => {
       if (i === 10) {
-        expect(cell.getAttribute("tabindex")).toBe("0");
+        expect(cell).toHaveAttribute("tabindex", "0");
       } else {
-        expect(cell.getAttribute("tabindex")).toBe("-1");
+        expect(cell).toHaveAttribute("tabindex", "-1");
       }
     });
   });
@@ -129,8 +129,8 @@ describe("SessionCalendar keyboard navigation", () => {
     cells[10].focus();
     press(cells[10], "ArrowRight");
 
-    expect(cells[10].getAttribute("tabindex")).toBe("-1");
-    expect(cells[11].getAttribute("tabindex")).toBe("0");
+    expect(cells[10]).toHaveAttribute("tabindex", "-1");
+    expect(cells[11]).toHaveAttribute("tabindex", "0");
     expect(document.activeElement).toBe(cells[11]);
   });
 
@@ -139,8 +139,8 @@ describe("SessionCalendar keyboard navigation", () => {
     cells[10].focus();
     press(cells[10], "ArrowLeft");
 
-    expect(cells[10].getAttribute("tabindex")).toBe("-1");
-    expect(cells[9].getAttribute("tabindex")).toBe("0");
+    expect(cells[10]).toHaveAttribute("tabindex", "-1");
+    expect(cells[9]).toHaveAttribute("tabindex", "0");
     expect(document.activeElement).toBe(cells[9]);
   });
 
@@ -149,8 +149,8 @@ describe("SessionCalendar keyboard navigation", () => {
     cells[10].focus();
     press(cells[10], "ArrowUp");
 
-    expect(cells[10].getAttribute("tabindex")).toBe("-1");
-    expect(cells[3].getAttribute("tabindex")).toBe("0");
+    expect(cells[10]).toHaveAttribute("tabindex", "-1");
+    expect(cells[3]).toHaveAttribute("tabindex", "0");
     expect(document.activeElement).toBe(cells[3]);
   });
 
@@ -159,8 +159,8 @@ describe("SessionCalendar keyboard navigation", () => {
     cells[10].focus();
     press(cells[10], "ArrowDown");
 
-    expect(cells[10].getAttribute("tabindex")).toBe("-1");
-    expect(cells[17].getAttribute("tabindex")).toBe("0");
+    expect(cells[10]).toHaveAttribute("tabindex", "-1");
+    expect(cells[17]).toHaveAttribute("tabindex", "0");
     expect(document.activeElement).toBe(cells[17]);
   });
 
@@ -169,8 +169,8 @@ describe("SessionCalendar keyboard navigation", () => {
     cells[10].focus();
     press(cells[10], "Home");
 
-    expect(cells[10].getAttribute("tabindex")).toBe("-1");
-    expect(cells[7].getAttribute("tabindex")).toBe("0");
+    expect(cells[10]).toHaveAttribute("tabindex", "-1");
+    expect(cells[7]).toHaveAttribute("tabindex", "0");
     expect(document.activeElement).toBe(cells[7]);
   });
 
@@ -179,8 +179,8 @@ describe("SessionCalendar keyboard navigation", () => {
     cells[10].focus();
     press(cells[10], "End");
 
-    expect(cells[10].getAttribute("tabindex")).toBe("-1");
-    expect(cells[13].getAttribute("tabindex")).toBe("0");
+    expect(cells[10]).toHaveAttribute("tabindex", "-1");
+    expect(cells[13]).toHaveAttribute("tabindex", "0");
     expect(document.activeElement).toBe(cells[13]);
   });
 
@@ -193,7 +193,7 @@ describe("SessionCalendar keyboard navigation", () => {
 
     press(cells[0], "ArrowLeft");
 
-    expect(cells[0].getAttribute("tabindex")).toBe("0");
+    expect(cells[0]).toHaveAttribute("tabindex", "0");
     expect(document.activeElement).toBe(cells[0]);
   });
 
@@ -207,7 +207,7 @@ describe("SessionCalendar keyboard navigation", () => {
 
     press(cells[last], "ArrowRight");
 
-    expect(cells[last].getAttribute("tabindex")).toBe("0");
+    expect(cells[last]).toHaveAttribute("tabindex", "0");
     expect(document.activeElement).toBe(cells[last]);
   });
 
@@ -220,7 +220,7 @@ describe("SessionCalendar keyboard navigation", () => {
 
     press(cells[3], "ArrowUp");
 
-    expect(cells[3].getAttribute("tabindex")).toBe("0");
+    expect(cells[3]).toHaveAttribute("tabindex", "0");
     expect(document.activeElement).toBe(cells[3]);
   });
 


### PR DESCRIPTION
## Summary

- `.textContent` → `toHaveTextContent()` に変換（4箇所）
- `.className` → `toHaveClass()` に変換（2箇所）
- `.getAttribute("tabindex")` → `toHaveAttribute("tabindex", ...)` に変換（17箇所）

## Test plan

- [x] 対象3ファイルのテスト全19件パス（`npx vitest run`）
- [x] 未変換パターンの残存なし（grep確認済み）
- [ ] CI パス確認

## Notes

- `toHaveTextContent` は部分一致セマンティクス（元は完全一致）だが、対象要素が単一テキストのため実質的な差異なし
- `session-calendar-month-navigation.test.tsx` の残存パターン（2箇所）は #399 で追跡

Closes #393

🤖 Generated with [Claude Code](https://claude.com/claude-code)