### PR TITLE
test(trpc): match, user-circle-participation, user-circle-session-participation の専用テスト追加

### DIFF
--- a/server/presentation/trpc/routers/match.test.ts
+++ b/server/presentation/trpc/routers/match.test.ts
@@ -1,0 +1,442 @@
+import { beforeEach, describe, expect, test, vi } from "vitest";
+import { appRouter } from "@/server/presentation/trpc/router";
+import type { Context } from "@/server/presentation/trpc/context";
+import {
+  circleSessionId,
+  matchId,
+  userId,
+} from "@/server/domain/common/ids";
+import {
+  BadRequestError,
+  ForbiddenError,
+} from "@/server/domain/common/errors";
+
+const createTestContext = (
+  actorIdValue: ReturnType<typeof userId> | null = userId("user-1"),
+) => {
+  const matchService = {
+    listByCircleSessionId: vi.fn(),
+    getMatch: vi.fn(),
+    recordMatch: vi.fn(),
+    updateMatch: vi.fn(),
+    deleteMatch: vi.fn(),
+  };
+
+  const context: Context = {
+    actorId: actorIdValue,
+    circleService: {
+      getCircle: vi.fn(),
+      createCircle: vi.fn(),
+      renameCircle: vi.fn(),
+      deleteCircle: vi.fn(),
+    },
+    circleParticipationService: {
+      listByCircleId: vi.fn(),
+      listByUserId: vi.fn(),
+      addParticipation: vi.fn(),
+      changeParticipationRole: vi.fn(),
+      withdrawParticipation: vi.fn(),
+      removeParticipation: vi.fn(),
+      transferOwnership: vi.fn(),
+    },
+    circleSessionService: {
+      listByCircleId: vi.fn(),
+      getCircleSession: vi.fn(),
+      createCircleSession: vi.fn(),
+      rescheduleCircleSession: vi.fn(),
+      updateCircleSessionDetails: vi.fn(),
+      deleteCircleSession: vi.fn(),
+    },
+    circleSessionParticipationService: {
+      listParticipations: vi.fn(),
+      listByUserId: vi.fn(),
+      addParticipation: vi.fn(),
+      changeParticipationRole: vi.fn(),
+      removeParticipation: vi.fn(),
+      transferOwnership: vi.fn(),
+      withdrawParticipation: vi.fn(),
+    },
+    matchService,
+    matchHistoryService: {
+      listByMatchId: vi.fn(),
+    },
+    userService: {
+      getUser: vi.fn(),
+      listUsers: vi.fn(),
+      getMe: vi.fn(),
+      updateProfile: vi.fn(),
+      changePassword: vi.fn(),
+    },
+    signupService: {
+      signup: vi.fn(),
+    },
+    circleInviteLinkService: {
+      createInviteLink: vi.fn(),
+      getInviteLinkInfo: vi.fn(),
+      redeemInviteLink: vi.fn(),
+    },
+    accessService: {} as Context["accessService"],
+  };
+
+  return { context, mocks: { matchService } };
+};
+
+const baseMatch = () => ({
+  id: matchId("match-1"),
+  circleSessionId: circleSessionId("session-1"),
+  createdAt: new Date("2024-06-01T10:00:00Z"),
+  player1Id: userId("player-1"),
+  player2Id: userId("player-2"),
+  outcome: "P1_WIN" as const,
+  deletedAt: null,
+});
+
+describe("match tRPC ルーター", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  describe("list", () => {
+    test("セッションの全対局一覧を取得できる", async () => {
+      const { context, mocks } = createTestContext();
+      const match = baseMatch();
+      mocks.matchService.listByCircleSessionId.mockResolvedValueOnce([match]);
+
+      const caller = appRouter.createCaller(context);
+      const result = await caller.matches.list({
+        circleSessionId: "session-1",
+      });
+
+      expect(result).toHaveLength(1);
+      expect(result[0].id).toBe("match-1");
+      expect(result[0].player1Id).toBe("player-1");
+      expect(result[0].outcome).toBe("P1_WIN");
+      expect(mocks.matchService.listByCircleSessionId).toHaveBeenCalledWith({
+        actorId: userId("user-1"),
+        circleSessionId: circleSessionId("session-1"),
+      });
+    });
+
+    test("空配列を返す（対局なし）", async () => {
+      const { context, mocks } = createTestContext();
+      mocks.matchService.listByCircleSessionId.mockResolvedValueOnce([]);
+
+      const caller = appRouter.createCaller(context);
+      const result = await caller.matches.list({
+        circleSessionId: "session-1",
+      });
+
+      expect(result).toEqual([]);
+    });
+
+    test("ForbiddenError → FORBIDDEN", async () => {
+      const { context, mocks } = createTestContext();
+      mocks.matchService.listByCircleSessionId.mockRejectedValueOnce(
+        new ForbiddenError(),
+      );
+
+      const caller = appRouter.createCaller(context);
+
+      await expect(
+        caller.matches.list({ circleSessionId: "session-1" }),
+      ).rejects.toMatchObject({ code: "FORBIDDEN" });
+    });
+
+    test("未認証: actorId null → UNAUTHORIZED", async () => {
+      const { context } = createTestContext(null);
+      const caller = appRouter.createCaller(context);
+
+      await expect(
+        caller.matches.list({ circleSessionId: "session-1" }),
+      ).rejects.toMatchObject({ code: "UNAUTHORIZED" });
+    });
+  });
+
+  describe("get", () => {
+    test("対局1件を取得できる", async () => {
+      const { context, mocks } = createTestContext();
+      const match = baseMatch();
+      mocks.matchService.getMatch.mockResolvedValueOnce(match);
+
+      const caller = appRouter.createCaller(context);
+      const result = await caller.matches.get({ matchId: "match-1" });
+
+      expect(result.id).toBe("match-1");
+      expect(result.circleSessionId).toBe("session-1");
+      expect(result.player1Id).toBe("player-1");
+      expect(result.player2Id).toBe("player-2");
+      expect(mocks.matchService.getMatch).toHaveBeenCalledWith({
+        actorId: userId("user-1"),
+        id: matchId("match-1"),
+      });
+    });
+
+    test("存在しない対局 → NOT_FOUND", async () => {
+      const { context, mocks } = createTestContext();
+      mocks.matchService.getMatch.mockResolvedValueOnce(null);
+
+      const caller = appRouter.createCaller(context);
+
+      await expect(
+        caller.matches.get({ matchId: "nonexistent" }),
+      ).rejects.toMatchObject({ code: "NOT_FOUND" });
+    });
+
+    test("ForbiddenError → FORBIDDEN", async () => {
+      const { context, mocks } = createTestContext();
+      mocks.matchService.getMatch.mockRejectedValueOnce(
+        new ForbiddenError(),
+      );
+
+      const caller = appRouter.createCaller(context);
+
+      await expect(
+        caller.matches.get({ matchId: "match-1" }),
+      ).rejects.toMatchObject({ code: "FORBIDDEN" });
+    });
+
+    test("未認証: actorId null → UNAUTHORIZED", async () => {
+      const { context } = createTestContext(null);
+      const caller = appRouter.createCaller(context);
+
+      await expect(
+        caller.matches.get({ matchId: "match-1" }),
+      ).rejects.toMatchObject({ code: "UNAUTHORIZED" });
+    });
+  });
+
+  describe("create", () => {
+    test("対局を作成できる（outcome あり）", async () => {
+      const { context, mocks } = createTestContext();
+      const match = baseMatch();
+      mocks.matchService.recordMatch.mockResolvedValueOnce(match);
+
+      const caller = appRouter.createCaller(context);
+      const result = await caller.matches.create({
+        circleSessionId: "session-1",
+        player1Id: "player-1",
+        player2Id: "player-2",
+        outcome: "P1_WIN",
+      });
+
+      expect(result.id).toBe("match-1");
+      expect(result.outcome).toBe("P1_WIN");
+      expect(mocks.matchService.recordMatch).toHaveBeenCalledWith(
+        expect.objectContaining({
+          actorId: userId("user-1"),
+          circleSessionId: circleSessionId("session-1"),
+          player1Id: userId("player-1"),
+          player2Id: userId("player-2"),
+          outcome: "P1_WIN",
+        }),
+      );
+    });
+
+    test("対局を作成できる（outcome なし）", async () => {
+      const { context, mocks } = createTestContext();
+      const match = { ...baseMatch(), outcome: "UNKNOWN" as const };
+      mocks.matchService.recordMatch.mockResolvedValueOnce(match);
+
+      const caller = appRouter.createCaller(context);
+      const result = await caller.matches.create({
+        circleSessionId: "session-1",
+        player1Id: "player-1",
+        player2Id: "player-2",
+      });
+
+      expect(result.outcome).toBe("UNKNOWN");
+      expect(mocks.matchService.recordMatch).toHaveBeenCalledWith(
+        expect.objectContaining({
+          outcome: undefined,
+        }),
+      );
+    });
+
+    test("ForbiddenError → FORBIDDEN", async () => {
+      const { context, mocks } = createTestContext();
+      mocks.matchService.recordMatch.mockRejectedValueOnce(
+        new ForbiddenError(),
+      );
+
+      const caller = appRouter.createCaller(context);
+
+      await expect(
+        caller.matches.create({
+          circleSessionId: "session-1",
+          player1Id: "player-1",
+          player2Id: "player-2",
+        }),
+      ).rejects.toMatchObject({ code: "FORBIDDEN" });
+    });
+
+    test("BadRequestError（プレイヤー不正）→ BAD_REQUEST", async () => {
+      const { context, mocks } = createTestContext();
+      mocks.matchService.recordMatch.mockRejectedValueOnce(
+        new BadRequestError("Players must be different"),
+      );
+
+      const caller = appRouter.createCaller(context);
+
+      await expect(
+        caller.matches.create({
+          circleSessionId: "session-1",
+          player1Id: "player-1",
+          player2Id: "player-1",
+        }),
+      ).rejects.toMatchObject({ code: "BAD_REQUEST" });
+    });
+
+    test("未認証: actorId null → UNAUTHORIZED", async () => {
+      const { context } = createTestContext(null);
+      const caller = appRouter.createCaller(context);
+
+      await expect(
+        caller.matches.create({
+          circleSessionId: "session-1",
+          player1Id: "player-1",
+          player2Id: "player-2",
+        }),
+      ).rejects.toMatchObject({ code: "UNAUTHORIZED" });
+    });
+  });
+
+  describe("update", () => {
+    test("対局を更新できる（プレイヤー変更）", async () => {
+      const { context, mocks } = createTestContext();
+      const updated = {
+        ...baseMatch(),
+        player1Id: userId("player-3"),
+        player2Id: userId("player-4"),
+      };
+      mocks.matchService.updateMatch.mockResolvedValueOnce(updated);
+
+      const caller = appRouter.createCaller(context);
+      const result = await caller.matches.update({
+        matchId: "match-1",
+        player1Id: "player-3",
+        player2Id: "player-4",
+      });
+
+      expect(result.player1Id).toBe("player-3");
+      expect(result.player2Id).toBe("player-4");
+      expect(mocks.matchService.updateMatch).toHaveBeenCalledWith({
+        actorId: userId("user-1"),
+        id: matchId("match-1"),
+        player1Id: userId("player-3"),
+        player2Id: userId("player-4"),
+        outcome: undefined,
+      });
+    });
+
+    test("対局を更新できる（outcome のみ変更）", async () => {
+      const { context, mocks } = createTestContext();
+      const updated = { ...baseMatch(), outcome: "DRAW" as const };
+      mocks.matchService.updateMatch.mockResolvedValueOnce(updated);
+
+      const caller = appRouter.createCaller(context);
+      const result = await caller.matches.update({
+        matchId: "match-1",
+        outcome: "DRAW",
+      });
+
+      expect(result.outcome).toBe("DRAW");
+      expect(mocks.matchService.updateMatch).toHaveBeenCalledWith({
+        actorId: userId("user-1"),
+        id: matchId("match-1"),
+        player1Id: undefined,
+        player2Id: undefined,
+        outcome: "DRAW",
+      });
+    });
+
+    test("ForbiddenError → FORBIDDEN", async () => {
+      const { context, mocks } = createTestContext();
+      mocks.matchService.updateMatch.mockRejectedValueOnce(
+        new ForbiddenError(),
+      );
+
+      const caller = appRouter.createCaller(context);
+
+      await expect(
+        caller.matches.update({ matchId: "match-1", outcome: "DRAW" }),
+      ).rejects.toMatchObject({ code: "FORBIDDEN" });
+    });
+
+    test("BadRequestError（削除済み対局）→ BAD_REQUEST", async () => {
+      const { context, mocks } = createTestContext();
+      mocks.matchService.updateMatch.mockRejectedValueOnce(
+        new BadRequestError("Match is deleted"),
+      );
+
+      const caller = appRouter.createCaller(context);
+
+      await expect(
+        caller.matches.update({ matchId: "match-1", outcome: "DRAW" }),
+      ).rejects.toMatchObject({ code: "BAD_REQUEST" });
+    });
+
+    test("未認証: actorId null → UNAUTHORIZED", async () => {
+      const { context } = createTestContext(null);
+      const caller = appRouter.createCaller(context);
+
+      await expect(
+        caller.matches.update({ matchId: "match-1", outcome: "DRAW" }),
+      ).rejects.toMatchObject({ code: "UNAUTHORIZED" });
+    });
+  });
+
+  describe("delete", () => {
+    test("対局を論理削除できる", async () => {
+      const { context, mocks } = createTestContext();
+      const deleted = {
+        ...baseMatch(),
+        deletedAt: new Date("2024-06-02T00:00:00Z"),
+      };
+      mocks.matchService.deleteMatch.mockResolvedValueOnce(deleted);
+
+      const caller = appRouter.createCaller(context);
+      const result = await caller.matches.delete({ matchId: "match-1" });
+
+      expect(result.deletedAt).toEqual(new Date("2024-06-02T00:00:00Z"));
+      expect(mocks.matchService.deleteMatch).toHaveBeenCalledWith({
+        actorId: userId("user-1"),
+        id: matchId("match-1"),
+      });
+    });
+
+    test("ForbiddenError → FORBIDDEN", async () => {
+      const { context, mocks } = createTestContext();
+      mocks.matchService.deleteMatch.mockRejectedValueOnce(
+        new ForbiddenError(),
+      );
+
+      const caller = appRouter.createCaller(context);
+
+      await expect(
+        caller.matches.delete({ matchId: "match-1" }),
+      ).rejects.toMatchObject({ code: "FORBIDDEN" });
+    });
+
+    test("BadRequestError（削除済み対局）→ BAD_REQUEST", async () => {
+      const { context, mocks } = createTestContext();
+      mocks.matchService.deleteMatch.mockRejectedValueOnce(
+        new BadRequestError("Match is already deleted"),
+      );
+
+      const caller = appRouter.createCaller(context);
+
+      await expect(
+        caller.matches.delete({ matchId: "match-1" }),
+      ).rejects.toMatchObject({ code: "BAD_REQUEST" });
+    });
+
+    test("未認証: actorId null → UNAUTHORIZED", async () => {
+      const { context } = createTestContext(null);
+      const caller = appRouter.createCaller(context);
+
+      await expect(
+        caller.matches.delete({ matchId: "match-1" }),
+      ).rejects.toMatchObject({ code: "UNAUTHORIZED" });
+    });
+  });
+});

