### PR TITLE
refactor: listByUserId を listByPlayerId にリネーム

### DIFF
--- a/server/application/match-history/match-history-service.test.ts
+++ b/server/application/match-history/match-history-service.test.ts
@@ -14,7 +14,7 @@ const matchHistoryRepository = {
 const matchRepository = {
   findById: vi.fn(),
   listByCircleSessionId: vi.fn(),
-  listByUserId: vi.fn(),
+  listByPlayerId: vi.fn(),
   listByUserIdWithCircle: vi.fn(),
   save: vi.fn(),
 } satisfies MatchRepository;

--- a/server/application/match/match-service.test.ts
+++ b/server/application/match/match-service.test.ts
@@ -18,7 +18,7 @@ import { createMatch } from "@/server/domain/models/match/match";
 const matchRepository = {
   findById: vi.fn(),
   listByCircleSessionId: vi.fn(),
-  listByUserId: vi.fn(),
+  listByPlayerId: vi.fn(),
   listByUserIdWithCircle: vi.fn(),
   save: vi.fn(),
 } satisfies MatchRepository;
@@ -312,7 +312,7 @@ describe("UnitOfWork 経路", () => {
   const depsMatchRepository = {
     findById: vi.fn(),
     listByCircleSessionId: vi.fn(),
-    listByUserId: vi.fn(),
+    listByPlayerId: vi.fn(),
     listByUserIdWithCircle: vi.fn(),
     save: vi.fn(),
   } satisfies MatchRepository;
@@ -343,7 +343,7 @@ describe("UnitOfWork 経路", () => {
   const uowMatchRepository = {
     findById: vi.fn(),
     listByCircleSessionId: vi.fn(),
-    listByUserId: vi.fn(),
+    listByPlayerId: vi.fn(),
     listByUserIdWithCircle: vi.fn(),
     save: vi.fn(),
   } satisfies MatchRepository;

--- a/server/application/service-container.test.ts
+++ b/server/application/service-container.test.ts
@@ -29,7 +29,7 @@ const createSessionStub = () => ({
 const createMatchStub = () => ({
   findById: vi.fn(),
   listByCircleSessionId: vi.fn(),
-  listByUserId: vi.fn(),
+  listByPlayerId: vi.fn(),
   listByUserIdWithCircle: vi.fn(),
   save: vi.fn(),
 });

--- a/server/application/user/user-statistics-service.test.ts
+++ b/server/application/user/user-statistics-service.test.ts
@@ -13,7 +13,7 @@ import type { MatchWithCircle } from "@/server/domain/models/match/match-read-mo
 const matchRepository = {
   findById: vi.fn(),
   listByCircleSessionId: vi.fn(),
-  listByUserId: vi.fn(),
+  listByPlayerId: vi.fn(),
   listByUserIdWithCircle: vi.fn(),
   save: vi.fn(),
 } satisfies MatchRepository;

--- a/server/domain/models/match/match-repository.ts
+++ b/server/domain/models/match/match-repository.ts
@@ -10,8 +10,8 @@ export type MatchRepository = {
   findById(id: MatchId): Promise<Match | null>;
   /** Returns matches ordered by createdAt ascending. */
   listByCircleSessionId(circleSessionId: CircleSessionId): Promise<Match[]>;
-  /** Returns non-deleted matches where the user is player1 or player2. */
-  listByUserId(userId: UserId): Promise<Match[]>;
+  /** Returns non-deleted matches where the player is player1 or player2. */
+  listByPlayerId(playerId: UserId): Promise<Match[]>;
   /** Returns non-deleted matches with circle info via CircleSession. */
   listByUserIdWithCircle(userId: UserId): Promise<MatchWithCircle[]>;
   save(match: Match): Promise<void>;

--- a/server/infrastructure/repository/match/prisma-match-repository.ts
+++ b/server/infrastructure/repository/match/prisma-match-repository.ts
@@ -36,13 +36,13 @@ export const createPrismaMatchRepository = (
     return matches.map(mapMatchToDomain);
   },
 
-  async listByUserId(userId: UserId): Promise<Match[]> {
+  async listByPlayerId(playerId: UserId): Promise<Match[]> {
     const matches = await client.match.findMany({
       where: {
         deletedAt: null,
         OR: [
-          { player1Id: toPersistenceId(userId) },
-          { player2Id: toPersistenceId(userId) },
+          { player1Id: toPersistenceId(playerId) },
+          { player2Id: toPersistenceId(playerId) },
         ],
       },
       orderBy: { createdAt: "asc" },


### PR DESCRIPTION
## Summary
- `MatchRepository.listByUserId` を `listByPlayerId` にリネーム
- player1/player2 を検索するメソッドであることを名前で明示
- リポジトリインターフェース、Prisma実装、関連テストのモックを一括更新

Closes #506

## 変更ファイル
- `server/domain/models/match/match-repository.ts` — インターフェース定義
- `server/infrastructure/repository/match/prisma-match-repository.ts` — Prisma実装
- `server/application/match-history/match-history-service.test.ts` — テストモック
- `server/application/match/match-service.test.ts` — テストモック
- `server/application/service-container.test.ts` — テストモック
- `server/application/user/user-statistics-service.test.ts` — テストモック

## Test plan
- [x] `npm run test:run` で全テスト通過を確認
- [x] `npx tsc --noEmit` で型エラーがないことを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)