### PR TITLE
test: classifyOutcomeForUser のドメイン層ユニットテストを追加

### DIFF
--- a/server/domain/models/match/match.test.ts
+++ b/server/domain/models/match/match.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, test } from "vitest";
 import { circleSessionId, matchId, userId } from "@/server/domain/common/ids";
 import {
+  classifyOutcomeForUser,
   createMatch,
   deleteMatch,
   hasDifferentPlayers,
@@ -170,5 +171,39 @@ describe("Match ドメイン", () => {
 
   test("hasDifferentPlayers は同一プレイヤーで false を返す", () => {
     expect(hasDifferentPlayers(userId("user-1"), userId("user-1"))).toBe(false);
+  });
+
+  describe("classifyOutcomeForUser", () => {
+    test("P1_WIN でプレイヤー1の場合 win を返す", () => {
+      expect(classifyOutcomeForUser("P1_WIN", true)).toBe("win");
+    });
+
+    test("P1_WIN でプレイヤー2の場合 loss を返す", () => {
+      expect(classifyOutcomeForUser("P1_WIN", false)).toBe("loss");
+    });
+
+    test("P2_WIN でプレイヤー1の場合 loss を返す", () => {
+      expect(classifyOutcomeForUser("P2_WIN", true)).toBe("loss");
+    });
+
+    test("P2_WIN でプレイヤー2の場合 win を返す", () => {
+      expect(classifyOutcomeForUser("P2_WIN", false)).toBe("win");
+    });
+
+    test("DRAW でプレイヤー1の場合 draw を返す", () => {
+      expect(classifyOutcomeForUser("DRAW", true)).toBe("draw");
+    });
+
+    test("DRAW でプレイヤー2の場合 draw を返す", () => {
+      expect(classifyOutcomeForUser("DRAW", false)).toBe("draw");
+    });
+
+    test("UNKNOWN でプレイヤー1の場合 null を返す", () => {
+      expect(classifyOutcomeForUser("UNKNOWN", true)).toBeNull();
+    });
+
+    test("UNKNOWN でプレイヤー2の場合 null を返す", () => {
+      expect(classifyOutcomeForUser("UNKNOWN", false)).toBeNull();
+    });
   });
 });


### PR DESCRIPTION
## Summary

Closes #512

- `classifyOutcomeForUser` の全分岐（P1_WIN, P2_WIN, DRAW, UNKNOWN × isPlayer1）に対する直接ユニットテストを追加
- 将来 `MatchOutcome` にバリアントが追加された際の回帰テストとして機能

## Test plan

- [x] `npm run test:run -- server/domain/models/match/match.test.ts` — 全21テストがパス
- [ ] CI の全テストがパスすることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)