### PR TITLE
fix: compound unique key 参照の修正 (#418)

### DIFF
--- a/prisma/seed.ts
+++ b/prisma/seed.ts
@@ -333,13 +333,23 @@ async function main() {
   });
 
   for (const membership of circleMemberships) {
-    await prisma.circleMembership.upsert({
+    const existing = await prisma.circleMembership.findFirst({
       where: {
-        userId_circleId: { userId: membership.userId, circleId: circle.id },
+        userId: membership.userId,
+        circleId: circle.id,
+        deletedAt: null,
       },
-      update: { role: membership.role },
-      create: { ...membership, circleId: circle.id },
     });
+    if (existing) {
+      await prisma.circleMembership.update({
+        where: { id: existing.id },
+        data: { role: membership.role },
+      });
+    } else {
+      await prisma.circleMembership.create({
+        data: { ...membership, circleId: circle.id },
+      });
+    }
   }
 
   for (const session of sessions) {
@@ -357,16 +367,23 @@ async function main() {
   }
 
   for (const membership of sessionMemberships) {
-    await prisma.circleSessionMembership.upsert({
+    const existing = await prisma.circleSessionMembership.findFirst({
       where: {
-        userId_circleSessionId: {
-          userId: membership.userId,
-          circleSessionId: membership.circleSessionId,
-        },
+        userId: membership.userId,
+        circleSessionId: membership.circleSessionId,
+        deletedAt: null,
       },
-      update: { role: membership.role },
-      create: membership,
     });
+    if (existing) {
+      await prisma.circleSessionMembership.update({
+        where: { id: existing.id },
+        data: { role: membership.role },
+      });
+    } else {
+      await prisma.circleSessionMembership.create({
+        data: membership,
+      });
+    }
   }
 
   for (const match of matches) {

--- a/server/infrastructure/repository/circle-session/prisma-circle-session-participation-repository.ts
+++ b/server/infrastructure/repository/circle-session/prisma-circle-session-participation-repository.ts
@@ -70,16 +70,19 @@ export const createPrismaCircleSessionParticipationRepository = (
     const persistedUserId = toPersistenceId(userId);
     const persistedRole = mapCircleSessionRoleToPersistence(role);
 
-    await client.circleSessionMembership.update({
+    const existing = await client.circleSessionMembership.findFirst({
       where: {
-        userId_circleSessionId: {
-          userId: persistedUserId,
-          circleSessionId: persistedCircleSessionId,
-        },
+        userId: persistedUserId,
+        circleSessionId: persistedCircleSessionId,
+        deletedAt: null,
       },
-      data: {
-        role: persistedRole,
-      },
+    });
+    if (!existing) {
+      throw new Error("CircleSessionMembership not found");
+    }
+    await client.circleSessionMembership.update({
+      where: { id: existing.id },
+      data: { role: persistedRole },
     });
   },
 

--- a/server/infrastructure/repository/circle/prisma-circle-participation-repository.ts
+++ b/server/infrastructure/repository/circle/prisma-circle-participation-repository.ts
@@ -58,16 +58,19 @@ export const createPrismaCircleParticipationRepository = (
     const persistedCircleId = toPersistenceId(circleId);
     const persistedRole = mapCircleRoleToPersistence(role);
 
-    await client.circleMembership.update({
+    const existing = await client.circleMembership.findFirst({
       where: {
-        userId_circleId: {
-          userId: toPersistenceId(userId),
-          circleId: persistedCircleId,
-        },
+        userId: toPersistenceId(userId),
+        circleId: persistedCircleId,
+        deletedAt: null,
       },
-      data: {
-        role: persistedRole,
-      },
+    });
+    if (!existing) {
+      throw new Error("CircleMembership not found");
+    }
+    await client.circleMembership.update({
+      where: { id: existing.id },
+      data: { role: persistedRole },
     });
   },
 


### PR DESCRIPTION
## Summary

- `@@unique` 削除に伴い Prisma Client の `WhereUniqueInput` から消失した compound unique key (`userId_circleId` / `userId_circleSessionId`) の参照を `findFirst` + `update` パターンに置換
- `deletedAt: null` 条件を適用し、論理削除済みレコードを除外
- seed.ts の `upsert` を `findFirst` + `create`/`update` に変更してべき等性を維持

Closes #418

## Test plan

- [x] `npx tsc --noEmit` — 型エラーなし
- [x] `npm run lint` — 警告・エラーなし
- [x] `npm run test:run` — 58 files, 631 tests passed
- [x] 正常パス・not found パスのテストカバレッジ確認済み

🤖 Generated with [Claude Code](https://claude.com/claude-code)