### PR TITLE
perf: getOpponents の対戦相手ID取得を DISTINCT クエリに最適化

### DIFF
--- a/server/application/match-history/match-history-service.test.ts
+++ b/server/application/match-history/match-history-service.test.ts
@@ -17,6 +17,7 @@ const matchRepository = {
   listByPlayerId: vi.fn(),
   listByBothPlayerIds: vi.fn(),
   listByPlayerIdWithCircle: vi.fn(),
+  listDistinctOpponentIds: vi.fn(),
   save: vi.fn(),
 } satisfies MatchRepository;
 

--- a/server/application/match/match-service.test.ts
+++ b/server/application/match/match-service.test.ts
@@ -21,6 +21,7 @@ const matchRepository = {
   listByPlayerId: vi.fn(),
   listByBothPlayerIds: vi.fn(),
   listByPlayerIdWithCircle: vi.fn(),
+  listDistinctOpponentIds: vi.fn(),
   save: vi.fn(),
 } satisfies MatchRepository;
 
@@ -316,6 +317,7 @@ describe("UnitOfWork 経路", () => {
     listByPlayerId: vi.fn(),
     listByBothPlayerIds: vi.fn(),
     listByPlayerIdWithCircle: vi.fn(),
+    listDistinctOpponentIds: vi.fn(),
     save: vi.fn(),
   } satisfies MatchRepository;
 
@@ -348,6 +350,7 @@ describe("UnitOfWork 経路", () => {
     listByPlayerId: vi.fn(),
     listByBothPlayerIds: vi.fn(),
     listByPlayerIdWithCircle: vi.fn(),
+    listDistinctOpponentIds: vi.fn(),
     save: vi.fn(),
   } satisfies MatchRepository;
 

--- a/server/application/service-container.test.ts
+++ b/server/application/service-container.test.ts
@@ -32,6 +32,7 @@ const createMatchStub = () => ({
   listByPlayerId: vi.fn(),
   listByBothPlayerIds: vi.fn(),
   listByPlayerIdWithCircle: vi.fn(),
+  listDistinctOpponentIds: vi.fn(),
   save: vi.fn(),
 });
 

--- a/server/application/user/user-statistics-service.test.ts
+++ b/server/application/user/user-statistics-service.test.ts
@@ -17,6 +17,7 @@ const matchRepository = {
   listByPlayerId: vi.fn(),
   listByBothPlayerIds: vi.fn(),
   listByPlayerIdWithCircle: vi.fn(),
+  listDistinctOpponentIds: vi.fn(),
   save: vi.fn(),
 } satisfies MatchRepository;
 
@@ -380,7 +381,7 @@ describe("UserStatisticsService", () => {
 
   describe("getOpponents", () => {
     test("対局なしの場合、空配列を返す", async () => {
-      matchRepository.listByPlayerId.mockResolvedValue([]);
+      matchRepository.listDistinctOpponentIds.mockResolvedValue([]);
 
       const result = await service.getOpponents(TARGET_USER);
 
@@ -388,12 +389,8 @@ describe("UserStatisticsService", () => {
       expect(userRepository.findByIds).not.toHaveBeenCalled();
     });
 
-    test("対戦相手を重複排除して名前付きで返す", async () => {
-      matchRepository.listByPlayerId.mockResolvedValue([
-        createTestMatch({ player1Id: TARGET_USER, player2Id: OPPONENT }),
-        createTestMatch({ player1Id: OPPONENT, player2Id: TARGET_USER }),
-        createTestMatch({ player1Id: TARGET_USER, player2Id: OPPONENT_B }),
-      ]);
+    test("対戦相手を名前付きで返す", async () => {
+      matchRepository.listDistinctOpponentIds.mockResolvedValue([OPPONENT, OPPONENT_B]);
       userRepository.findByIds.mockResolvedValue([
         { id: OPPONENT, name: "対戦相手A", email: null, image: null, createdAt: new Date() },
         { id: OPPONENT_B, name: "対戦相手B", email: null, image: null, createdAt: new Date() },
@@ -408,9 +405,7 @@ describe("UserStatisticsService", () => {
     });
 
     test("名前がnullのユーザーは「名前未設定」として返す", async () => {
-      matchRepository.listByPlayerId.mockResolvedValue([
-        createTestMatch({ player1Id: TARGET_USER, player2Id: OPPONENT }),
-      ]);
+      matchRepository.listDistinctOpponentIds.mockResolvedValue([OPPONENT]);
       userRepository.findByIds.mockResolvedValue([
         { id: OPPONENT, name: null, email: null, image: null, createdAt: new Date() },
       ]);

--- a/server/application/user/user-statistics-service.ts
+++ b/server/application/user/user-statistics-service.ts
@@ -68,19 +68,12 @@ export const createUserStatisticsService = (
   },
 
   async getOpponents(targetUserId: UserId): Promise<OpponentInfo[]> {
-    const matches =
-      await deps.matchRepository.listByPlayerId(targetUserId);
+    const opponentIds =
+      await deps.matchRepository.listDistinctOpponentIds(targetUserId);
 
-    const opponentIds = new Set<UserId>();
-    for (const match of matches) {
-      const opponentId =
-        match.player1Id === targetUserId ? match.player2Id : match.player1Id;
-      opponentIds.add(opponentId);
-    }
+    if (opponentIds.length === 0) return [];
 
-    if (opponentIds.size === 0) return [];
-
-    const users = await deps.userRepository.findByIds([...opponentIds]);
+    const users = await deps.userRepository.findByIds(opponentIds);
     return users
       .map((u) => ({ userId: u.id, name: u.name ?? "名前未設定" }))
       .sort((a, b) => a.name.localeCompare(b.name, "ja"));

--- a/server/domain/models/match/match-repository.ts
+++ b/server/domain/models/match/match-repository.ts
@@ -16,5 +16,7 @@ export type MatchRepository = {
   listByBothPlayerIds(playerId: UserId, opponentId: UserId): Promise<Match[]>;
   /** Returns non-deleted matches with circle info via CircleSession. */
   listByPlayerIdWithCircle(playerId: UserId): Promise<MatchWithCircle[]>;
+  /** 論理削除を除外し、player1/player2 両方のポジションから対戦相手IDを重複排除して返す。 */
+  listDistinctOpponentIds(playerId: UserId): Promise<UserId[]>;
   save(match: Match): Promise<void>;
 };

--- a/server/infrastructure/repository/match/prisma-match-repository.ts
+++ b/server/infrastructure/repository/match/prisma-match-repository.ts
@@ -11,7 +11,7 @@ import type {
   MatchId,
   UserId,
 } from "@/server/domain/common/ids";
-import { circleId } from "@/server/domain/common/ids";
+import { circleId, userId } from "@/server/domain/common/ids";
 import { toPersistenceId } from "@/server/infrastructure/common/id-utils";
 
 export const createPrismaMatchRepository = (
@@ -101,6 +101,29 @@ export const createPrismaMatchRepository = (
       circleId: circleId(m.session.circleId),
       circleName: m.session.circle.name,
     }));
+  },
+
+  async listDistinctOpponentIds(playerId: UserId): Promise<UserId[]> {
+    const pid = toPersistenceId(playerId);
+
+    const [asPlayer1, asPlayer2] = await Promise.all([
+      client.match.findMany({
+        where: { player1Id: pid, deletedAt: null },
+        select: { player2Id: true },
+        distinct: ["player2Id"],
+      }),
+      client.match.findMany({
+        where: { player2Id: pid, deletedAt: null },
+        select: { player1Id: true },
+        distinct: ["player1Id"],
+      }),
+    ]);
+
+    const ids = new Set<string>();
+    for (const m of asPlayer1) ids.add(m.player2Id);
+    for (const m of asPlayer2) ids.add(m.player1Id);
+
+    return [...ids].map(userId);
   },
 
   async save(match: Match): Promise<void> {


### PR DESCRIPTION
## Summary

Closes #525

- `MatchRepository` に `listDistinctOpponentIds(playerId)` メソッドを追加し、Prisma の `distinct` 句でDB側の重複排除を実現
- `UserStatisticsService.getOpponents()` から全マッチ読み込み＋メモリ上の `Set` 重複排除を削除し、新メソッドに置き換え
- 関連する4テストファイルのモックを更新

## Test plan

- [x] `npx tsc --noEmit` で型チェック通過
- [x] `npm run test:run` で全テスト通過（713テスト）
- [x] `getOpponents` 関連テスト3件が正しく動作することを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)