--- a/server/presentation/trpc/routers/user-circle-participation.test.ts
+++ b/server/presentation/trpc/routers/user-circle-participation.test.ts
@@ -1,0 +1,147 @@
+import { beforeEach, describe, expect, test, vi } from "vitest";
+import { appRouter } from "@/server/presentation/trpc/router";
+import type { Context } from "@/server/presentation/trpc/context";
+import { circleId, userId } from "@/server/domain/common/ids";
+import { ForbiddenError } from "@/server/domain/common/errors";
+
+const createTestContext = (
+  actorIdValue: ReturnType<typeof userId> | null = userId("user-1"),
+) => {
+  const circleParticipationService = {
+    listByCircleId: vi.fn(),
+    listByUserId: vi.fn(),
+    addParticipation: vi.fn(),
+    changeParticipationRole: vi.fn(),
+    withdrawParticipation: vi.fn(),
+    removeParticipation: vi.fn(),
+    transferOwnership: vi.fn(),
+  };
+
+  const context: Context = {
+    actorId: actorIdValue,
+    circleService: {
+      getCircle: vi.fn(),
+      createCircle: vi.fn(),
+      renameCircle: vi.fn(),
+      deleteCircle: vi.fn(),
+    },
+    circleParticipationService,
+    circleSessionService: {
+      listByCircleId: vi.fn(),
+      getCircleSession: vi.fn(),
+      createCircleSession: vi.fn(),
+      rescheduleCircleSession: vi.fn(),
+      updateCircleSessionDetails: vi.fn(),
+      deleteCircleSession: vi.fn(),
+    },
+    circleSessionParticipationService: {
+      listParticipations: vi.fn(),
+      listByUserId: vi.fn(),
+      addParticipation: vi.fn(),
+      changeParticipationRole: vi.fn(),
+      removeParticipation: vi.fn(),
+      transferOwnership: vi.fn(),
+      withdrawParticipation: vi.fn(),
+    },
+    matchService: {
+      listByCircleSessionId: vi.fn(),
+      getMatch: vi.fn(),
+      recordMatch: vi.fn(),
+      updateMatch: vi.fn(),
+      deleteMatch: vi.fn(),
+    },
+    matchHistoryService: {
+      listByMatchId: vi.fn(),
+    },
+    userService: {
+      getUser: vi.fn(),
+      listUsers: vi.fn(),
+      getMe: vi.fn(),
+      updateProfile: vi.fn(),
+      changePassword: vi.fn(),
+    },
+    signupService: {
+      signup: vi.fn(),
+    },
+    circleInviteLinkService: {
+      createInviteLink: vi.fn(),
+      getInviteLinkInfo: vi.fn(),
+      redeemInviteLink: vi.fn(),
+    },
+    accessService: {} as Context["accessService"],
+  };
+
+  return { context, mocks: { circleParticipationService } };
+};
+
+describe("userCircleParticipation tRPC ルーター", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  describe("list", () => {
+    test("ユーザーの研究会参加一覧を取得できる", async () => {
+      const { context, mocks } = createTestContext();
+      mocks.circleParticipationService.listByUserId.mockResolvedValueOnce([
+        {
+          circleId: circleId("circle-1"),
+          circleName: "京大将棋研究会",
+          role: "CircleMember",
+        },
+        {
+          circleId: circleId("circle-2"),
+          circleName: "テスト研究会",
+          role: "CircleOwner",
+        },
+      ]);
+
+      const caller = appRouter.createCaller(context);
+      const result = await caller.users.circles.participations.list({});
+
+      expect(result).toHaveLength(2);
+      expect(result[0].circleId).toBe("circle-1");
+      expect(result[0].circleName).toBe("京大将棋研究会");
+      expect(result[0].role).toBe("CircleMember");
+      expect(result[1].circleId).toBe("circle-2");
+      expect(result[1].role).toBe("CircleOwner");
+      expect(
+        mocks.circleParticipationService.listByUserId,
+      ).toHaveBeenCalledWith({
+        actorId: userId("user-1"),
+        userId: userId("user-1"),
+      });
+    });
+
+    test("空配列を返す（参加なし）", async () => {
+      const { context, mocks } = createTestContext();
+      mocks.circleParticipationService.listByUserId.mockResolvedValueOnce([]);
+
+      const caller = appRouter.createCaller(context);
+      const result = await caller.users.circles.participations.list({});
+
+      expect(result).toEqual([]);
+    });
+
+    test("ForbiddenError → FORBIDDEN", async () => {
+      const { context, mocks } = createTestContext();
+      mocks.circleParticipationService.listByUserId.mockRejectedValueOnce(
+        new ForbiddenError(),
+      );
+
+      const caller = appRouter.createCaller(context);
+
+      await expect(
+        caller.users.circles.participations.list({}),
+      ).rejects.toMatchObject({ code: "FORBIDDEN" });
+    });
+
+    test("未認証: actorId null → UNAUTHORIZED", async () => {
+      const { context } = createTestContext(null);
+      const caller = appRouter.createCaller(context);
+
+      await expect(
+        caller.users.circles.participations.list({}),
+      ).rejects.toMatchObject({ code: "UNAUTHORIZED" });
+    });
+  });
+});

