### PR TITLE
feat: プレゼンテーション層・フロントエンドの論理削除対応 (#413)

### DIFF
--- a/app/invite/[token]/invite-accept-view.tsx
+++ b/app/invite/[token]/invite-accept-view.tsx
@@ -66,6 +66,21 @@ export function InviteAcceptView({
     );
   }
 
+  if (redeemMutation.isSuccess) {
+    return (
+      <div className="flex flex-col items-center gap-4 rounded-3xl border border-border/60 bg-white/85 p-8 text-center shadow-sm">
+        <p className="text-sm font-semibold text-(--brand-ink)">
+          {redeemMutation.data.alreadyMember
+            ? `「${circleName}」に再参加しました`
+            : `「${circleName}」に参加しました`}
+        </p>
+        <p className="text-xs text-(--brand-ink-muted)">
+          リダイレクト中...
+        </p>
+      </div>
+    );
+  }
+
   return (
     <div className="flex flex-col items-center gap-4 rounded-3xl border border-border/60 bg-white/85 p-8 text-center shadow-sm">
       <p className="text-sm font-semibold text-(--brand-ink)">

--- a/server/application/circle-session/circle-session-service.test.ts
+++ b/server/application/circle-session/circle-session-service.test.ts
@@ -262,7 +262,7 @@ describe("UnitOfWork 経路", () => {
     updateParticipationRole: vi.fn(),
     areUsersParticipating: vi.fn(),
     removeParticipation: vi.fn(),
-    } satisfies CircleSessionParticipationRepository;
+  } satisfies CircleSessionParticipationRepository;
 
   // UoWコールバック用リポジトリ（UoW内専用）
   const uowCircleSessionRepository = {
@@ -280,7 +280,7 @@ describe("UnitOfWork 経路", () => {
     updateParticipationRole: vi.fn(),
     areUsersParticipating: vi.fn(),
     removeParticipation: vi.fn(),
-    } satisfies CircleSessionParticipationRepository;
+  } satisfies CircleSessionParticipationRepository;
 
   const unitOfWork: UnitOfWork = vi.fn(async (op) =>
     op({

--- a/server/application/match/match-service.test.ts
+++ b/server/application/match/match-service.test.ts
@@ -325,7 +325,7 @@ describe("UnitOfWork 経路", () => {
     updateParticipationRole: vi.fn(),
     areUsersParticipating: vi.fn(),
     removeParticipation: vi.fn(),
-    } satisfies CircleSessionParticipationRepository;
+  } satisfies CircleSessionParticipationRepository;
 
   const depsCircleSessionRepository = {
     findById: vi.fn(),
@@ -354,7 +354,7 @@ describe("UnitOfWork 経路", () => {
     updateParticipationRole: vi.fn(),
     areUsersParticipating: vi.fn(),
     removeParticipation: vi.fn(),
-    } satisfies CircleSessionParticipationRepository;
+  } satisfies CircleSessionParticipationRepository;
 
   const uowCircleSessionRepository = {
     findById: vi.fn(),


### PR DESCRIPTION
## Summary

Closes #413

プレゼンテーション層・フロントエンドをメンバーシップ論理削除に対応させる。

### 変更内容

- **フロントエンド**: 招待承認画面で `alreadyMember` フラグに基づき「再参加しました」/「参加しました」のメッセージ出し分け
- **テスト修正**: `} satisfies` のインデント修正（verify指摘）

### 確認済み事項（変更不要）

- DTO に `deletedAt` を含めない方針 → マッパーの Zod `.parse()` で除去済み
- tRPC ルーターはサービス層呼び出しのみのため変更不要
- メンバー一覧はアクティブメンバーのみ返却される設計で変更不要

## Test plan

- [x] `npx tsc --noEmit` パス
- [x] `npm run lint` パス
- [x] `npm run test:run` → 57ファイル / 630テスト 全パス
- [ ] 招待リンクからの新規参加で「参加しました」メッセージが表示されること（手動確認）
- [ ] 招待リンクからの再加入で「再参加しました」メッセージが表示されること（手動確認）

🤖 Generated with [Claude Code](https://claude.com/claude-code)