### PR TITLE
feat: 研究会名に maxLength(50) 制約を追加

### DIFF
--- a/app/components/circle-create-dialog.tsx
+++ b/app/components/circle-create-dialog.tsx
@@ -88,6 +88,7 @@ export function CircleCreateDialog() {
             value={name}
             onChange={(event) => setName(event.target.value)}
             placeholder="研究会名"
+            maxLength={50}
             aria-required="true"
             className="mt-2 bg-white"
           />

--- a/server/domain/models/circle/circle.test.ts
+++ b/server/domain/models/circle/circle.test.ts
@@ -28,4 +28,25 @@ describe("Circle ドメイン", () => {
     const circle = createCircle({ id: circleId("circle-1"), name: "Home" });
     expect(() => renameCircle(circle, "  ")).toThrow("Circle name is required");
   });
+
+  test("createCircle は50文字ちょうどの名前を受け入れる", () => {
+    const name = "あ".repeat(50);
+    const circle = createCircle({ id: circleId("circle-1"), name });
+    expect(circle.name).toBe(name);
+  });
+
+  test("createCircle は51文字以上の名前を拒否する", () => {
+    const name = "あ".repeat(51);
+    expect(() => createCircle({ id: circleId("circle-1"), name })).toThrow(
+      "Circle name must be at most 50 characters",
+    );
+  });
+
+  test("renameCircle は51文字以上の名前を拒否する", () => {
+    const circle = createCircle({ id: circleId("circle-1"), name: "Home" });
+    const name = "あ".repeat(51);
+    expect(() => renameCircle(circle, name)).toThrow(
+      "Circle name must be at most 50 characters",
+    );
+  });
 });

--- a/server/domain/models/circle/circle.ts
+++ b/server/domain/models/circle/circle.ts
@@ -1,5 +1,8 @@
 import type { CircleId } from "@/server/domain/common/ids";
-import { assertNonEmpty } from "@/server/domain/common/validation";
+import {
+  assertMaxLength,
+  assertNonEmpty,
+} from "@/server/domain/common/validation";
 
 export type Circle = {
   id: CircleId;
@@ -15,11 +18,19 @@ export type CircleCreateParams = {
 
 export const createCircle = (params: CircleCreateParams): Circle => ({
   id: params.id,
-  name: assertNonEmpty(params.name, "Circle name"),
+  name: assertMaxLength(
+    assertNonEmpty(params.name, "Circle name"),
+    50,
+    "Circle name",
+  ),
   createdAt: params.createdAt ?? new Date(),
 });
 
 export const renameCircle = (circle: Circle, name: string): Circle => ({
   ...circle,
-  name: assertNonEmpty(name, "Circle name"),
+  name: assertMaxLength(
+    assertNonEmpty(name, "Circle name"),
+    50,
+    "Circle name",
+  ),
 });

--- a/server/presentation/dto/circle.ts
+++ b/server/presentation/dto/circle.ts
@@ -16,14 +16,14 @@ export const circleGetInputSchema = z.object({
 export type CircleGetInput = z.infer<typeof circleGetInputSchema>;
 
 export const circleCreateInputSchema = z.object({
-  name: z.string().trim().min(1),
+  name: z.string().trim().min(1).max(50),
 });
 
 export type CircleCreateInput = z.infer<typeof circleCreateInputSchema>;
 
 export const circleRenameInputSchema = z.object({
   circleId: circleIdSchema,
-  name: z.string().trim().min(1),
+  name: z.string().trim().min(1).max(50),
 });
 
 export type CircleRenameInput = z.infer<typeof circleRenameInputSchema>;


### PR DESCRIPTION
## Summary

Closes #466

- ドメイン層: `createCircle` / `renameCircle` に `assertMaxLength(50)` を追加
- プレゼンテーション層: `circleCreateInputSchema` / `circleRenameInputSchema` に Zod `.max(50)` を追加
- クライアント層: `circle-create-dialog.tsx` の `<Input>` に `maxLength={50}` を追加
- 境界値テスト3件を追加（50文字受入、51文字拒否 x createCircle/renameCircle）

## Test plan

- [ ] `npm run test:run -- server/domain/models/circle/circle.test.ts` → 7 tests passed
- [ ] `npx tsc --noEmit` → エラーなし
- [ ] 研究会作成ダイアログで50文字超の入力が制限されることを確認
- [ ] API 直接呼び出しで51文字以上の名前が Zod エラーになることを確認

## Follow-up issues

- #531 バリデーション上限値のマジックナンバーを定数化する
- #532 Circle.name に DB レベルの VarChar 制約を追加する
- #533 研究会作成ダイアログに文字数カウンターを表示する

🤖 Generated with [Claude Code](https://claude.com/claude-code)