### PR TITLE
fix: removeParticipation の not-found ガード追加

### DIFF
--- a/server/infrastructure/repository/circle-session/prisma-circle-session-participation-repository.test.ts
+++ b/server/infrastructure/repository/circle-session/prisma-circle-session-participation-repository.test.ts
@@ -230,6 +230,7 @@ describe("Prisma CircleSession 参加者リポジトリ", () => {
 
   test("論理削除後の再参加で create が呼ばれる", async () => {
     // 1. removeParticipation で論理削除
+    mockedPrisma.circleSessionMembership.updateMany.mockResolvedValueOnce({ count: 1 });
     await prismaCircleSessionParticipationRepository.removeParticipation(
       circleSessionId("session-1"),
       userId("user-1"),
@@ -297,7 +298,19 @@ describe("Prisma CircleSession 参加者リポジトリ", () => {
     ]);
   });
 
+  test("removeParticipation はレコードが見つからない場合エラーをスローする", async () => {
+    mockedPrisma.circleSessionMembership.updateMany.mockResolvedValueOnce({ count: 0 });
+
+    await expect(
+      prismaCircleSessionParticipationRepository.removeParticipation(
+        circleSessionId("session-1"),
+        userId("user-1"),
+      ),
+    ).rejects.toThrow("CircleSessionMembership not found");
+  });
+
   test("removeParticipation は参加者を論理削除する", async () => {
+    mockedPrisma.circleSessionMembership.updateMany.mockResolvedValueOnce({ count: 1 });
     await prismaCircleSessionParticipationRepository.removeParticipation(
       circleSessionId("session-1"),
       userId("user-1"),

--- a/server/infrastructure/repository/circle-session/prisma-circle-session-participation-repository.ts
+++ b/server/infrastructure/repository/circle-session/prisma-circle-session-participation-repository.ts
@@ -110,7 +110,7 @@ export const createPrismaCircleSessionParticipationRepository = (
     const persistedCircleSessionId = toPersistenceId(circleSessionId);
     const persistedUserId = toPersistenceId(userId);
 
-    await client.circleSessionMembership.updateMany({
+    const result = await client.circleSessionMembership.updateMany({
       where: {
         circleSessionId: persistedCircleSessionId,
         userId: persistedUserId,
@@ -118,6 +118,9 @@ export const createPrismaCircleSessionParticipationRepository = (
       },
       data: { deletedAt: new Date() },
     });
+    if (result.count === 0) {
+      throw new Error("CircleSessionMembership not found");
+    }
   },
 
 });

--- a/server/infrastructure/repository/circle/prisma-circle-participation-repository.test.ts
+++ b/server/infrastructure/repository/circle/prisma-circle-participation-repository.test.ts
@@ -165,6 +165,7 @@ describe("Prisma Circle 参加者リポジトリ", () => {
 
   test("論理削除後の再参加で create が呼ばれる", async () => {
     // 1. removeParticipation で論理削除
+    mockedPrisma.circleMembership.updateMany.mockResolvedValueOnce({ count: 1 });
     await prismaCircleParticipationRepository.removeParticipation(
       circleId("circle-1"),
       userId("user-1"),
@@ -229,7 +230,19 @@ describe("Prisma Circle 参加者リポジトリ", () => {
     ]);
   });
 
+  test("removeParticipation はレコードが見つからない場合エラーをスローする", async () => {
+    mockedPrisma.circleMembership.updateMany.mockResolvedValueOnce({ count: 0 });
+
+    await expect(
+      prismaCircleParticipationRepository.removeParticipation(
+        circleId("circle-1"),
+        userId("user-1"),
+      ),
+    ).rejects.toThrow("CircleMembership not found");
+  });
+
   test("removeParticipation は研究会メンバーシップを論理削除する", async () => {
+    mockedPrisma.circleMembership.updateMany.mockResolvedValueOnce({ count: 1 });
     await prismaCircleParticipationRepository.removeParticipation(
       circleId("circle-1"),
       userId("user-1"),

--- a/server/infrastructure/repository/circle/prisma-circle-participation-repository.ts
+++ b/server/infrastructure/repository/circle/prisma-circle-participation-repository.ts
@@ -75,7 +75,7 @@ export const createPrismaCircleParticipationRepository = (
     const persistedCircleId = toPersistenceId(circleId);
     const persistedUserId = toPersistenceId(userId);
 
-    await client.circleMembership.updateMany({
+    const result = await client.circleMembership.updateMany({
       where: {
         circleId: persistedCircleId,
         userId: persistedUserId,
@@ -83,6 +83,9 @@ export const createPrismaCircleParticipationRepository = (
       },
       data: { deletedAt: new Date() },
     });
+    if (result.count === 0) {
+      throw new Error("CircleMembership not found");
+    }
   },
 });
 


### PR DESCRIPTION
## Summary
- `removeParticipation` で `updateMany` の結果が 0 件だった場合にエラーをスローするガードを追加
- CircleParticipationRepository / CircleSessionParticipationRepository の両方に適用
- 対応するユニットテストを追加

Closes 関連: #408

## Test plan
- [x] `prisma-circle-participation-repository.test.ts` 全9テスト合格
- [x] `prisma-circle-session-participation-repository.test.ts` 全13テスト合格

🤖 Generated with [Claude Code](https://claude.com/claude-code)