### PR TITLE
refactor(trpc): matchRouter.get の NOT_FOUND エラーを NotFoundError に置換

### DIFF
--- a/server/presentation/trpc/routers/match.ts
+++ b/server/presentation/trpc/routers/match.ts
@@ -1,4 +1,5 @@
 import { randomUUID } from "crypto";
+import { NotFoundError } from "@/server/domain/common/errors";
 import { matchId } from "@/server/domain/common/ids";
 import {
   matchCreateInputSchema,
@@ -40,7 +41,7 @@ export const matchRouter = router({
           id: input.matchId,
         });
         if (!match) {
-          throw new Error("Match not found");
+          throw new NotFoundError("Match");
         }
         return toMatchDto(match);
       }),


### PR DESCRIPTION
## Summary

- `matchRouter.get` で `throw new Error("Match not found")` を `throw new NotFoundError("Match")` に変更
- `toTrpcError` のフォールバック文字列マッチ依存を排除し、型安全な `DomainError` パスを使用

Closes #479

## Verification

- [x] `npm run test:run -- server/presentation/trpc/routers/match.test.ts` — 22 tests passed
- [x] `npx tsc --noEmit` — 型エラーなし
- [x] クライアント側は `code: "NOT_FOUND"` で判定しており、メッセージ文字列に依存していないことを確認

## Review points

- エラーメッセージが `"Resource not found"` → `"Match not found"` に変わるが、エンドポイント名から推測可能な情報のみであり問題なし
- 残りのルーター・サービス層の移行は #481 で対応

🤖 Generated with [Claude Code](https://claude.com/claude-code)