### PR TITLE
test: hasAttribute("disabled") を toBeDisabled() に置き換え (#397)

### DIFF
--- a/app/(authenticated)/circle-sessions/components/match-dialog.test.tsx
+++ b/app/(authenticated)/circle-sessions/components/match-dialog.test.tsx
@@ -275,7 +275,7 @@ describe("MatchDialog", () => {
         name: "処理中…",
       });
       expect(submitButton).toBeInTheDocument();
-      expect(submitButton.hasAttribute("disabled")).toBe(true);
+      expect(submitButton).toBeDisabled();
     });
 
     it("updateMatchIsPending が true のとき送信ボタンが disabled かつラベルが「処理中…」", () => {
@@ -290,7 +290,7 @@ describe("MatchDialog", () => {
         name: "処理中…",
       });
       expect(submitButton).toBeInTheDocument();
-      expect(submitButton.hasAttribute("disabled")).toBe(true);
+      expect(submitButton).toBeDisabled();
     });
 
     it("activeDialog が null のときダイアログが開かない", () => {


### PR DESCRIPTION
## Summary

- `match-dialog.test.tsx` の `hasAttribute("disabled")` パターン2箇所を jest-dom の `toBeDisabled()` に置き換え
- テスト失敗時のエラーメッセージが `expected false to be true` → `expected element to be disabled` に改善

Closes #397

## Verification

- [x] 全14テスト通過（`npm run test:run -- match-dialog.test.tsx`）
- [x] 変更は2行のみ（L278, L293）
- [x] `app/` 配下のテストに `hasAttribute("disabled")` の残存なし

## Follow-up

- #401: `hasAttribute("aria-current")` の置き換え（別スコープ）

🤖 Generated with [Claude Code](https://claude.ai/claude-code)