### PR TITLE
fix(ui): ボタンホバー時に cursor: pointer を適用

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -174,4 +174,8 @@
     );
     background-attachment: fixed;
   }
+  button:not(:disabled),
+  [role="button"]:not(:disabled) {
+    @apply cursor-pointer;
+  }
 }


### PR DESCRIPTION
## Summary

- Tailwind CSS v4 がボタンのデフォルトカーソルを `cursor: default` に変更したため、ホバー時に指マークが表示されなくなっていた
- グローバル CSS の `@layer base` に `button:not(:disabled)` / `[role="button"]:not(:disabled)` へ `@apply cursor-pointer` を追加
- shadcn/ui 公式ドキュメントの推奨回避策に準拠

Closes #468

## Verification

- [x] `npm run lint` パス
- [x] `npx tsc --noEmit` パス
- [x] ブラウザで各ボタン（Toggle Sidebar, CircleCreateDialog, UserMenu）の `cursor: pointer` 適用を確認
- [x] disabled 状態のボタンでは `cursor: pointer` が適用されないことを確認

## Review points

- `@apply cursor-pointer` を使用（raw CSS `cursor: pointer` は Tailwind v4.1 の `@layer base` 内でドロップされるため）
- `[role="button"]:not(:disabled)` は `aria-disabled="true"` をカバーしない（現時点で `role="button"` の使用箇所なし、実害なし）

🤖 Generated with [Claude Code](https://claude.com/claude-code)