### PR TITLE
test: hasAttribute("aria-current") を toHaveAttribute に置き換え (#401)

### DIFF
--- a/components/calendar/session-calendar-keyboard.test.tsx
+++ b/components/calendar/session-calendar-keyboard.test.tsx
@@ -120,8 +120,8 @@ describe("SessionCalendar keyboard navigation", () => {
     const cells = getCells();
     expect(cells[10].getAttribute("aria-current")).toBe("date");
     // Other cells should not have aria-current
-    expect(cells[0].hasAttribute("aria-current")).toBe(false);
-    expect(cells[5].hasAttribute("aria-current")).toBe(false);
+    expect(cells[0]).not.toHaveAttribute("aria-current");
+    expect(cells[5]).not.toHaveAttribute("aria-current");
   });
 
   it("ArrowRight moves focus to the next cell", () => {


### PR DESCRIPTION
## Summary
- `session-calendar-keyboard.test.tsx` の `hasAttribute("aria-current")` を jest-dom の `toHaveAttribute` マッチャーに置き換え（2箇所）
- 失敗時のエラーメッセージが `expected true to be false` → `expected element not to have attribute "aria-current"` となり、意図が明確になる

Closes #401

## Test plan
- [ ] `npm run test:run -- components/calendar/session-calendar-keyboard.test.tsx` でテストが通ること

🤖 Generated with [Claude Code](https://claude.com/claude-code)