### PR TITLE
test: addParticipation テストに返却値のアサーションを追加

### DIFF
--- a/server/application/circle-session/circle-session-participation-service.test.ts
+++ b/server/application/circle-session/circle-session-participation-service.test.ts
@@ -144,13 +144,14 @@ describe("CircleSession 参加関係サービス", () => {
       },
     ]);
 
-    await service.addParticipation({
+    const result = await service.addParticipation({
       actorId: "user-actor",
       circleSessionId: circleSessionId("session-1"),
       userId: userId("user-rejoining"),
       role: "CircleSessionMember",
     });
 
+    expect(result).toBeUndefined();
     expect(
       circleSessionParticipationRepository.addParticipation,
     ).toHaveBeenCalledWith(
@@ -280,13 +281,14 @@ describe("CircleSession 参加関係サービス", () => {
       },
     ]);
 
-    await service.addParticipation({
+    const result = await service.addParticipation({
       actorId: "user-actor",
       circleSessionId: circleSessionId("session-1"),
       userId: userId("user-2"),
       role: "CircleSessionMember",
     });
 
+    expect(result).toBeUndefined();
     expect(
       circleSessionParticipationRepository.addParticipation,
     ).toHaveBeenCalledWith(

--- a/server/application/circle/circle-participation-service.test.ts
+++ b/server/application/circle/circle-participation-service.test.ts
@@ -204,13 +204,14 @@ describe("Circle 参加関係サービス", () => {
       },
     ]);
 
-    await service.addParticipation({
+    const result = await service.addParticipation({
       actorId: "user-actor",
       circleId: circleId("circle-1"),
       userId: userId("user-rejoining"),
       role: "CircleMember",
     });
 
+    expect(result).toBeUndefined();
     expect(
       circleParticipationRepository.addParticipation,
     ).toHaveBeenCalledWith(


### PR DESCRIPTION
## Summary

- `addParticipation` テストでサービスメソッドの返却値をキャプチャし、`expect(result).toBeUndefined()` アサーションを追加
- 対象: `circle-participation-service.test.ts`、`circle-session-participation-service.test.ts`
- 返却値の加工・変換が入った場合のリグレッション検知を可能にする

Closes #491

## Test plan

- [x] `npm run test:run -- server/application/circle/circle-participation-service.test.ts` — 20 tests passed
- [x] `npm run test:run -- server/application/circle-session/circle-session-participation-service.test.ts` — 20 tests passed

## Verification

1. 変更された各テストで `result` 変数が追加されていること
2. `expect(result).toBeUndefined()` が既存の `toHaveBeenCalledWith` アサーションと併用されていること
3. 全40テストがパスすること

🤖 Generated with [Claude Code](https://claude.com/claude-code)