### PR TITLE
refactor: エラーバウンダリの共通UI部分を ErrorContent コンポーネントに抽出

### DIFF
--- a/app/(authenticated)/error.tsx
+++ b/app/(authenticated)/error.tsx
@@ -1,8 +1,7 @@
 "use client";
 
 import { useEffect } from "react";
-import Link from "next/link";
-import { Button } from "@/components/ui/button";
+import { ErrorContent } from "@/components/error-content";
 
 type ErrorProps = {
   error: Error & { digest?: string };
@@ -14,43 +13,5 @@ export default function Error({ error, reset }: ErrorProps) {
     console.error("Error caught by error boundary:", error);
   }, [error]);
 
-  return (
-    <div className="flex min-h-full flex-col items-center justify-center px-6">
-      <div className="max-w-md space-y-6 text-center">
-        <h1 className="text-6xl font-bold text-destructive">Error</h1>
-        <h2 className="text-2xl font-(--font-display) text-(--brand-ink)">
-          エラーが発生しました
-        </h2>
-        <p className="text-sm leading-relaxed text-(--brand-ink-muted)">
-          予期しないエラーが発生しました。再試行するか、しばらくしてからもう一度お試しください。
-        </p>
-        {process.env.NODE_ENV === "development" && (
-          <div className="rounded-lg border border-destructive/30 bg-destructive/5 p-4 text-left">
-            <p className="text-xs font-semibold text-destructive">
-              開発環境のみ表示
-            </p>
-            <p className="mt-2 break-all font-mono text-xs text-(--brand-ink-muted)">
-              {error.message}
-            </p>
-            {error.digest && (
-              <p className="mt-1 font-mono text-xs text-(--brand-ink-muted)">
-                Digest: {error.digest}
-              </p>
-            )}
-          </div>
-        )}
-        <div className="flex flex-col gap-3 sm:flex-row sm:justify-center">
-          <Button
-            onClick={reset}
-            className="bg-(--brand-moss) hover:bg-(--brand-moss)/90"
-          >
-            再試行
-          </Button>
-          <Button variant="outline" asChild>
-            <Link href="/">ホームに戻る</Link>
-          </Button>
-        </div>
-      </div>
-    </div>
-  );
+  return <ErrorContent error={error} reset={reset} className="min-h-full" />;
 }

--- a/app/error.tsx
+++ b/app/error.tsx
@@ -1,8 +1,7 @@
 "use client";
 
 import { useEffect } from "react";
-import Link from "next/link";
-import { Button } from "@/components/ui/button";
+import { ErrorContent } from "@/components/error-content";
 
 type ErrorProps = {
   error: Error & { digest?: string };
@@ -14,43 +13,5 @@ export default function Error({ error, reset }: ErrorProps) {
     console.error("Error caught by error boundary:", error);
   }, [error]);
 
-  return (
-    <div className="flex min-h-svh flex-col items-center justify-center px-6">
-      <div className="max-w-md space-y-6 text-center">
-        <h1 className="text-6xl font-bold text-destructive">Error</h1>
-        <h2 className="text-2xl font-(--font-display) text-(--brand-ink)">
-          エラーが発生しました
-        </h2>
-        <p className="text-sm leading-relaxed text-(--brand-ink-muted)">
-          予期しないエラーが発生しました。再試行するか、しばらくしてからもう一度お試しください。
-        </p>
-        {process.env.NODE_ENV === "development" && (
-          <div className="rounded-lg border border-destructive/30 bg-destructive/5 p-4 text-left">
-            <p className="text-xs font-semibold text-destructive">
-              開発環境のみ表示
-            </p>
-            <p className="mt-2 break-all font-mono text-xs text-(--brand-ink-muted)">
-              {error.message}
-            </p>
-            {error.digest && (
-              <p className="mt-1 font-mono text-xs text-(--brand-ink-muted)">
-                Digest: {error.digest}
-              </p>
-            )}
-          </div>
-        )}
-        <div className="flex flex-col gap-3 sm:flex-row sm:justify-center">
-          <Button
-            onClick={reset}
-            className="bg-(--brand-moss) hover:bg-(--brand-moss)/90"
-          >
-            再試行
-          </Button>
-          <Button variant="outline" asChild>
-            <Link href="/">ホームに戻る</Link>
-          </Button>
-        </div>
-      </div>
-    </div>
-  );
+  return <ErrorContent error={error} reset={reset} className="min-h-svh" />;
 }

--- a/components/error-content.tsx
+++ b/components/error-content.tsx
@@ -1,0 +1,58 @@
+"use client";
+
+import Link from "next/link";
+import { Button } from "@/components/ui/button";
+import { cn } from "@/lib/utils";
+
+type ErrorContentProps = {
+  error: Error & { digest?: string };
+  reset: () => void;
+  className?: string;
+};
+
+export function ErrorContent({ error, reset, className }: ErrorContentProps) {
+  return (
+    <div
+      className={cn(
+        "flex flex-col items-center justify-center px-6",
+        className,
+      )}
+    >
+      <div className="max-w-md space-y-6 text-center">
+        <h1 className="text-6xl font-bold text-destructive">Error</h1>
+        <h2 className="text-2xl font-(--font-display) text-(--brand-ink)">
+          エラーが発生しました
+        </h2>
+        <p className="text-sm leading-relaxed text-(--brand-ink-muted)">
+          予期しないエラーが発生しました。再試行するか、しばらくしてからもう一度お試しください。
+        </p>
+        {process.env.NODE_ENV === "development" && (
+          <div className="rounded-lg border border-destructive/30 bg-destructive/5 p-4 text-left">
+            <p className="text-xs font-semibold text-destructive">
+              開発環境のみ表示
+            </p>
+            <p className="mt-2 break-all font-mono text-xs text-(--brand-ink-muted)">
+              {error.message}
+            </p>
+            {error.digest && (
+              <p className="mt-1 font-mono text-xs text-(--brand-ink-muted)">
+                Digest: {error.digest}
+              </p>
+            )}
+          </div>
+        )}
+        <div className="flex flex-col gap-3 sm:flex-row sm:justify-center">
+          <Button
+            onClick={reset}
+            className="bg-(--brand-moss) hover:bg-(--brand-moss)/90"
+          >
+            再試行
+          </Button>
+          <Button variant="outline" asChild>
+            <Link href="/">ホームに戻る</Link>
+          </Button>
+        </div>
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary

Closes #520

- `components/error-content.tsx` に共通エラー表示UIを抽出
- `app/error.tsx` と `app/(authenticated)/error.tsx` から重複UIを削除し、`ErrorContent` を呼び出す形にリファクタリング
- 外部コンテナの `className` を props で受け取り、レイアウトの違い（`min-h-svh` vs `min-h-full`）を吸収

## Test plan

- [ ] `npm run lint` — pass
- [ ] `npx tsc --noEmit` — pass
- [ ] `npm run dev` でルートエラーバウンダリが正しく表示されること
- [ ] 認証済みページのエラーバウンダリが正しく表示されること
- [ ] 「再試行」ボタン・「ホームに戻る」リンクが動作すること

🤖 Generated with [Claude Code](https://claude.com/claude-code)