### PR TITLE
test(domain): inviteLinkToken() の単体テストを追加 (#470)

### DIFF
--- a/server/domain/common/ids.test.ts
+++ b/server/domain/common/ids.test.ts
@@ -6,6 +6,7 @@ import {
   matchId,
   matchHistoryId,
   circleInviteLinkId,
+  inviteLinkToken,
 } from "./ids";
 import { BadRequestError } from "./errors";
 
@@ -79,6 +80,36 @@ describe("circleInviteLinkId", () => {
     expect(() => circleInviteLinkId("")).toThrow(BadRequestError);
     expect(() => circleInviteLinkId("")).toThrow(
       "Invalid circle invite link ID",
+    );
+  });
+});
+
+describe("inviteLinkToken", () => {
+  it("should return branded InviteLinkToken for valid UUID string", () => {
+    const token = inviteLinkToken("550e8400-e29b-41d4-a716-446655440000");
+    expect(token).toBe("550e8400-e29b-41d4-a716-446655440000");
+  });
+
+  it("should throw BadRequestError for non-UUID string", () => {
+    expect(() => inviteLinkToken("not-a-uuid")).toThrow(BadRequestError);
+    expect(() => inviteLinkToken("not-a-uuid")).toThrow(
+      "Invalid invite link token",
+    );
+  });
+
+  it("should throw BadRequestError for empty string", () => {
+    expect(() => inviteLinkToken("")).toThrow(BadRequestError);
+    expect(() => inviteLinkToken("")).toThrow("Invalid invite link token");
+  });
+
+  it("should accept uppercase hex UUID", () => {
+    const token = inviteLinkToken("550E8400-E29B-41D4-A716-446655440000");
+    expect(token).toBe("550E8400-E29B-41D4-A716-446655440000");
+  });
+
+  it("should throw BadRequestError for UUID-like string with wrong length", () => {
+    expect(() => inviteLinkToken("550e8400-e29b-41d4-a716-44665544000")).toThrow(
+      BadRequestError,
     );
   });
 });


### PR DESCRIPTION
## Summary

- `inviteLinkToken()` ドメイン関数に対する直接ユニットテスト（5ケース）を `ids.test.ts` に追加
- 本番コードの変更なし。テスト追加のみ

## Test plan

- [x] `npm run test:run -- server/domain/common/ids.test.ts` → 17 tests passed（既存12 + 新規5）
- [x] 本番コード `ids.ts` に差分がないことを確認

## Verification steps

1. `git diff main -- server/domain/common/ids.ts` で本番コードに変更がないことを確認
2. `npm run test:run -- server/domain/common/ids.test.ts` で全テストがパスすることを確認

Closes #470

🤖 Generated with [Claude Code](https://claude.com/claude-code)