--- a/server/presentation/trpc/routers/user-circle-session-participation.test.ts
+++ b/server/presentation/trpc/routers/user-circle-session-participation.test.ts
@@ -1,0 +1,187 @@
+import { beforeEach, describe, expect, test, vi } from "vitest";
+import { appRouter } from "@/server/presentation/trpc/router";
+import type { Context } from "@/server/presentation/trpc/context";
+import { circleId, circleSessionId, userId } from "@/server/domain/common/ids";
+import { ForbiddenError } from "@/server/domain/common/errors";
+
+const createTestContext = (
+  actorIdValue: ReturnType<typeof userId> | null = userId("user-1"),
+) => {
+  const circleSessionParticipationService = {
+    listParticipations: vi.fn(),
+    listByUserId: vi.fn(),
+    addParticipation: vi.fn(),
+    changeParticipationRole: vi.fn(),
+    removeParticipation: vi.fn(),
+    transferOwnership: vi.fn(),
+    withdrawParticipation: vi.fn(),
+  };
+
+  const context: Context = {
+    actorId: actorIdValue,
+    circleService: {
+      getCircle: vi.fn(),
+      createCircle: vi.fn(),
+      renameCircle: vi.fn(),
+      deleteCircle: vi.fn(),
+    },
+    circleParticipationService: {
+      listByCircleId: vi.fn(),
+      listByUserId: vi.fn(),
+      addParticipation: vi.fn(),
+      changeParticipationRole: vi.fn(),
+      withdrawParticipation: vi.fn(),
+      removeParticipation: vi.fn(),
+      transferOwnership: vi.fn(),
+    },
+    circleSessionService: {
+      listByCircleId: vi.fn(),
+      getCircleSession: vi.fn(),
+      createCircleSession: vi.fn(),
+      rescheduleCircleSession: vi.fn(),
+      updateCircleSessionDetails: vi.fn(),
+      deleteCircleSession: vi.fn(),
+    },
+    circleSessionParticipationService,
+    matchService: {
+      listByCircleSessionId: vi.fn(),
+      getMatch: vi.fn(),
+      recordMatch: vi.fn(),
+      updateMatch: vi.fn(),
+      deleteMatch: vi.fn(),
+    },
+    matchHistoryService: {
+      listByMatchId: vi.fn(),
+    },
+    userService: {
+      getUser: vi.fn(),
+      listUsers: vi.fn(),
+      getMe: vi.fn(),
+      updateProfile: vi.fn(),
+      changePassword: vi.fn(),
+    },
+    signupService: {
+      signup: vi.fn(),
+    },
+    circleInviteLinkService: {
+      createInviteLink: vi.fn(),
+      getInviteLinkInfo: vi.fn(),
+      redeemInviteLink: vi.fn(),
+    },
+    accessService: {} as Context["accessService"],
+  };
+
+  return { context, mocks: { circleSessionParticipationService } };
+};
+
+const baseSummary = (overrides?: Record<string, unknown>) => ({
+  circleSessionId: circleSessionId("session-1"),
+  circleId: circleId("circle-1"),
+  circleName: "京大将棋研究会",
+  title: "第1回例会",
+  startsAt: new Date("2024-06-01T13:00:00Z"),
+  endsAt: new Date("2024-06-01T17:00:00Z"),
+  location: "部室",
+  ...overrides,
+});
+
+describe("userCircleSessionParticipation tRPC ルーター", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  describe("list", () => {
+    test("ユーザーのセッション参加一覧を取得できる（limit 指定あり）", async () => {
+      const { context, mocks } = createTestContext();
+      mocks.circleSessionParticipationService.listByUserId.mockResolvedValueOnce(
+        [baseSummary()],
+      );
+
+      const caller = appRouter.createCaller(context);
+      const result =
+        await caller.users.circleSessions.participations.list({ limit: 5 });
+
+      expect(result).toHaveLength(1);
+      expect(result[0].circleSessionId).toBe("session-1");
+      expect(result[0].circleId).toBe("circle-1");
+      expect(result[0].circleName).toBe("京大将棋研究会");
+      expect(result[0].title).toBe("第1回例会");
+      expect(result[0].location).toBe("部室");
+      expect(
+        mocks.circleSessionParticipationService.listByUserId,
+      ).toHaveBeenCalledWith({
+        actorId: userId("user-1"),
+        userId: userId("user-1"),
+        limit: 5,
+      });
+    });
+
+    test("ユーザーのセッション参加一覧を取得できる（limit 省略）", async () => {
+      const { context, mocks } = createTestContext();
+      mocks.circleSessionParticipationService.listByUserId.mockResolvedValueOnce(
+        [baseSummary()],
+      );
+
+      const caller = appRouter.createCaller(context);
+      const result =
+        await caller.users.circleSessions.participations.list({});
+
+      expect(result).toHaveLength(1);
+      expect(
+        mocks.circleSessionParticipationService.listByUserId,
+      ).toHaveBeenCalledWith({
+        actorId: userId("user-1"),
+        userId: userId("user-1"),
+        limit: undefined,
+      });
+    });
+
+    test("空配列を返す（参加なし）", async () => {
+      const { context, mocks } = createTestContext();
+      mocks.circleSessionParticipationService.listByUserId.mockResolvedValueOnce(
+        [],
+      );
+
+      const caller = appRouter.createCaller(context);
+      const result =
+        await caller.users.circleSessions.participations.list({});
+
+      expect(result).toEqual([]);
+    });
+
+    test("location が null の場合も正しく返す", async () => {
+      const { context, mocks } = createTestContext();
+      mocks.circleSessionParticipationService.listByUserId.mockResolvedValueOnce(
+        [baseSummary({ location: null })],
+      );
+
+      const caller = appRouter.createCaller(context);
+      const result =
+        await caller.users.circleSessions.participations.list({});
+
+      expect(result[0].location).toBeNull();
+    });
+
+    test("ForbiddenError → FORBIDDEN", async () => {
+      const { context, mocks } = createTestContext();
+      mocks.circleSessionParticipationService.listByUserId.mockRejectedValueOnce(
+        new ForbiddenError(),
+      );
+
+      const caller = appRouter.createCaller(context);
+
+      await expect(
+        caller.users.circleSessions.participations.list({}),
+      ).rejects.toMatchObject({ code: "FORBIDDEN" });
+    });
+
+    test("未認証: actorId null → UNAUTHORIZED", async () => {
+      const { context } = createTestContext(null);
+      const caller = appRouter.createCaller(context);
+
+      await expect(
+        caller.users.circleSessions.participations.list({}),
+      ).rejects.toMatchObject({ code: "UNAUTHORIZED" });
+    });
+  });
+});


