### PR TITLE
feat: OAuthユーザーのメールアドレス変更を制限する

### DIFF
--- a/app/(authenticated)/account/page.tsx
+++ b/app/(authenticated)/account/page.tsx
@@ -22,6 +22,7 @@ export default async function AccountPage() {
         <ProfileFormInner
           initialName={viewModel.name}
           initialEmail={viewModel.email}
+          hasPassword={viewModel.hasPassword}
         />
       </section>
 

--- a/app/(authenticated)/account/profile-form.tsx
+++ b/app/(authenticated)/account/profile-form.tsx
@@ -11,9 +11,11 @@ import { toast } from "sonner";
 export function ProfileFormInner({
   initialName,
   initialEmail,
+  hasPassword,
 }: {
   initialName: string;
   initialEmail: string;
+  hasPassword: boolean;
 }) {
   const { update: updateSession } = useSession();
   const utils = trpc.useUtils();
@@ -71,7 +73,14 @@ export function ProfileFormInner({
           onChange={(e) => setEmail(e.target.value)}
           placeholder="メールアドレス"
           className="bg-white"
+          disabled={!hasPassword}
+          aria-describedby={!hasPassword ? "profile-email-desc" : undefined}
         />
+        {!hasPassword && (
+          <p id="profile-email-desc" className="text-xs text-(--brand-ink-muted)">
+            メールアドレスはOAuth連携先で管理されています
+          </p>
+        )}
       </div>
       <Button
         type="submit"

--- a/server/application/user/user-service.ts
+++ b/server/application/user/user-service.ts
@@ -59,6 +59,12 @@ export const createUserService = (deps: UserServiceDeps) => ({
     }
 
     if (email !== null) {
+      const passwordHash =
+        await deps.userRepository.findPasswordHashById(actorId);
+      if (passwordHash === null) {
+        throw new BadRequestError("OAuth users cannot change email");
+      }
+
       const exists = await deps.userRepository.emailExists(email, actorId);
       if (exists) {
         throw new BadRequestError("Email already in use");


### PR DESCRIPTION
## Summary

Closes #406

- **バックエンド**: `UserService.updateProfile()` でパスワード未設定（OAuth専用）ユーザーのメール変更を `BadRequestError` で拒否
- **フロントエンド**: `profile-form.tsx` でメール入力欄を `disabled` にし、「メールアドレスはOAuth連携先で管理されています」と表示
- **テスト**: OAuthユーザーのメール変更拒否・名前のみ更新のケースを追加

## Test plan

- [ ] `npm run test:run -- server/application/user/user-service.test.ts` で新規テスト3件がパスすること
- [ ] `npx tsc --noEmit` で型エラーがないこと
- [ ] OAuth（Google）ユーザーでログインし、アカウント設定画面でメール欄が無効化されていること
- [ ] Credentialsユーザーでログインし、メール変更が従来通り動作すること

🤖 Generated with [Claude Code](https://claude.com/claude-code)