### PR TITLE
refactor: listByUserIdWithCircle を listByPlayerIdWithCircle にリネーム

### DIFF
--- a/server/application/match-history/match-history-service.test.ts
+++ b/server/application/match-history/match-history-service.test.ts
@@ -15,7 +15,7 @@ const matchRepository = {
   findById: vi.fn(),
   listByCircleSessionId: vi.fn(),
   listByPlayerId: vi.fn(),
-  listByUserIdWithCircle: vi.fn(),
+  listByPlayerIdWithCircle: vi.fn(),
   save: vi.fn(),
 } satisfies MatchRepository;
 

--- a/server/application/match/match-service.test.ts
+++ b/server/application/match/match-service.test.ts
@@ -19,7 +19,7 @@ const matchRepository = {
   findById: vi.fn(),
   listByCircleSessionId: vi.fn(),
   listByPlayerId: vi.fn(),
-  listByUserIdWithCircle: vi.fn(),
+  listByPlayerIdWithCircle: vi.fn(),
   save: vi.fn(),
 } satisfies MatchRepository;
 
@@ -313,7 +313,7 @@ describe("UnitOfWork 経路", () => {
     findById: vi.fn(),
     listByCircleSessionId: vi.fn(),
     listByPlayerId: vi.fn(),
-    listByUserIdWithCircle: vi.fn(),
+    listByPlayerIdWithCircle: vi.fn(),
     save: vi.fn(),
   } satisfies MatchRepository;
 
@@ -344,7 +344,7 @@ describe("UnitOfWork 経路", () => {
     findById: vi.fn(),
     listByCircleSessionId: vi.fn(),
     listByPlayerId: vi.fn(),
-    listByUserIdWithCircle: vi.fn(),
+    listByPlayerIdWithCircle: vi.fn(),
     save: vi.fn(),
   } satisfies MatchRepository;
 

--- a/server/application/service-container.test.ts
+++ b/server/application/service-container.test.ts
@@ -30,7 +30,7 @@ const createMatchStub = () => ({
   findById: vi.fn(),
   listByCircleSessionId: vi.fn(),
   listByPlayerId: vi.fn(),
-  listByUserIdWithCircle: vi.fn(),
+  listByPlayerIdWithCircle: vi.fn(),
   save: vi.fn(),
 });
 

--- a/server/application/user/user-statistics-service.test.ts
+++ b/server/application/user/user-statistics-service.test.ts
@@ -14,7 +14,7 @@ const matchRepository = {
   findById: vi.fn(),
   listByCircleSessionId: vi.fn(),
   listByPlayerId: vi.fn(),
-  listByUserIdWithCircle: vi.fn(),
+  listByPlayerIdWithCircle: vi.fn(),
   save: vi.fn(),
 } satisfies MatchRepository;
 
@@ -53,18 +53,18 @@ describe("UserStatisticsService", () => {
 
   describe("getMatchStatisticsAll - total", () => {
     test("対局なしの場合、全て0を返す", async () => {
-      matchRepository.listByUserIdWithCircle.mockResolvedValue([]);
+      matchRepository.listByPlayerIdWithCircle.mockResolvedValue([]);
 
       const result = await service.getMatchStatisticsAll(TARGET_USER);
 
       expect(result.total).toEqual({ wins: 0, losses: 0, draws: 0 });
       expect(
-        matchRepository.listByUserIdWithCircle,
+        matchRepository.listByPlayerIdWithCircle,
       ).toHaveBeenCalledWith(TARGET_USER);
     });
 
     test("player1として勝った場合、winsが1増える", async () => {
-      matchRepository.listByUserIdWithCircle.mockResolvedValue([
+      matchRepository.listByPlayerIdWithCircle.mockResolvedValue([
         createTestMatchWithCircle({
           player1Id: TARGET_USER,
           player2Id: OPPONENT,
@@ -78,7 +78,7 @@ describe("UserStatisticsService", () => {
     });
 
     test("player1として負けた場合、lossesが1増える", async () => {
-      matchRepository.listByUserIdWithCircle.mockResolvedValue([
+      matchRepository.listByPlayerIdWithCircle.mockResolvedValue([
         createTestMatchWithCircle({
           player1Id: TARGET_USER,
           player2Id: OPPONENT,
@@ -92,7 +92,7 @@ describe("UserStatisticsService", () => {
     });
 
     test("player2として勝った場合、winsが1増える", async () => {
-      matchRepository.listByUserIdWithCircle.mockResolvedValue([
+      matchRepository.listByPlayerIdWithCircle.mockResolvedValue([
         createTestMatchWithCircle({
           player1Id: OPPONENT,
           player2Id: TARGET_USER,
@@ -106,7 +106,7 @@ describe("UserStatisticsService", () => {
     });
 
     test("player2として負けた場合、lossesが1増える", async () => {
-      matchRepository.listByUserIdWithCircle.mockResolvedValue([
+      matchRepository.listByPlayerIdWithCircle.mockResolvedValue([
         createTestMatchWithCircle({
           player1Id: OPPONENT,
           player2Id: TARGET_USER,
@@ -120,7 +120,7 @@ describe("UserStatisticsService", () => {
     });
 
     test("引き分けの場合、drawsが1増える", async () => {
-      matchRepository.listByUserIdWithCircle.mockResolvedValue([
+      matchRepository.listByPlayerIdWithCircle.mockResolvedValue([
         createTestMatchWithCircle({ outcome: "DRAW" }),
       ]);
 
@@ -130,7 +130,7 @@ describe("UserStatisticsService", () => {
     });
 
     test("UNKNOWNの対局は集計から除外される", async () => {
-      matchRepository.listByUserIdWithCircle.mockResolvedValue([
+      matchRepository.listByPlayerIdWithCircle.mockResolvedValue([
         createTestMatchWithCircle({ outcome: "UNKNOWN" }),
       ]);
 
@@ -142,7 +142,7 @@ describe("UserStatisticsService", () => {
 
   describe("getMatchStatisticsAll - byCircle", () => {
     test("対局なしの場合、空配列を返す", async () => {
-      matchRepository.listByUserIdWithCircle.mockResolvedValue([]);
+      matchRepository.listByPlayerIdWithCircle.mockResolvedValue([]);
 
       const result = await service.getMatchStatisticsAll(TARGET_USER);
 
@@ -150,7 +150,7 @@ describe("UserStatisticsService", () => {
     });
 
     test("1つの研究会のみの場合、その研究会の統計を返す", async () => {
-      matchRepository.listByUserIdWithCircle.mockResolvedValue([
+      matchRepository.listByPlayerIdWithCircle.mockResolvedValue([
         createTestMatchWithCircle({
           player1Id: TARGET_USER,
           player2Id: OPPONENT,
@@ -181,7 +181,7 @@ describe("UserStatisticsService", () => {
     });
 
     test("複数の研究会にまたがる対局データで正しく集計される", async () => {
-      matchRepository.listByUserIdWithCircle.mockResolvedValue([
+      matchRepository.listByPlayerIdWithCircle.mockResolvedValue([
         // 研究会A: 勝ち
         createTestMatchWithCircle({
           player1Id: TARGET_USER,
@@ -250,7 +250,7 @@ describe("UserStatisticsService", () => {
 
   describe("getMatchStatisticsAll - 統合テスト", () => {
     test("トータルと研究会別が同時に正しく計算される", async () => {
-      matchRepository.listByUserIdWithCircle.mockResolvedValue([
+      matchRepository.listByPlayerIdWithCircle.mockResolvedValue([
         // 研究会A: 勝ち
         createTestMatchWithCircle({
           player1Id: TARGET_USER,
@@ -313,7 +313,7 @@ describe("UserStatisticsService", () => {
 
       // DBクエリは1回のみ
       expect(
-        matchRepository.listByUserIdWithCircle,
+        matchRepository.listByPlayerIdWithCircle,
       ).toHaveBeenCalledTimes(1);
     });
   });

--- a/server/application/user/user-statistics-service.ts
+++ b/server/application/user/user-statistics-service.ts
@@ -20,7 +20,7 @@ export const createUserStatisticsService = (
     byCircle: CircleMatchStatistics[];
   }> {
     const matches =
-      await deps.matchRepository.listByUserIdWithCircle(targetUserId);
+      await deps.matchRepository.listByPlayerIdWithCircle(targetUserId);
 
     const total = { wins: 0, losses: 0, draws: 0 };
     const circleMap = new Map<

--- a/server/domain/models/match/match-repository.ts
+++ b/server/domain/models/match/match-repository.ts
@@ -13,6 +13,6 @@ export type MatchRepository = {
   /** Returns non-deleted matches where the player is player1 or player2. */
   listByPlayerId(playerId: UserId): Promise<Match[]>;
   /** Returns non-deleted matches with circle info via CircleSession. */
-  listByUserIdWithCircle(userId: UserId): Promise<MatchWithCircle[]>;
+  listByPlayerIdWithCircle(playerId: UserId): Promise<MatchWithCircle[]>;
   save(match: Match): Promise<void>;
 };

--- a/server/infrastructure/repository/match/prisma-match-repository.ts
+++ b/server/infrastructure/repository/match/prisma-match-repository.ts
@@ -51,15 +51,15 @@ export const createPrismaMatchRepository = (
     return matches.map(mapMatchToDomain);
   },
 
-  async listByUserIdWithCircle(
-    userId: UserId,
+  async listByPlayerIdWithCircle(
+    playerId: UserId,
   ): Promise<MatchWithCircle[]> {
     const matches = await client.match.findMany({
       where: {
         deletedAt: null,
         OR: [
-          { player1Id: toPersistenceId(userId) },
-          { player2Id: toPersistenceId(userId) },
+          { player1Id: toPersistenceId(playerId) },
+          { player2Id: toPersistenceId(playerId) },
         ],
       },
       include: {


### PR DESCRIPTION
## Summary

Closes #516

- `MatchRepository.listByUserIdWithCircle(userId)` を `listByPlayerIdWithCircle(playerId)` にリネーム
- `PrismaMatchRepository` の実装メソッドを同様にリネーム
- `UserStatisticsService` の呼び出し箇所を更新
- 関連テストファイル（4ファイル）のモック定義・呼び出しを更新

#506 で `listByUserId` → `listByPlayerId` にリネーム済みだったが、`listByUserIdWithCircle` が未対応だったため、用語を統一。

## Test plan

- [x] `npm run test:run` で全テスト通過を確認
- [x] `npx tsc --noEmit` で型チェック通過を確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)