### PR TITLE
docs: Membership モデルに部分ユニークインデックスの警告コメントを追加

### DIFF
--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -120,6 +120,8 @@ model CircleMembership {
   circle Circle @relation(fields: [circleId], references: [id], onDelete: Cascade)
 
   /// 研究会参加（継続的所属）。アクティブレコード（deletedAt IS NULL）の一意性は部分ユニークインデックスで担保。
+  /// 部分ユニークインデックスは migration 20260219083336 で作成。
+  /// ⚠ @@unique を再追加しないこと（deletedAt を含む論理削除レコードが一意性制約に違反するため）。
   @@index([circleId, role])
 }
 
@@ -137,6 +139,8 @@ model CircleSessionMembership {
   session CircleSession @relation(fields: [circleSessionId], references: [id], onDelete: Cascade)
 
   /// セッション参加（単発参加）。アクティブレコード（deletedAt IS NULL）の一意性は部分ユニークインデックスで担保。
+  /// 部分ユニークインデックスは migration 20260219083336 で作成。
+  /// ⚠ @@unique を再追加しないこと（deletedAt を含む論理削除レコードが一意性制約に違反するため）。
   @@index([circleSessionId])
   @@index([circleSessionId, role])
   @@map("CircleSessionMembership")


### PR DESCRIPTION
## Summary
- `CircleMembership` と `CircleSessionMembership` の doc comment に部分ユニークインデックスの migration 参照と `@@unique` 再追加禁止の警告を追記

## Test plan
- [x] `npx prisma validate` でスキーマの妥当性を確認済み
- コメントのみの変更のため、動作への影響なし

Closes #425

🤖 Generated with [Claude Code](https://claude.com/claude-code)