### PR TITLE
refactor(presentation): createPublicContext の返却サービスを必要最小限に制限

### DIFF
--- a/server/presentation/trpc/context.ts
+++ b/server/presentation/trpc/context.ts
@@ -56,15 +56,18 @@ export type Context = Awaited<ReturnType<typeof createContext>>;
 /**
  * 公開ページ（未認証ユーザーもアクセス可能）向けコンテキスト。
  * tRPC ルーターでは使用しないこと。
+ *
+ * 認証なしでアクセス可能なため、サービスの追加は最小限に留めること。
+ * 使用箇所は ESLint ルールで invite-link-provider に制限されている。
  */
 export const createPublicContext = async () => {
   const session = await getSession();
   const actorId = session?.user?.id ?? null;
-  const services = buildServiceContainer();
+  const { circleInviteLinkService } = buildServiceContainer();
 
   return {
     actorId,
-    ...services,
+    circleInviteLinkService,
   };
 };
 


### PR DESCRIPTION
## Summary

- `createPublicContext()` が `buildServiceContainer()` の全サービスを展開していたのを、`circleInviteLinkService` のみ返すよう変更
- `actorId: null` の状態で認可必須サービスが型レベルでアクセス不可になり、誤用リスクを排除
- JSDoc にセキュリティ注記を追加（サービス追加時の注意喚起、ESLint 制限の明記）

Closes #458

## Verification

### 自動検証（verify phase で実施済み）

- `npx tsc --noEmit`: パス
- `npx vitest run`: 638 tests passed（invite-link 関連テスト 9 件含む）
- `npx eslint server/presentation/trpc/context.ts`: パス

### 手動検証手順

1. 開発サーバー起動後、未認証状態で招待リンクページ `/circles/{circleId}/invite/{token}` にアクセスし、正常に表示されることを確認
2. 認証状態で同ページにアクセスし、メンバーシップ状態が正しく表示されることを確認
3. 無効なトークンでアクセスし、invalid 状態が返ることを確認

## Related Issues

- #463 招待リンクトークンの形式バリデーションを DB クエリ前に追加する（verify phase で起票）
- #464 createPublicContext で必要なサービスのみインスタンス化する（verify phase で起票）

🤖 Generated with [Claude Code](https://claude.com/claude-code)