### PR DESCRIPTION
## Summary

Closes #476

- `match.test.ts`: matchRouter の全5 procedure（list, get, create, update, delete）に対するテスト22件を追加
- `user-circle-participation.test.ts`: userCircleParticipationRouter（list）に対するテスト4件を追加
- `user-circle-session-participation.test.ts`: userCircleSessionParticipationRouter（list）に対するテスト6件を追加

各テストは正常系・異常系・未認証アクセスをカバーし、既存テスト（`user.test.ts`）のパターンに従っています。

## Test plan

- [x] `npm run test:run -- server/presentation/trpc/routers/match.test.ts` — 22 tests passed
- [x] `npm run test:run -- server/presentation/trpc/routers/user-circle-participation.test.ts` — 4 tests passed
- [x] `npm run test:run -- server/presentation/trpc/routers/user-circle-session-participation.test.ts` — 6 tests passed
- [x] `npm run test:run` — Full suite 677 tests passed, 0 failures
- [x] `npx tsc --noEmit` — 型エラーなし
- [x] `npm run lint` — 新規ファイルに警告・エラーなし

## Review points

- テストパターンが `user.test.ts` と一貫しているか
- Branded Type（`userId()`, `matchId()` 等）の使用が正しいか
- verify.md の Minor 発見事項2件は follow-up issue として作成済み: #478, #479

🤖 Generated with [Claude Code](https://claude.com/claude-code)