### PR TITLE
refactor: throw new Error("... not found") を NotFoundError に統一 (#481)

### DIFF
--- a/server/domain/services/authz/ownership.test.ts
+++ b/server/domain/services/authz/ownership.test.ts
@@ -85,7 +85,7 @@ describe("Owner の不変条件", () => {
         userId("user-1"),
         userId("user-2"),
       ),
-    ).toThrow("Target member not found");
+    ).toThrow("TargetMember not found");
   });
 
   test("transferCircleOwnership は同一ユーザーへの移譲を拒否する", () => {
@@ -211,7 +211,7 @@ describe("Owner の不変条件", () => {
         userId("user-1"),
         userId("user-2"),
       ),
-    ).toThrow("Target member not found");
+    ).toThrow("TargetMember not found");
   });
 });
 

--- a/server/domain/services/authz/ownership.ts
+++ b/server/domain/services/authz/ownership.ts
@@ -1,4 +1,4 @@
-import { ForbiddenError } from "@/server/domain/common/errors";
+import { ForbiddenError, NotFoundError } from "@/server/domain/common/errors";
 import type { UserId } from "@/server/domain/common/ids";
 import { assertDifferentIds } from "@/server/domain/common/validation";
 import {
@@ -81,7 +81,7 @@ export const transferCircleOwnership = (
 
   const target = members.find((member) => member.userId === toUserId);
   if (!target) {
-    throw new Error("Target member not found");
+    throw new NotFoundError("TargetMember");
   }
 
   const updated = members.map((member) => {
@@ -172,7 +172,7 @@ export const transferCircleSessionOwnership = (
 
   const target = members.find((member) => member.userId === toUserId);
   if (!target) {
-    throw new Error("Target member not found");
+    throw new NotFoundError("TargetMember");
   }
 
   const updated = members.map((member) => {

--- a/server/infrastructure/repository/circle-session/prisma-circle-session-participation-repository.ts
+++ b/server/infrastructure/repository/circle-session/prisma-circle-session-participation-repository.ts
@@ -7,6 +7,7 @@ import {
 } from "@/server/infrastructure/mappers/circle-session-participation-mapper";
 import type { CircleSessionRole } from "@/server/domain/services/authz/roles";
 import type { CircleSessionParticipation } from "@/server/domain/models/circle-session/circle-session-participation";
+import { NotFoundError } from "@/server/domain/common/errors";
 import {
   toPersistenceId,
   toPersistenceIds,
@@ -87,7 +88,7 @@ export const createPrismaCircleSessionParticipationRepository = (
       data: { role: persistedRole },
     });
     if (result.count === 0) {
-      throw new Error("CircleSessionMembership not found");
+      throw new NotFoundError("CircleSessionMembership");
     }
   },
 
@@ -128,7 +129,7 @@ export const createPrismaCircleSessionParticipationRepository = (
       data: { deletedAt: new Date() },
     });
     if (result.count === 0) {
-      throw new Error("CircleSessionMembership not found");
+      throw new NotFoundError("CircleSessionMembership");
     }
   },
 });

--- a/server/infrastructure/repository/circle/prisma-circle-participation-repository.ts
+++ b/server/infrastructure/repository/circle/prisma-circle-participation-repository.ts
@@ -7,6 +7,7 @@ import {
   mapCircleParticipationFromPersistence,
   mapCircleRoleToPersistence,
 } from "@/server/infrastructure/mappers/circle-participation-mapper";
+import { NotFoundError } from "@/server/domain/common/errors";
 import { toPersistenceId } from "@/server/infrastructure/common/id-utils";
 
 export const createPrismaCircleParticipationRepository = (
@@ -79,7 +80,7 @@ export const createPrismaCircleParticipationRepository = (
       data: { role: persistedRole },
     });
     if (result.count === 0) {
-      throw new Error("CircleMembership not found");
+      throw new NotFoundError("CircleMembership");
     }
   },
 
@@ -96,7 +97,7 @@ export const createPrismaCircleParticipationRepository = (
       data: { deletedAt: new Date() },
     });
     if (result.count === 0) {
-      throw new Error("CircleMembership not found");
+      throw new NotFoundError("CircleMembership");
     }
   },
 });

--- a/server/presentation/trpc/errors.test.ts
+++ b/server/presentation/trpc/errors.test.ts
@@ -87,11 +87,13 @@ describe("toTrpcError", () => {
       expect(result.code).toBe("FORBIDDEN");
     });
 
-    test('"xxx not found" -> NOT_FOUND（生メッセージは漏洩しない）', () => {
+    test('"xxx not found" -> INTERNAL_SERVER_ERROR（フォールバック削除済み）', () => {
+      const spy = vi.spyOn(console, "error").mockImplementation(() => {});
       const result = toTrpcError(new Error("User cid_secret not found"));
-      expect(result.code).toBe("NOT_FOUND");
-      expect(result.message).toBe("Resource not found");
+      expect(result.code).toBe("INTERNAL_SERVER_ERROR");
+      expect(result.message).toBe("Internal server error");
       expect(result.message).not.toContain("cid_secret");
+      spy.mockRestore();
     });
   });
 

