### PR TITLE
refactor(trpc): Unauthorized/Forbidden 文字列マッチングフォールバックを削除 (#483)

### DIFF
--- a/server/presentation/trpc/errors.test.ts
+++ b/server/presentation/trpc/errors.test.ts
@@ -76,18 +76,8 @@ describe("toTrpcError", () => {
     });
   });
 
-  describe("フォールバック文字列マッチ", () => {
-    test('"Unauthorized" -> UNAUTHORIZED', () => {
-      const result = toTrpcError(new Error("Unauthorized"));
-      expect(result.code).toBe("UNAUTHORIZED");
-    });
-
-    test('"Forbidden" -> FORBIDDEN', () => {
-      const result = toTrpcError(new Error("Forbidden"));
-      expect(result.code).toBe("FORBIDDEN");
-    });
-
-    test('"xxx not found" -> INTERNAL_SERVER_ERROR（フォールバック削除済み）', () => {
+  describe("未分類エラーのフォールバック", () => {
+    test('"xxx not found" 文字列エラーは INTERNAL_SERVER_ERROR になる', () => {
       const spy = vi.spyOn(console, "error").mockImplementation(() => {});
       const result = toTrpcError(new Error("User cid_secret not found"));
       expect(result.code).toBe("INTERNAL_SERVER_ERROR");
@@ -95,9 +85,7 @@ describe("toTrpcError", () => {
       expect(result.message).not.toContain("cid_secret");
       spy.mockRestore();
     });
-  });
 
-  describe("未分類エラーのフォールバック", () => {
     test("生メッセージが漏洩せず INTERNAL_SERVER_ERROR が返る", () => {
       const spy = vi.spyOn(console, "error").mockImplementation(() => {});
       const original = new Error("DB connection failed: host=secret-db");

--- a/server/presentation/trpc/errors.ts
+++ b/server/presentation/trpc/errors.ts
@@ -1,9 +1,6 @@
 import { TRPCError } from "@trpc/server";
 import { DomainError } from "@/server/domain/common/errors";
 
-const toMessage = (error: unknown): string =>
-  error instanceof Error ? error.message : "Unknown error";
-
 export const toTrpcError = (error: unknown): TRPCError => {
   if (error instanceof TRPCError) {
     if (error.code === "INTERNAL_SERVER_ERROR") {
@@ -21,17 +18,6 @@ export const toTrpcError = (error: unknown): TRPCError => {
   // Do not include dynamic data (IDs, emails, SQL, etc.) in DomainError messages.
   if (error instanceof DomainError) {
     return new TRPCError({ code: error.code, message: error.message });
-  }
-
-  // フォールバック（移行期間中の互換性維持: Unauthorized, Forbidden）
-  const message = toMessage(error);
-
-  if (message === "Unauthorized") {
-    return new TRPCError({ code: "UNAUTHORIZED", message });
-  }
-
-  if (message === "Forbidden") {
-    return new TRPCError({ code: "FORBIDDEN", message });
   }
 
   console.error("Unhandled error in tRPC handler:", error);

--- a/server/presentation/trpc/router.test.ts
+++ b/server/presentation/trpc/router.test.ts
@@ -12,6 +12,7 @@ import {
   CircleRole,
   CircleSessionRole,
 } from "@/server/domain/services/authz/roles";
+import { ForbiddenError } from "@/server/domain/common/errors";
 
 const createContext = () => {
   const circleService = {
@@ -258,7 +259,7 @@ describe("tRPC router", () => {
   test("circles.delete は権限エラーで FORBIDDEN", async () => {
     const { context, mocks } = createContext();
     mocks.circleService.deleteCircle.mockRejectedValueOnce(
-      new Error("Forbidden"),
+      new ForbiddenError(),
     );
 
     const caller = appRouter.createCaller(context);

--- a/server/presentation/trpc/routers/circle-invite-link.test.ts
+++ b/server/presentation/trpc/routers/circle-invite-link.test.ts
@@ -7,6 +7,7 @@ import {
   inviteLinkToken,
   userId,
 } from "@/server/domain/common/ids";
+import { ForbiddenError } from "@/server/domain/common/errors";
 
 const TEST_TOKEN_UUID = "550e8400-e29b-41d4-a716-446655440000";
 
@@ -168,7 +169,7 @@ describe("circleInviteLink tRPC ルーター", () => {
   test("circles.inviteLinks.create はエラー時に適切なTRPCエラーを返す", async () => {
     const { context, mocks } = createTestContext();
     mocks.circleInviteLinkService.createInviteLink.mockRejectedValueOnce(
-      new Error("Forbidden"),
+      new ForbiddenError(),
     );
 
     const caller = appRouter.createCaller(context);


### PR DESCRIPTION
## Summary

- `toTrpcError` から `"Unauthorized"` / `"Forbidden"` の文字列マッチングフォールバックを削除
- 未使用の `toMessage` ヘルパー関数を削除
- テストモック内の `new Error("Forbidden")` を `ForbiddenError()` に置換
- フォールバック文字列マッチのテストを削除し、未分類エラーテストに統合

Closes #483

## 変更ファイル

| ファイル | 変更内容 |
|---------|---------|
| `errors.ts` | フォールバック分岐 (L29-35) と `toMessage` ヘルパーを削除 |
| `errors.test.ts` | フォールバックテストを削除、未分類エラーの describe に統合 |
| `router.test.ts` | モックを `new Error("Forbidden")` → `ForbiddenError()` に置換 |
| `circle-invite-link.test.ts` | 同上 |

## 検証方法

- 全 675 テスト (61 ファイル) パス
- `npx tsc --noEmit` エラーなし
- `server/` 内に `throw new Error("Unauthorized")` / `throw new Error("Forbidden")` が 0 件であることを grep 確認済み

## レビューポイント

- フォールバック削除後、`DomainError` でない `"Unauthorized"` / `"Forbidden"` エラーは `INTERNAL_SERVER_ERROR` になるが、本番コードに該当パターンは 0 件のためリグレッションリスクなし

🤖 Generated with [Claude Code](https://claude.com/claude-code)