### PR TITLE
refactor: 祝日プロバイダーのレイヤー依存方向を修正

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -108,17 +108,6 @@ const eslintConfig = defineConfig([
       "no-restricted-imports": "off",
     },
   },
-  // TODO: #455 — holiday provider の DI 化後に削除
-  {
-    files: [
-      "server/presentation/providers/home-provider.ts",
-      "server/presentation/providers/circle-overview-provider.ts",
-      "server/presentation/trpc/routers/holiday.ts",
-    ],
-    rules: {
-      "no-restricted-imports": "off",
-    },
-  },
   // infrastructure: no importing presentation, application
   {
     files: ["server/infrastructure/**/*.{ts,tsx}"],
@@ -134,12 +123,13 @@ const eslintConfig = defineConfig([
       ],
     },
   },
-  // infrastructure exception: application/common（port 定義 — RateLimiter, UnitOfWork）の import を許可
+  // infrastructure exception: application/common（port 定義 — RateLimiter, UnitOfWork, HolidayProvider）の import を許可
   {
     files: [
       "server/infrastructure/rate-limit/**/*.{ts,tsx}",
       "server/infrastructure/transaction/**/*.{ts,tsx}",
       "server/infrastructure/auth/**/*.{ts,tsx}",
+      "server/infrastructure/holiday/**/*.{ts,tsx}",
     ],
     rules: {
       "no-restricted-imports": [

--- a/server/application/common/holiday-provider.ts
+++ b/server/application/common/holiday-provider.ts
@@ -1,0 +1,6 @@
+export type HolidayProvider = {
+  /** 指定期間内の祝日を "YYYY-MM-DD" 形式の文字列配列で返す */
+  getHolidayDateStrings(start: Date, end: Date): string[];
+  /** 現在年 ± offsetYears 年分の祝日を返す */
+  getHolidayDateStringsForRange(offsetYears?: number): string[];
+};

--- a/server/application/service-container.test.ts
+++ b/server/application/service-container.test.ts
@@ -100,6 +100,10 @@ describe("Service container", () => {
       signupRepository,
       circleInviteLinkRepository,
       passwordUtils: { hash: vi.fn(), verify: vi.fn() },
+      holidayProvider: {
+        getHolidayDateStrings: vi.fn(),
+        getHolidayDateStringsForRange: vi.fn(),
+      },
       generateMatchHistoryId: () => matchHistoryId("history-1"),
     });
 
@@ -113,6 +117,7 @@ describe("Service container", () => {
     expect(container.matchHistoryService).toBeDefined();
     expect(container.signupService).toBeDefined();
     expect(container.circleInviteLinkService).toBeDefined();
+    expect(container.holidayProvider).toBeDefined();
 
     circleRepository.findById.mockResolvedValueOnce(null);
     await expect(

--- a/server/application/service-container.ts
+++ b/server/application/service-container.ts
@@ -23,6 +23,7 @@ import type { UserRepository } from "@/server/domain/models/user/user-repository
 import type { SignupRepository } from "@/server/domain/models/user/signup-repository";
 import type { CircleInviteLinkRepository } from "@/server/domain/models/circle/circle-invite-link-repository";
 import type { PasswordUtils } from "@/server/application/user/user-service";
+import type { HolidayProvider } from "@/server/application/common/holiday-provider";
 
 export type ServiceContainer = {
   circleService: ReturnType<typeof createCircleService>;
@@ -39,6 +40,7 @@ export type ServiceContainer = {
   matchHistoryService: ReturnType<typeof createMatchHistoryService>;
   signupService: ReturnType<typeof createSignupService>;
   circleInviteLinkService: ReturnType<typeof createCircleInviteLinkService>;
+  holidayProvider: HolidayProvider;
 };
 
 export type ServiceContainerDeps = {
@@ -53,6 +55,7 @@ export type ServiceContainerDeps = {
   signupRepository: SignupRepository;
   circleInviteLinkRepository: CircleInviteLinkRepository;
   passwordUtils: PasswordUtils;
+  holidayProvider: HolidayProvider;
   generateMatchHistoryId?: () => ReturnType<typeof matchHistoryId>;
   unitOfWork?: UnitOfWork;
 };
@@ -127,5 +130,6 @@ export const createServiceContainer = (
       circleParticipationRepository: deps.circleParticipationRepository,
       accessService,
     }),
+    holidayProvider: deps.holidayProvider,
   };
 };

--- a/server/infrastructure/holiday/japanese-holiday-provider.test.ts
+++ b/server/infrastructure/holiday/japanese-holiday-provider.test.ts
@@ -1,9 +1,11 @@
 import { describe, expect, it } from "vitest";
-import { getHolidayDateStrings } from "./japanese-holiday-provider";
+import { createJapaneseHolidayProvider } from "./japanese-holiday-provider";
+
+const provider = createJapaneseHolidayProvider();
 
 describe("getHolidayDateStrings", () => {
   it("元日（1月1日）を含む", () => {
-    const result = getHolidayDateStrings(
+    const result = provider.getHolidayDateStrings(
       new Date(2026, 0, 1),
       new Date(2026, 0, 31),
     );
@@ -11,7 +13,7 @@ describe("getHolidayDateStrings", () => {
   });
 
   it("建国記念の日（2月11日）を含む", () => {
-    const result = getHolidayDateStrings(
+    const result = provider.getHolidayDateStrings(
       new Date(2026, 1, 1),
       new Date(2026, 1, 28),
     );
@@ -20,7 +22,7 @@ describe("getHolidayDateStrings", () => {
 
   it("平日のみの期間は空配列を返す", () => {
     // 2026-02-16（月）〜2026-02-20（金）は祝日なし
-    const result = getHolidayDateStrings(
+    const result = provider.getHolidayDateStrings(
       new Date(2026, 1, 16),
       new Date(2026, 1, 20),
     );
@@ -29,7 +31,7 @@ describe("getHolidayDateStrings", () => {
 
   it("振替休日を含む", () => {
     // 2025-02-24 は天皇誕生日(2/23 日曜)の振替休日
-    const result = getHolidayDateStrings(
+    const result = provider.getHolidayDateStrings(
       new Date(2025, 1, 1),
       new Date(2025, 1, 28),
     );
@@ -37,7 +39,7 @@ describe("getHolidayDateStrings", () => {
   });
 
   it("YYYY-MM-DD 形式で返す", () => {
-    const result = getHolidayDateStrings(
+    const result = provider.getHolidayDateStrings(
       new Date(2026, 0, 1),
       new Date(2026, 0, 1),
     );

--- a/server/infrastructure/holiday/japanese-holiday-provider.ts
+++ b/server/infrastructure/holiday/japanese-holiday-provider.ts
@@ -1,9 +1,10 @@
 import holiday_jp from "@holiday-jp/holiday_jp";
+import type { HolidayProvider } from "@/server/application/common/holiday-provider";
 
 /**
  * 指定期間内の日本の祝日を "YYYY-MM-DD" 形式の文字列配列で返す（サーバー専用）
  */
-export function getHolidayDateStrings(start: Date, end: Date): string[] {
+function getHolidayDateStrings(start: Date, end: Date): string[] {
   const holidays = holiday_jp.between(start, end);
   return holidays.map((h) => {
     const d = h.date;
@@ -17,9 +18,14 @@ export function getHolidayDateStrings(start: Date, end: Date): string[] {
 /**
  * 現在年 ± offsetYears 年分の祝日を返す（Provider 用ヘルパー）
  */
-export function getHolidayDateStringsForRange(offsetYears = 1): string[] {
+function getHolidayDateStringsForRange(offsetYears = 1): string[] {
   const now = new Date();
   const start = new Date(now.getFullYear() - offsetYears, 0, 1);
   const end = new Date(now.getFullYear() + offsetYears, 11, 31);
   return getHolidayDateStrings(start, end);
 }
+
+export const createJapaneseHolidayProvider = (): HolidayProvider => ({
+  getHolidayDateStrings,
+  getHolidayDateStringsForRange,
+});

--- a/server/presentation/providers/circle-overview-provider.ts
+++ b/server/presentation/providers/circle-overview-provider.ts
@@ -1,5 +1,4 @@
 import { formatDateTimeRange } from "@/lib/date-utils";
-import { getHolidayDateStringsForRange } from "@/server/infrastructure/holiday/japanese-holiday-provider";
 import { CircleRole } from "@/server/domain/services/authz/roles";
 import { NotFoundError } from "@/server/domain/common/errors";
 import { appRouter } from "@/server/presentation/trpc/router";
@@ -98,7 +97,7 @@ export async function getCircleOverviewViewModel(
       name: userNameById.get(participation.userId) ?? participation.userId,
       role: roleKeyByDto[participation.role] ?? "member",
     })),
-    holidayDates: getHolidayDateStringsForRange(),
+    holidayDates: ctx.holidayProvider.getHolidayDateStringsForRange(),
   };
 
   return overview;

--- a/server/presentation/providers/home-provider.ts
+++ b/server/presentation/providers/home-provider.ts
@@ -1,4 +1,3 @@
-import { getHolidayDateStringsForRange } from "@/server/infrastructure/holiday/japanese-holiday-provider";
 import { appRouter } from "@/server/presentation/trpc/router";
 import { createContext } from "@/server/presentation/trpc/context";
 import type { HomeViewModel } from "@/server/presentation/view-models/home";
@@ -33,6 +32,6 @@ export async function getHomeViewModel(): Promise<HomeViewModel> {
       end: s.endsAt.toISOString(),
       url: `/circle-sessions/${s.circleSessionId}`,
     })),
-    holidayDates: getHolidayDateStringsForRange(),
+    holidayDates: ctx.holidayProvider.getHolidayDateStringsForRange(),
   };
 }

--- a/server/presentation/trpc/context.ts
+++ b/server/presentation/trpc/context.ts
@@ -18,8 +18,10 @@ import {
   hashPassword,
   verifyPassword,
 } from "@/server/infrastructure/auth/password";
+import { createJapaneseHolidayProvider } from "@/server/infrastructure/holiday/japanese-holiday-provider";
 
 const getSession = createGetSession(nextAuthSessionService);
+const japaneseHolidayProvider = createJapaneseHolidayProvider();
 
 const buildServiceContainer = (): ServiceContainer =>
   createServiceContainer({
@@ -35,6 +37,7 @@ const buildServiceContainer = (): ServiceContainer =>
     signupRepository: prismaSignupRepository,
     circleInviteLinkRepository: prismaCircleInviteLinkRepository,
     passwordUtils: { hash: hashPassword, verify: verifyPassword },
+    holidayProvider: japaneseHolidayProvider,
     unitOfWork: prismaUnitOfWork,
   });
 

--- a/server/presentation/trpc/router.test.ts
+++ b/server/presentation/trpc/router.test.ts
@@ -85,6 +85,7 @@ const createContext = () => {
     signupService,
     circleInviteLinkService,
     accessService: {} as Context["accessService"],
+    holidayProvider: {} as Context["holidayProvider"],
   };
 
   return {

--- a/server/presentation/trpc/routers/circle-invite-link.test.ts
+++ b/server/presentation/trpc/routers/circle-invite-link.test.ts
@@ -74,6 +74,7 @@ const createTestContext = () => {
     },
     circleInviteLinkService,
     accessService: {} as Context["accessService"],
+    holidayProvider: {} as Context["holidayProvider"],
   };
 
   return { context, mocks: { circleInviteLinkService } };

--- a/server/presentation/trpc/routers/holiday.ts
+++ b/server/presentation/trpc/routers/holiday.ts
@@ -1,6 +1,5 @@
 import { z } from "zod";
 import { publicProcedure, router } from "@/server/presentation/trpc/trpc";
-import { getHolidayDateStrings } from "@/server/infrastructure/holiday/japanese-holiday-provider";
 
 const MAX_RANGE_MS = 5 * 365.25 * 24 * 60 * 60 * 1000; // ~5年
 
@@ -21,7 +20,7 @@ export const holidayRouter = router({
         ),
     )
     .output(z.array(z.string()))
-    .query(({ input }) => {
-      return getHolidayDateStrings(input.start, input.end);
+    .query(({ input, ctx }) => {
+      return ctx.holidayProvider.getHolidayDateStrings(input.start, input.end);
     }),
 });

--- a/server/presentation/trpc/routers/match.test.ts
+++ b/server/presentation/trpc/routers/match.test.ts
@@ -76,6 +76,7 @@ const createTestContext = (
       redeemInviteLink: vi.fn(),
     },
     accessService: {} as Context["accessService"],
+    holidayProvider: {} as Context["holidayProvider"],
   };
 
   return { context, mocks: { matchService } };

--- a/server/presentation/trpc/routers/user-circle-participation.test.ts
+++ b/server/presentation/trpc/routers/user-circle-participation.test.ts
@@ -69,6 +69,7 @@ const createTestContext = (
       redeemInviteLink: vi.fn(),
     },
     accessService: {} as Context["accessService"],
+    holidayProvider: {} as Context["holidayProvider"],
   };
 
   return { context, mocks: { circleParticipationService } };

--- a/server/presentation/trpc/routers/user-circle-session-participation.test.ts
+++ b/server/presentation/trpc/routers/user-circle-session-participation.test.ts
@@ -69,6 +69,7 @@ const createTestContext = (
       redeemInviteLink: vi.fn(),
     },
     accessService: {} as Context["accessService"],
+    holidayProvider: {} as Context["holidayProvider"],
   };
 
   return { context, mocks: { circleSessionParticipationService } };

--- a/server/presentation/trpc/routers/user.test.ts
+++ b/server/presentation/trpc/routers/user.test.ts
@@ -71,6 +71,7 @@ const createTestContext = (actorIdValue: ReturnType<typeof userId> | null = user
       redeemInviteLink: vi.fn(),
     },
     accessService: {} as Context["accessService"],
+    holidayProvider: {} as Context["holidayProvider"],
   };
 
   return { context, mocks: { userService } };


### PR DESCRIPTION
## Summary

Closes #455

- `HolidayProvider` 型を `application/common/` に定義し、`ServiceContainer` 経由で presentation 層に注入
- presentation 層から infrastructure 層への直接 import を解消し、クリーンアーキテクチャの依存方向に準拠
- bare function export を削除し DI バイパスを防止
- `context.ts` でプロバイダーをシングルトン化

## Test plan

- [x] `npx tsc --noEmit` — 型エラーなし
- [x] `npm run lint` — ESLint エラーなし
- [x] `npm run test:run` — 全テスト通過（675 tests）
- [ ] presentation 層のファイルに `@/server/infrastructure/holiday/` への import がないことを確認

## Related

- Follow-up: #486 (createMockServiceContainer テストヘルパー導入)

🤖 Generated with [Claude Code](https://claude.com/claude-code)