### PR TITLE
feat: 対戦相手別成績検索機能を追加

### DIFF
--- a/app/(authenticated)/users/components/opponent-record-search.tsx
+++ b/app/(authenticated)/users/components/opponent-record-search.tsx
@@ -1,0 +1,131 @@
+"use client";
+
+import { useState } from "react";
+import { ChevronsUpDown, Check } from "lucide-react";
+import { trpc } from "@/lib/trpc/client";
+import { Button } from "@/components/ui/button";
+import {
+  Popover,
+  PopoverContent,
+  PopoverTrigger,
+} from "@/components/ui/popover";
+import {
+  Command,
+  CommandEmpty,
+  CommandGroup,
+  CommandInput,
+  CommandItem,
+  CommandList,
+} from "@/components/ui/command";
+import { Skeleton } from "@/components/ui/skeleton";
+import { cn } from "@/lib/utils";
+
+type OpponentRecordSearchProps = {
+  userId: string;
+};
+
+export function OpponentRecordSearch({ userId }: OpponentRecordSearchProps) {
+  const [open, setOpen] = useState(false);
+  const [selectedOpponentId, setSelectedOpponentId] = useState<string | null>(
+    null,
+  );
+
+  const opponentsQuery = trpc.users.statistics.opponents.useQuery({
+    targetUserId: userId,
+  });
+
+  const recordQuery = trpc.users.statistics.opponentRecord.useQuery(
+    { targetUserId: userId, opponentId: selectedOpponentId! },
+    { enabled: selectedOpponentId !== null },
+  );
+
+  const opponents = opponentsQuery.data ?? [];
+  const selectedOpponent = opponents.find(
+    (o) => o.userId === selectedOpponentId,
+  );
+
+  return (
+    <div className="flex flex-col gap-4">
+      <Popover open={open} onOpenChange={setOpen}>
+        <PopoverTrigger asChild>
+          <Button
+            variant="outline"
+            role="combobox"
+            aria-expanded={open}
+            className="w-full justify-between"
+          >
+            {selectedOpponent ? selectedOpponent.name : "対戦相手を選択..."}
+            <ChevronsUpDown className="ml-2 h-4 w-4 shrink-0 opacity-50" />
+          </Button>
+        </PopoverTrigger>
+        <PopoverContent className="w-[var(--radix-popover-trigger-width)] p-0">
+          <Command>
+            <CommandInput placeholder="名前で検索..." />
+            <CommandList>
+              <CommandEmpty>対戦相手が見つかりません</CommandEmpty>
+              <CommandGroup>
+                {opponents.map((opponent) => (
+                  <CommandItem
+                    key={opponent.userId}
+                    value={opponent.name}
+                    onSelect={() => {
+                      setSelectedOpponentId(
+                        opponent.userId === selectedOpponentId
+                          ? null
+                          : opponent.userId,
+                      );
+                      setOpen(false);
+                    }}
+                  >
+                    <Check
+                      className={cn(
+                        "mr-2 h-4 w-4",
+                        selectedOpponentId === opponent.userId
+                          ? "opacity-100"
+                          : "opacity-0",
+                      )}
+                    />
+                    {opponent.name}
+                  </CommandItem>
+                ))}
+              </CommandGroup>
+            </CommandList>
+          </Command>
+        </PopoverContent>
+      </Popover>
+
+      {selectedOpponentId && (
+        <div className="flex gap-6">
+          {recordQuery.isLoading ? (
+            <>
+              <Skeleton className="h-10 w-16" />
+              <Skeleton className="h-10 w-16" />
+              <Skeleton className="h-10 w-16" />
+            </>
+          ) : recordQuery.data ? (
+            <>
+              <div className="flex items-baseline gap-1">
+                <span className="text-3xl font-bold text-(--brand-moss)">
+                  {recordQuery.data.wins}
+                </span>
+                <span className="text-sm text-muted-foreground">勝</span>
+              </div>
+              <div className="flex items-baseline gap-1">
+                <span className="text-3xl font-bold text-(--brand-ink)">
+                  {recordQuery.data.losses}
+                </span>
+                <span className="text-sm text-muted-foreground">敗</span>
+              </div>
+              <div className="flex items-baseline gap-1">
+                <span className="text-3xl font-bold text-muted-foreground">
+                  {recordQuery.data.draws}
+                </span>
+                <span className="text-sm text-muted-foreground">分</span>
+              </div>
+            </>
+          ) : null}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/app/(authenticated)/users/components/user-profile-view.tsx
+++ b/app/(authenticated)/users/components/user-profile-view.tsx
@@ -1,5 +1,6 @@
 import type { UserProfileViewModel } from "@/server/presentation/view-models/user-profile";
 import Image from "next/image";
+import { OpponentRecordSearch } from "@/app/(authenticated)/users/components/opponent-record-search";
 
 type UserProfileViewProps = {
   profile: UserProfileViewModel;
@@ -96,6 +97,13 @@ export function UserProfileView({ profile }: UserProfileViewProps) {
             </div>
           </div>
         )}
+      </section>
+
+      <section className="rounded-2xl border border-border/60 bg-white/90 p-8 shadow-sm">
+        <h2 className="mb-4 text-lg font-bold text-(--brand-ink)">
+          対戦相手別成績
+        </h2>
+        <OpponentRecordSearch userId={profile.userId} />
       </section>
     </div>
   );

--- a/components/ui/command.tsx
+++ b/components/ui/command.tsx
@@ -1,0 +1,184 @@
+"use client"
+
+import * as React from "react"
+import { Command as CommandPrimitive } from "cmdk"
+import { SearchIcon } from "lucide-react"
+
+import { cn } from "@/lib/utils"
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog"
+
+function Command({
+  className,
+  ...props
+}: React.ComponentProps<typeof CommandPrimitive>) {
+  return (
+    <CommandPrimitive
+      data-slot="command"
+      className={cn(
+        "bg-popover text-popover-foreground flex h-full w-full flex-col overflow-hidden rounded-md",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+function CommandDialog({
+  title = "Command Palette",
+  description = "Search for a command to run...",
+  children,
+  className,
+  showCloseButton = true,
+  ...props
+}: React.ComponentProps<typeof Dialog> & {
+  title?: string
+  description?: string
+  className?: string
+  showCloseButton?: boolean
+}) {
+  return (
+    <Dialog {...props}>
+      <DialogHeader className="sr-only">
+        <DialogTitle>{title}</DialogTitle>
+        <DialogDescription>{description}</DialogDescription>
+      </DialogHeader>
+      <DialogContent
+        className={cn("overflow-hidden p-0", className)}
+        showCloseButton={showCloseButton}
+      >
+        <Command className="[&_[cmdk-group-heading]]:text-muted-foreground **:data-[slot=command-input-wrapper]:h-12 [&_[cmdk-group-heading]]:px-2 [&_[cmdk-group-heading]]:font-medium [&_[cmdk-group]]:px-2 [&_[cmdk-group]:not([hidden])_~[cmdk-group]]:pt-0 [&_[cmdk-input-wrapper]_svg]:h-5 [&_[cmdk-input-wrapper]_svg]:w-5 [&_[cmdk-input]]:h-12 [&_[cmdk-item]]:px-2 [&_[cmdk-item]]:py-3 [&_[cmdk-item]_svg]:h-5 [&_[cmdk-item]_svg]:w-5">
+          {children}
+        </Command>
+      </DialogContent>
+    </Dialog>
+  )
+}
+
+function CommandInput({
+  className,
+  ...props
+}: React.ComponentProps<typeof CommandPrimitive.Input>) {
+  return (
+    <div
+      data-slot="command-input-wrapper"
+      className="flex h-9 items-center gap-2 border-b px-3"
+    >
+      <SearchIcon className="size-4 shrink-0 opacity-50" />
+      <CommandPrimitive.Input
+        data-slot="command-input"
+        className={cn(
+          "placeholder:text-muted-foreground flex h-10 w-full rounded-md bg-transparent py-3 text-sm outline-hidden disabled:cursor-not-allowed disabled:opacity-50",
+          className
+        )}
+        {...props}
+      />
+    </div>
+  )
+}
+
+function CommandList({
+  className,
+  ...props
+}: React.ComponentProps<typeof CommandPrimitive.List>) {
+  return (
+    <CommandPrimitive.List
+      data-slot="command-list"
+      className={cn(
+        "max-h-[300px] scroll-py-1 overflow-x-hidden overflow-y-auto",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+function CommandEmpty({
+  ...props
+}: React.ComponentProps<typeof CommandPrimitive.Empty>) {
+  return (
+    <CommandPrimitive.Empty
+      data-slot="command-empty"
+      className="py-6 text-center text-sm"
+      {...props}
+    />
+  )
+}
+
+function CommandGroup({
+  className,
+  ...props
+}: React.ComponentProps<typeof CommandPrimitive.Group>) {
+  return (
+    <CommandPrimitive.Group
+      data-slot="command-group"
+      className={cn(
+        "text-foreground [&_[cmdk-group-heading]]:text-muted-foreground overflow-hidden p-1 [&_[cmdk-group-heading]]:px-2 [&_[cmdk-group-heading]]:py-1.5 [&_[cmdk-group-heading]]:text-xs [&_[cmdk-group-heading]]:font-medium",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+function CommandSeparator({
+  className,
+  ...props
+}: React.ComponentProps<typeof CommandPrimitive.Separator>) {
+  return (
+    <CommandPrimitive.Separator
+      data-slot="command-separator"
+      className={cn("bg-border -mx-1 h-px", className)}
+      {...props}
+    />
+  )
+}
+
+function CommandItem({
+  className,
+  ...props
+}: React.ComponentProps<typeof CommandPrimitive.Item>) {
+  return (
+    <CommandPrimitive.Item
+      data-slot="command-item"
+      className={cn(
+        "data-[selected=true]:bg-accent data-[selected=true]:text-accent-foreground [&_svg:not([class*='text-'])]:text-muted-foreground relative flex cursor-default items-center gap-2 rounded-sm px-2 py-1.5 text-sm outline-hidden select-none data-[disabled=true]:pointer-events-none data-[disabled=true]:opacity-50 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+function CommandShortcut({
+  className,
+  ...props
+}: React.ComponentProps<"span">) {
+  return (
+    <span
+      data-slot="command-shortcut"
+      className={cn(
+        "text-muted-foreground ml-auto text-xs tracking-widest",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+export {
+  Command,
+  CommandDialog,
+  CommandInput,
+  CommandList,
+  CommandEmpty,
+  CommandGroup,
+  CommandItem,
+  CommandShortcut,
+  CommandSeparator,
+}

--- a/components/ui/popover.tsx
+++ b/components/ui/popover.tsx
@@ -1,0 +1,89 @@
+"use client"
+
+import * as React from "react"
+import { Popover as PopoverPrimitive } from "radix-ui"
+
+import { cn } from "@/lib/utils"
+
+function Popover({
+  ...props
+}: React.ComponentProps<typeof PopoverPrimitive.Root>) {
+  return <PopoverPrimitive.Root data-slot="popover" {...props} />
+}
+
+function PopoverTrigger({
+  ...props
+}: React.ComponentProps<typeof PopoverPrimitive.Trigger>) {
+  return <PopoverPrimitive.Trigger data-slot="popover-trigger" {...props} />
+}
+
+function PopoverContent({
+  className,
+  align = "center",
+  sideOffset = 4,
+  ...props
+}: React.ComponentProps<typeof PopoverPrimitive.Content>) {
+  return (
+    <PopoverPrimitive.Portal>
+      <PopoverPrimitive.Content
+        data-slot="popover-content"
+        align={align}
+        sideOffset={sideOffset}
+        className={cn(
+          "bg-popover text-popover-foreground data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 z-50 w-72 origin-(--radix-popover-content-transform-origin) rounded-md border p-4 shadow-md outline-hidden",
+          className
+        )}
+        {...props}
+      />
+    </PopoverPrimitive.Portal>
+  )
+}
+
+function PopoverAnchor({
+  ...props
+}: React.ComponentProps<typeof PopoverPrimitive.Anchor>) {
+  return <PopoverPrimitive.Anchor data-slot="popover-anchor" {...props} />
+}
+
+function PopoverHeader({ className, ...props }: React.ComponentProps<"div">) {
+  return (
+    <div
+      data-slot="popover-header"
+      className={cn("flex flex-col gap-1 text-sm", className)}
+      {...props}
+    />
+  )
+}
+
+function PopoverTitle({ className, ...props }: React.ComponentProps<"h2">) {
+  return (
+    <div
+      data-slot="popover-title"
+      className={cn("font-medium", className)}
+      {...props}
+    />
+  )
+}
+
+function PopoverDescription({
+  className,
+  ...props
+}: React.ComponentProps<"p">) {
+  return (
+    <p
+      data-slot="popover-description"
+      className={cn("text-muted-foreground", className)}
+      {...props}
+    />
+  )
+}
+
+export {
+  Popover,
+  PopoverTrigger,
+  PopoverContent,
+  PopoverAnchor,
+  PopoverHeader,
+  PopoverTitle,
+  PopoverDescription,
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -32,6 +32,7 @@
         "@trpc/server": "^11.0.0",
         "class-variance-authority": "^0.7.1",
         "clsx": "^2.1.1",
+        "cmdk": "^1.1.1",
         "dotenv": "^17.2.3",
         "lucide-react": "^0.556.0",
         "next": "^16.1.6",
@@ -6452,6 +6453,22 @@
       "license": "MIT",
       "engines": {
         "node": ">=6"
+      }
+    },
+    "node_modules/cmdk": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/cmdk/-/cmdk-1.1.1.tgz",
+      "integrity": "sha512-Vsv7kFaXm+ptHDMZ7izaRsP70GgrW9NBNGswt9OZaVBLlE0SNpDq8eu/VGXyF9r7M0azK3Wy7OlYXsuyYLFzHg==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-compose-refs": "^1.1.1",
+        "@radix-ui/react-dialog": "^1.1.6",
+        "@radix-ui/react-id": "^1.1.0",
+        "@radix-ui/react-primitive": "^2.0.2"
+      },
+      "peerDependencies": {
+        "react": "^18 || ^19 || ^19.0.0-rc",
+        "react-dom": "^18 || ^19 || ^19.0.0-rc"
       }
     },
     "node_modules/color-convert": {

--- a/package.json
+++ b/package.json
@@ -46,6 +46,7 @@
     "@trpc/server": "^11.0.0",
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",
+    "cmdk": "^1.1.1",
     "dotenv": "^17.2.3",
     "lucide-react": "^0.556.0",
     "next": "^16.1.6",

--- a/server/application/match-history/match-history-service.test.ts
+++ b/server/application/match-history/match-history-service.test.ts
@@ -15,6 +15,7 @@ const matchRepository = {
   findById: vi.fn(),
   listByCircleSessionId: vi.fn(),
   listByPlayerId: vi.fn(),
+  listByBothPlayerIds: vi.fn(),
   listByPlayerIdWithCircle: vi.fn(),
   save: vi.fn(),
 } satisfies MatchRepository;

--- a/server/application/match/match-service.test.ts
+++ b/server/application/match/match-service.test.ts
@@ -19,6 +19,7 @@ const matchRepository = {
   findById: vi.fn(),
   listByCircleSessionId: vi.fn(),
   listByPlayerId: vi.fn(),
+  listByBothPlayerIds: vi.fn(),
   listByPlayerIdWithCircle: vi.fn(),
   save: vi.fn(),
 } satisfies MatchRepository;
@@ -313,6 +314,7 @@ describe("UnitOfWork 経路", () => {
     findById: vi.fn(),
     listByCircleSessionId: vi.fn(),
     listByPlayerId: vi.fn(),
+    listByBothPlayerIds: vi.fn(),
     listByPlayerIdWithCircle: vi.fn(),
     save: vi.fn(),
   } satisfies MatchRepository;
@@ -344,6 +346,7 @@ describe("UnitOfWork 経路", () => {
     findById: vi.fn(),
     listByCircleSessionId: vi.fn(),
     listByPlayerId: vi.fn(),
+    listByBothPlayerIds: vi.fn(),
     listByPlayerIdWithCircle: vi.fn(),
     save: vi.fn(),
   } satisfies MatchRepository;

--- a/server/application/service-container.test.ts
+++ b/server/application/service-container.test.ts
@@ -30,6 +30,7 @@ const createMatchStub = () => ({
   findById: vi.fn(),
   listByCircleSessionId: vi.fn(),
   listByPlayerId: vi.fn(),
+  listByBothPlayerIds: vi.fn(),
   listByPlayerIdWithCircle: vi.fn(),
   save: vi.fn(),
 });

--- a/server/application/service-container.ts
+++ b/server/application/service-container.ts
@@ -134,6 +134,7 @@ export const createServiceContainer = (
     }),
     userStatisticsService: createUserStatisticsService({
       matchRepository: deps.matchRepository,
+      userRepository: deps.userRepository,
     }),
     holidayProvider: deps.holidayProvider,
   };

--- a/server/application/user/user-statistics-service.test.ts
+++ b/server/application/user/user-statistics-service.test.ts
@@ -1,30 +1,62 @@
 import { beforeEach, describe, expect, test, vi } from "vitest";
 import { createUserStatisticsService } from "@/server/application/user/user-statistics-service";
 import type { MatchRepository } from "@/server/domain/models/match/match-repository";
+import type { UserRepository } from "@/server/domain/models/user/user-repository";
 import {
   circleId,
   circleSessionId,
   matchId,
   userId,
 } from "@/server/domain/common/ids";
-import type { MatchOutcome } from "@/server/domain/models/match/match";
+import type { MatchOutcome, Match } from "@/server/domain/models/match/match";
 import type { MatchWithCircle } from "@/server/domain/models/match/match-read-models";
 
 const matchRepository = {
   findById: vi.fn(),
   listByCircleSessionId: vi.fn(),
   listByPlayerId: vi.fn(),
+  listByBothPlayerIds: vi.fn(),
   listByPlayerIdWithCircle: vi.fn(),
   save: vi.fn(),
 } satisfies MatchRepository;
 
-const service = createUserStatisticsService({ matchRepository });
+const userRepository = {
+  findById: vi.fn(),
+  findByIds: vi.fn(),
+  findByEmail: vi.fn(),
+  save: vi.fn(),
+  updateProfile: vi.fn(),
+  emailExists: vi.fn(),
+  findPasswordHashById: vi.fn(),
+  findPasswordChangedAt: vi.fn(),
+  updatePasswordHash: vi.fn(),
+} satisfies UserRepository;
+
+const service = createUserStatisticsService({ matchRepository, userRepository });
 
 const TARGET_USER = userId("target-user");
 const OPPONENT = userId("opponent");
 
 const CIRCLE_A = circleId("circle-a");
 const CIRCLE_B = circleId("circle-b");
+
+const OPPONENT_B = userId("opponent-b");
+
+const createTestMatch = (
+  overrides: Partial<{
+    player1Id: ReturnType<typeof userId>;
+    player2Id: ReturnType<typeof userId>;
+    outcome: MatchOutcome;
+  }> = {},
+): Match => ({
+  id: matchId(`match-${Math.random()}`),
+  circleSessionId: circleSessionId("session-1"),
+  createdAt: new Date(),
+  player1Id: overrides.player1Id ?? TARGET_USER,
+  player2Id: overrides.player2Id ?? OPPONENT,
+  outcome: overrides.outcome ?? "UNKNOWN",
+  deletedAt: null,
+});
 
 const createTestMatchWithCircle = (
   overrides: Partial<{
@@ -343,6 +375,79 @@ describe("UserStatisticsService", () => {
       expect(
         matchRepository.listByPlayerIdWithCircle,
       ).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe("getOpponents", () => {
+    test("対局なしの場合、空配列を返す", async () => {
+      matchRepository.listByPlayerId.mockResolvedValue([]);
+
+      const result = await service.getOpponents(TARGET_USER);
+
+      expect(result).toEqual([]);
+      expect(userRepository.findByIds).not.toHaveBeenCalled();
+    });
+
+    test("対戦相手を重複排除して名前付きで返す", async () => {
+      matchRepository.listByPlayerId.mockResolvedValue([
+        createTestMatch({ player1Id: TARGET_USER, player2Id: OPPONENT }),
+        createTestMatch({ player1Id: OPPONENT, player2Id: TARGET_USER }),
+        createTestMatch({ player1Id: TARGET_USER, player2Id: OPPONENT_B }),
+      ]);
+      userRepository.findByIds.mockResolvedValue([
+        { id: OPPONENT, name: "対戦相手A", email: null, image: null, createdAt: new Date() },
+        { id: OPPONENT_B, name: "対戦相手B", email: null, image: null, createdAt: new Date() },
+      ]);
+
+      const result = await service.getOpponents(TARGET_USER);
+
+      expect(result).toEqual([
+        { userId: OPPONENT, name: "対戦相手A" },
+        { userId: OPPONENT_B, name: "対戦相手B" },
+      ]);
+    });
+
+    test("名前がnullのユーザーは「名前未設定」として返す", async () => {
+      matchRepository.listByPlayerId.mockResolvedValue([
+        createTestMatch({ player1Id: TARGET_USER, player2Id: OPPONENT }),
+      ]);
+      userRepository.findByIds.mockResolvedValue([
+        { id: OPPONENT, name: null, email: null, image: null, createdAt: new Date() },
+      ]);
+
+      const result = await service.getOpponents(TARGET_USER);
+
+      expect(result).toEqual([
+        { userId: OPPONENT, name: "名前未設定" },
+      ]);
+    });
+  });
+
+  describe("getOpponentRecord", () => {
+    test("対局なしの場合、全て0を返す", async () => {
+      matchRepository.listByBothPlayerIds.mockResolvedValue([]);
+
+      const result = await service.getOpponentRecord(TARGET_USER, OPPONENT);
+
+      expect(result).toEqual({ wins: 0, losses: 0, draws: 0 });
+      expect(matchRepository.listByBothPlayerIds).toHaveBeenCalledWith(
+        TARGET_USER,
+        OPPONENT,
+      );
+    });
+
+    test("勝敗引き分けを正しく集計する", async () => {
+      matchRepository.listByBothPlayerIds.mockResolvedValue([
+        createTestMatch({ player1Id: TARGET_USER, player2Id: OPPONENT, outcome: "P1_WIN" }),
+        createTestMatch({ player1Id: TARGET_USER, player2Id: OPPONENT, outcome: "P2_WIN" }),
+        createTestMatch({ player1Id: OPPONENT, player2Id: TARGET_USER, outcome: "P1_WIN" }),
+        createTestMatch({ player1Id: TARGET_USER, player2Id: OPPONENT, outcome: "DRAW" }),
+        createTestMatch({ player1Id: TARGET_USER, player2Id: OPPONENT, outcome: "UNKNOWN" }),
+      ]);
+
+      const result = await service.getOpponentRecord(TARGET_USER, OPPONENT);
+
+      expect(result).toEqual({ wins: 1, losses: 2, draws: 1 });
     });
   });
 });

--- a/server/application/user/user-statistics-service.ts
+++ b/server/application/user/user-statistics-service.ts
@@ -1,13 +1,20 @@
 import type { CircleId, UserId } from "@/server/domain/common/ids";
 import type { MatchRepository } from "@/server/domain/models/match/match-repository";
+import type { UserRepository } from "@/server/domain/models/user/user-repository";
 import { classifyOutcomeForUser } from "@/server/domain/models/match/match";
 import type {
   CircleMatchStatistics,
   UserMatchStatistics,
 } from "@/server/domain/models/match/match-statistics";
 
+export type OpponentInfo = {
+  userId: UserId;
+  name: string;
+};
+
 type UserStatisticsServiceDeps = {
   matchRepository: MatchRepository;
+  userRepository: UserRepository;
 };
 
 export const createUserStatisticsService = (
@@ -58,5 +65,48 @@ export const createUserStatisticsService = (
       .sort((a, b) => a.circleName.localeCompare(b.circleName, "ja"));
 
     return { total, byCircle };
+  },
+
+  async getOpponents(targetUserId: UserId): Promise<OpponentInfo[]> {
+    const matches =
+      await deps.matchRepository.listByPlayerId(targetUserId);
+
+    const opponentIds = new Set<UserId>();
+    for (const match of matches) {
+      const opponentId =
+        match.player1Id === targetUserId ? match.player2Id : match.player1Id;
+      opponentIds.add(opponentId);
+    }
+
+    if (opponentIds.size === 0) return [];
+
+    const users = await deps.userRepository.findByIds([...opponentIds]);
+    return users
+      .map((u) => ({ userId: u.id, name: u.name ?? "名前未設定" }))
+      .sort((a, b) => a.name.localeCompare(b.name, "ja"));
+  },
+
+  async getOpponentRecord(
+    targetUserId: UserId,
+    opponentId: UserId,
+  ): Promise<UserMatchStatistics> {
+    const matches = await deps.matchRepository.listByBothPlayerIds(
+      targetUserId,
+      opponentId,
+    );
+
+    const stats: UserMatchStatistics = { wins: 0, losses: 0, draws: 0 };
+
+    for (const match of matches) {
+      const isPlayer1 = match.player1Id === targetUserId;
+      const classified = classifyOutcomeForUser(match.outcome, isPlayer1);
+      if (classified === null) continue;
+
+      if (classified === "win") stats.wins++;
+      else if (classified === "loss") stats.losses++;
+      else stats.draws++;
+    }
+
+    return stats;
   },
 });

--- a/server/domain/models/match/match-repository.ts
+++ b/server/domain/models/match/match-repository.ts
@@ -12,6 +12,8 @@ export type MatchRepository = {
   listByCircleSessionId(circleSessionId: CircleSessionId): Promise<Match[]>;
   /** Returns non-deleted matches where the player is player1 or player2. */
   listByPlayerId(playerId: UserId): Promise<Match[]>;
+  /** Returns non-deleted matches where both players participated. */
+  listByBothPlayerIds(playerId: UserId, opponentId: UserId): Promise<Match[]>;
   /** Returns non-deleted matches with circle info via CircleSession. */
   listByPlayerIdWithCircle(playerId: UserId): Promise<MatchWithCircle[]>;
   save(match: Match): Promise<void>;

--- a/server/infrastructure/repository/match/prisma-match-repository.ts
+++ b/server/infrastructure/repository/match/prisma-match-repository.ts
@@ -51,6 +51,30 @@ export const createPrismaMatchRepository = (
     return matches.map(mapMatchToDomain);
   },
 
+  async listByBothPlayerIds(
+    playerId: UserId,
+    opponentId: UserId,
+  ): Promise<Match[]> {
+    const matches = await client.match.findMany({
+      where: {
+        deletedAt: null,
+        OR: [
+          {
+            player1Id: toPersistenceId(playerId),
+            player2Id: toPersistenceId(opponentId),
+          },
+          {
+            player1Id: toPersistenceId(opponentId),
+            player2Id: toPersistenceId(playerId),
+          },
+        ],
+      },
+      orderBy: { createdAt: "asc" },
+    });
+
+    return matches.map(mapMatchToDomain);
+  },
+
   async listByPlayerIdWithCircle(
     playerId: UserId,
   ): Promise<MatchWithCircle[]> {

--- a/server/presentation/dto/user.ts
+++ b/server/presentation/dto/user.ts
@@ -44,3 +44,23 @@ export const changePasswordInputSchema = z.object({
 });
 
 export type ChangePasswordInput = z.infer<typeof changePasswordInputSchema>;
+
+export const opponentsInputSchema = z.object({
+  targetUserId: userIdSchema,
+});
+
+export const opponentDtoSchema = z.object({
+  userId: z.string(),
+  name: z.string(),
+});
+
+export const opponentRecordInputSchema = z.object({
+  targetUserId: userIdSchema,
+  opponentId: userIdSchema,
+});
+
+export const opponentRecordDtoSchema = z.object({
+  wins: z.number(),
+  losses: z.number(),
+  draws: z.number(),
+});

--- a/server/presentation/trpc/routers/user-statistics.ts
+++ b/server/presentation/trpc/routers/user-statistics.ts
@@ -1,0 +1,37 @@
+import {
+  opponentDtoSchema,
+  opponentRecordDtoSchema,
+  opponentRecordInputSchema,
+  opponentsInputSchema,
+} from "@/server/presentation/dto/user";
+import { handleTrpcError } from "@/server/presentation/trpc/errors";
+import { protectedProcedure, router } from "@/server/presentation/trpc/trpc";
+
+export const userStatisticsRouter = router({
+  opponents: protectedProcedure
+    .input(opponentsInputSchema)
+    .output(opponentDtoSchema.array())
+    .query(({ ctx, input }) =>
+      handleTrpcError(async () => {
+        const opponents = await ctx.userStatisticsService.getOpponents(
+          input.targetUserId,
+        );
+        return opponents.map((o) => ({
+          userId: o.userId as string,
+          name: o.name,
+        }));
+      }),
+    ),
+
+  opponentRecord: protectedProcedure
+    .input(opponentRecordInputSchema)
+    .output(opponentRecordDtoSchema)
+    .query(({ ctx, input }) =>
+      handleTrpcError(async () => {
+        return ctx.userStatisticsService.getOpponentRecord(
+          input.targetUserId,
+          input.opponentId,
+        );
+      }),
+    ),
+});

--- a/server/presentation/trpc/routers/user.ts
+++ b/server/presentation/trpc/routers/user.ts
@@ -16,6 +16,7 @@ import { handleTrpcError } from "@/server/presentation/trpc/errors";
 import { protectedProcedure, router } from "@/server/presentation/trpc/trpc";
 import { userCircleRouter } from "@/server/presentation/trpc/routers/user-circle";
 import { userCircleSessionRouter } from "@/server/presentation/trpc/routers/user-circle-session";
+import { userStatisticsRouter } from "@/server/presentation/trpc/routers/user-statistics";
 import { z } from "zod";
 
 export const userRouter = router({
@@ -35,6 +36,7 @@ export const userRouter = router({
   memberships: userMembershipRouter,
   circles: userCircleRouter,
   circleSessions: userCircleSessionRouter,
+  statistics: userStatisticsRouter,
 
   list: protectedProcedure
     .input(userListInputSchema)


### PR DESCRIPTION
## Summary
- ユーザー詳細ページに特定の対戦相手との勝敗数を検索・表示する機能を追加
- `MatchRepository` に `listByBothPlayerIds` メソッドを追加し、2人のプレイヤー間の対局を取得可能に
- `UserStatisticsService` に `getOpponents`（対戦相手一覧）と `getOpponentRecord`（対戦成績）を追加
- tRPC エンドポイント `users.statistics.opponents` / `users.statistics.opponentRecord` を新設
- コンボボックス（cmdk）で対戦相手を選択し、勝敗数を表示するクライアントコンポーネントを実装

Closes #497

## Test plan
- [x] `npm run test:run -- server/application/user/user-statistics-service.test.ts` で新規テストが通ること
- [x] `npm run test:run` で既存テストが壊れていないこと
- [x] `npx tsc --noEmit` で型エラーがないこと
- [x] dev 環境でユーザー詳細ページを開き、対戦相手を選択して成績が表示されること

🤖 Generated with [Claude Code](https://claude.com/claude-code)