--- a/server/presentation/trpc/errors.ts
+++ b/server/presentation/trpc/errors.ts
@@ -23,7 +23,7 @@ export const toTrpcError = (error: unknown): TRPCError => {
     return new TRPCError({ code: error.code, message: error.message });
   }
 
-  // フォールバック（移行期間中の互換性維持）
+  // フォールバック（移行期間中の互換性維持: Unauthorized, Forbidden）
   const message = toMessage(error);
 
   if (message === "Unauthorized") {
@@ -32,10 +32,6 @@ export const toTrpcError = (error: unknown): TRPCError => {
 
   if (message === "Forbidden") {
     return new TRPCError({ code: "FORBIDDEN", message });
-  }
-
-  if (message.endsWith("not found")) {
-    return new TRPCError({ code: "NOT_FOUND", message: "Resource not found" });
   }
 
   console.error("Unhandled error in tRPC handler:", error);

--- a/server/presentation/trpc/routers/circle-session.ts
+++ b/server/presentation/trpc/routers/circle-session.ts
@@ -14,6 +14,7 @@ import {
   toCircleSessionDtos,
 } from "@/server/presentation/mappers/circle-session-mapper";
 import { circleSessionParticipationRouter } from "@/server/presentation/trpc/routers/circle-session-participation";
+import { NotFoundError } from "@/server/domain/common/errors";
 import { handleTrpcError } from "@/server/presentation/trpc/errors";
 import { protectedProcedure, router } from "@/server/presentation/trpc/trpc";
 
@@ -41,7 +42,7 @@ export const circleSessionRouter = router({
           input.circleSessionId,
         );
         if (!session) {
-          throw new Error("CircleSession not found");
+          throw new NotFoundError("CircleSession");
         }
         return toCircleSessionDto(session);
       }),

--- a/server/presentation/trpc/routers/circle.ts
+++ b/server/presentation/trpc/routers/circle.ts
@@ -11,6 +11,7 @@ import {
 import { circleParticipationRouter } from "@/server/presentation/trpc/routers/circle-participation";
 import { circleInviteLinkRouter } from "@/server/presentation/trpc/routers/circle-invite-link";
 import { toCircleDto } from "@/server/presentation/mappers/circle-mapper";
+import { NotFoundError } from "@/server/domain/common/errors";
 import { handleTrpcError } from "@/server/presentation/trpc/errors";
 import { protectedProcedure, router } from "@/server/presentation/trpc/trpc";
 
@@ -25,7 +26,7 @@ export const circleRouter = router({
           input.circleId,
         );
         if (!circle) {
-          throw new Error("Circle not found");
+          throw new NotFoundError("Circle");
         }
         return toCircleDto(circle);
       }),

--- a/server/presentation/trpc/routers/user.ts
+++ b/server/presentation/trpc/routers/user.ts
@@ -11,6 +11,7 @@ import {
   toUserDto,
   toUserDtos,
 } from "@/server/presentation/mappers/user-mapper";
+import { NotFoundError } from "@/server/domain/common/errors";
 import { handleTrpcError } from "@/server/presentation/trpc/errors";
 import { protectedProcedure, router } from "@/server/presentation/trpc/trpc";
 import { userCircleRouter } from "@/server/presentation/trpc/routers/user-circle";
@@ -25,7 +26,7 @@ export const userRouter = router({
       handleTrpcError(async () => {
         const user = await ctx.userService.getUser(ctx.actorId, input.userId);
         if (!user) {
-          throw new Error("User not found");
+          throw new NotFoundError("User");
         }
         return toUserDto(user);
       }),


### PR DESCRIPTION
## Summary

- 全9箇所の `throw new Error("... not found")` を `NotFoundError` に置換
- `toTrpcError` の `message.endsWith("not found")` フォールバックを削除し、生エラーメッセージのクライアント漏洩経路を排除
- テストを更新してフォールバック削除後の挙動を検証

Closes #481

## 変更箇所

| レイヤー | ファイル | 変更内容 |
|---------|---------|---------|
| Presentation | `circle.ts`, `circle-session.ts`, `user.ts` | `throw new Error` → `NotFoundError` |
| Domain | `ownership.ts` | `throw new Error("Target member not found")` → `NotFoundError("TargetMember")` |
| Infrastructure | `prisma-circle-participation-repository.ts`, `prisma-circle-session-participation-repository.ts` | `throw new Error` → `NotFoundError` |
| Presentation | `errors.ts` | `message.endsWith("not found")` フォールバック削除 |
| Test | `errors.test.ts`, `ownership.test.ts` | テスト更新 |

## Verification

- `npx tsc --noEmit`: 型チェック通過
- `npm run test:run`: 全677テスト通過
- `npx vitest run server/presentation/trpc/errors.test.ts`: 15テスト通過
- production コードに `throw new Error("...not found")` パターンの残存なしを grep 確認

## Follow-up

- #483: `Unauthorized`/`Forbidden` のフォールバック文字列マッチングも同様に統一する

🤖 Generated with [Claude Code](https://claude.com/claude-code)