### PR TITLE
feat: (authenticated) ルートグループにエラーバウンダリを追加

### DIFF
--- a/app/(authenticated)/error.tsx
+++ b/app/(authenticated)/error.tsx
@@ -1,0 +1,56 @@
+"use client";
+
+import { useEffect } from "react";
+import Link from "next/link";
+import { Button } from "@/components/ui/button";
+
+type ErrorProps = {
+  error: Error & { digest?: string };
+  reset: () => void;
+};
+
+export default function Error({ error, reset }: ErrorProps) {
+  useEffect(() => {
+    console.error("Error caught by error boundary:", error);
+  }, [error]);
+
+  return (
+    <div className="flex min-h-full flex-col items-center justify-center px-6">
+      <div className="max-w-md space-y-6 text-center">
+        <h1 className="text-6xl font-bold text-destructive">Error</h1>
+        <h2 className="text-2xl font-(--font-display) text-(--brand-ink)">
+          エラーが発生しました
+        </h2>
+        <p className="text-sm leading-relaxed text-(--brand-ink-muted)">
+          予期しないエラーが発生しました。再試行するか、しばらくしてからもう一度お試しください。
+        </p>
+        {process.env.NODE_ENV === "development" && (
+          <div className="rounded-lg border border-destructive/30 bg-destructive/5 p-4 text-left">
+            <p className="text-xs font-semibold text-destructive">
+              開発環境のみ表示
+            </p>
+            <p className="mt-2 break-all font-mono text-xs text-(--brand-ink-muted)">
+              {error.message}
+            </p>
+            {error.digest && (
+              <p className="mt-1 font-mono text-xs text-(--brand-ink-muted)">
+                Digest: {error.digest}
+              </p>
+            )}
+          </div>
+        )}
+        <div className="flex flex-col gap-3 sm:flex-row sm:justify-center">
+          <Button
+            onClick={reset}
+            className="bg-(--brand-moss) hover:bg-(--brand-moss)/90"
+          >
+            再試行
+          </Button>
+          <Button variant="outline" asChild>
+            <Link href="/">ホームに戻る</Link>
+          </Button>
+        </div>
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary

- `app/(authenticated)/error.tsx` を新規追加し、認証済みルート全体で統一的なエラーハンドリングを提供
- ユーザーフレンドリーなエラーメッセージ、再試行ボタン（`reset()`）、ホームへの遷移リンクを表示
- 開発環境では `error.message` と `error.digest` の詳細を表示

Closes #499

## Test plan

- [ ] `npm run dev` で開発サーバーを起動
- [ ] 認証済みルート内のサーバーコンポーネントで一時的に `throw new Error("test")` を追加
- [ ] カスタムエラーページが表示されることを確認（見出し・メッセージ・再試行ボタン・ホームリンク）
- [ ] 開発モードでエラー詳細が表示されることを確認
- [ ] 再試行ボタンが機能することを確認
- [ ] 認証済みレイアウト（サイドバー・ヘッダー）が保持されることを確認
- [ ] `npx tsc --noEmit` でエラーなし
- [ ] `npm run lint` でエラーなし

🤖 Generated with [Claude Code](https://claude.com/claude-code)