### PR TITLE
test: メンバーシップ論理削除済みユーザーの再加入テストを追加 (#414)

### DIFF
--- a/server/application/circle-session/circle-session-participation-service.test.ts
+++ b/server/application/circle-session/circle-session-participation-service.test.ts
@@ -132,6 +132,34 @@ describe("CircleSession 参加関係サービス", () => {
     ]);
   });
 
+  test("addParticipation は論理削除済みユーザーをセッションに再参加できる", async () => {
+    // listParticipations はアクティブメンバーのみ返す（論理削除済みユーザーは含まれない）
+    vi.mocked(
+      circleSessionParticipationRepository.listParticipations,
+    ).mockResolvedValueOnce([
+      {
+        circleSessionId: circleSessionId("session-1"),
+        userId: userId("user-1"),
+        role: "CircleSessionOwner",
+      },
+    ]);
+
+    await service.addParticipation({
+      actorId: "user-actor",
+      circleSessionId: circleSessionId("session-1"),
+      userId: userId("user-rejoining"),
+      role: "CircleSessionMember",
+    });
+
+    expect(
+      circleSessionParticipationRepository.addParticipation,
+    ).toHaveBeenCalledWith(
+      circleSessionId("session-1"),
+      userId("user-rejoining"),
+      "CircleSessionMember",
+    );
+  });
+
   test("addParticipation は既存メンバーの重複追加で ConflictError", async () => {
     vi.mocked(
       circleSessionParticipationRepository.listParticipations,

--- a/server/application/circle/circle-participation-service.test.ts
+++ b/server/application/circle/circle-participation-service.test.ts
@@ -191,6 +191,35 @@ describe("Circle 参加関係サービス", () => {
     ).rejects.toThrow("Circle not found");
   });
 
+  test("addParticipation は論理削除済みユーザーを再加入できる", async () => {
+    // listByCircleId はアクティブメンバーのみ返す（論理削除済みユーザーは含まれない）
+    vi.mocked(
+      circleParticipationRepository.listByCircleId,
+    ).mockResolvedValueOnce([
+      {
+        circleId: circleId("circle-1"),
+        userId: userId("user-owner"),
+        role: "CircleOwner",
+        createdAt: new Date("2025-01-01T00:00:00Z"),
+      },
+    ]);
+
+    await service.addParticipation({
+      actorId: "user-actor",
+      circleId: circleId("circle-1"),
+      userId: userId("user-rejoining"),
+      role: "CircleMember",
+    });
+
+    expect(
+      circleParticipationRepository.addParticipation,
+    ).toHaveBeenCalledWith(
+      circleId("circle-1"),
+      userId("user-rejoining"),
+      "CircleMember",
+    );
+  });
+
   test("addParticipation は既存メンバーの重複追加で ConflictError", async () => {
     vi.mocked(
       circleParticipationRepository.listByCircleId,


### PR DESCRIPTION
## Summary

- CircleParticipationService に論理削除済みユーザーの再加入テストを追加
- CircleSessionParticipationService に論理削除済みユーザーの再加入テストを追加
- 全 683 テスト PASS 確認済み

Closes #414

## 背景

親 issue #408（メンバーシップ論理削除）のサブ issue #409〜#413 で実装層の変更は完了済み。
本 PR はサービス層の再加入フローに対するテストカバレッジの追加。

## 変更内容

| ファイル | 内容 |
|---|---|
| `circle-participation-service.test.ts` | 論理削除済みユーザーの研究会再加入テスト追加 |
| `circle-session-participation-service.test.ts` | 論理削除済みユーザーのセッション再参加テスト追加 |

## 検証手順

```bash
npm run test:run -- server/application/circle/circle-participation-service.test.ts
npm run test:run -- server/application/circle-session/circle-session-participation-service.test.ts
npm run test:run  # 全テスト
```

## フォローアップ

- #491: addParticipation テストに戻り値アサーションを追加（priority: low）

🤖 Generated with [Claude Code](https://claude.com/claude-code)