### PR TITLE
refactor(lint): createPublicContext の import を providers 内で制限

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -88,6 +88,28 @@ const eslintConfig = defineConfig([
       ],
     },
   },
+  // presentation/providers: createPublicContext は invite-link-provider 以外で使用禁止
+  // 認証付きコンテキストには createContext を使うこと
+  {
+    files: ["server/presentation/providers/**/*.ts"],
+    ignores: ["**/*.test.ts"],
+    rules: {
+      "no-restricted-imports": [
+        "error",
+        {
+          patterns: ["@/server/infrastructure/**"],
+          paths: [
+            {
+              name: "@/server/presentation/trpc/context",
+              importNames: ["createPublicContext"],
+              message:
+                "Provider では createPublicContext ではなく createContext を使用してください。",
+            },
+          ],
+        },
+      ],
+    },
+  },
   // presentation exceptions: context.ts (DI composition root for tRPC)
   {
     files: ["server/presentation/trpc/context.ts"],
@@ -104,6 +126,18 @@ const eslintConfig = defineConfig([
     ],
     rules: {
       "no-restricted-imports": "off",
+    },
+  },
+  // TODO: #461 — invite-link-provider の DI 化後に削除
+  {
+    files: ["server/presentation/providers/invite-link-provider.ts"],
+    rules: {
+      "no-restricted-imports": [
+        "error",
+        {
+          patterns: ["@/server/infrastructure/**"],
+        },
+      ],
     },
   },
   // infrastructure: no importing presentation, application


### PR DESCRIPTION
Closes #459

## Summary

- `server/presentation/providers/**/*.ts` 内で `createPublicContext` の import を ESLint `no-restricted-imports` ルールで禁止
- `invite-link-provider.ts` のみ例外として `createPublicContext` を許可（公開ページ用プロバイダーのため）
- テストファイル（`*.test.ts`）はルール対象外

## Verification

- [x] `npm run lint` パス
- [x] `npx eslint --print-config` で各ファイルの effective rule を確認済み
  - `account-provider.ts`: `createPublicContext` 制限あり ✅
  - `invite-link-provider.ts`: `createPublicContext` 制限なし ✅
  - `invite-link-provider.test.ts`: 制限なし ✅
- [x] 設計レビュー: invite-link-provider 例外で infrastructure 制限が無効化されないことを確認

## Review points

- ESLint flat config のブロック順序に依存する override chain が増えている点（#455, #461 で段階的に解消予定）
- tRPC ルーター側の制限は今回スコープ外（issue 本文の通り）

🤖 Generated with [Claude Code](https://claude.com/claude-code)