### PR TITLE
refactor: バリデーション上限値のマジックナンバーを定数化 (#531)

### DIFF
--- a/app/components/circle-create-dialog.tsx
+++ b/app/components/circle-create-dialog.tsx
@@ -12,6 +12,7 @@ import {
 } from "@/components/ui/dialog";
 import { Input } from "@/components/ui/input";
 import { trpc } from "@/lib/trpc/client";
+import { CIRCLE_NAME_MAX_LENGTH } from "@/server/domain/models/circle/circle";
 import { CirclePlus } from "lucide-react";
 import { useRouter } from "next/navigation";
 import type { FormEvent } from "react";
@@ -88,7 +89,7 @@ export function CircleCreateDialog() {
             value={name}
             onChange={(event) => setName(event.target.value)}
             placeholder="研究会名"
-            maxLength={50}
+            maxLength={CIRCLE_NAME_MAX_LENGTH}
             aria-required="true"
             className="mt-2 bg-white"
           />

--- a/server/domain/models/circle-session/circle-session.ts
+++ b/server/domain/models/circle-session/circle-session.ts
@@ -6,6 +6,8 @@ import {
   assertValidDate,
 } from "@/server/domain/common/validation";
 
+export const CIRCLE_SESSION_TITLE_MAX_LENGTH = 100;
+
 export type CircleSession = {
   id: CircleSessionId;
   circleId: CircleId;
@@ -36,7 +38,7 @@ export const createCircleSession = (
   assertStartBeforeEnd(startsAt, endsAt, "CircleSession");
   const title = assertMaxLength(
     assertNonEmpty(params.title, "CircleSession title"),
-    100,
+    CIRCLE_SESSION_TITLE_MAX_LENGTH,
     "CircleSession title",
   );
 

--- a/server/domain/models/circle/circle.ts
+++ b/server/domain/models/circle/circle.ts
@@ -4,6 +4,8 @@ import {
   assertNonEmpty,
 } from "@/server/domain/common/validation";
 
+export const CIRCLE_NAME_MAX_LENGTH = 50;
+
 export type Circle = {
   id: CircleId;
   name: string;
@@ -20,7 +22,7 @@ export const createCircle = (params: CircleCreateParams): Circle => ({
   id: params.id,
   name: assertMaxLength(
     assertNonEmpty(params.name, "Circle name"),
-    50,
+    CIRCLE_NAME_MAX_LENGTH,
     "Circle name",
   ),
   createdAt: params.createdAt ?? new Date(),
@@ -30,7 +32,7 @@ export const renameCircle = (circle: Circle, name: string): Circle => ({
   ...circle,
   name: assertMaxLength(
     assertNonEmpty(name, "Circle name"),
-    50,
+    CIRCLE_NAME_MAX_LENGTH,
     "Circle name",
   ),
 });

--- a/server/presentation/dto/circle-session.ts
+++ b/server/presentation/dto/circle-session.ts
@@ -1,4 +1,5 @@
 import { z } from "zod";
+import { CIRCLE_SESSION_TITLE_MAX_LENGTH } from "@/server/domain/models/circle-session/circle-session";
 import {
   circleIdSchema,
   circleSessionIdSchema,
@@ -39,7 +40,7 @@ export const circleSessionCreateInputSchema = z.object({
   title: z
     .string()
     .transform(trimWithFullwidth)
-    .pipe(z.string().min(1).max(100)),
+    .pipe(z.string().min(1).max(CIRCLE_SESSION_TITLE_MAX_LENGTH)),
   startsAt: dateInputSchema,
   endsAt: dateInputSchema,
   location: z.string().nullable().optional(),
@@ -56,7 +57,7 @@ export const circleSessionUpdateInputSchema = z
     title: z
       .string()
       .transform(trimWithFullwidth)
-      .pipe(z.string().min(1).max(100))
+      .pipe(z.string().min(1).max(CIRCLE_SESSION_TITLE_MAX_LENGTH))
       .optional(),
     startsAt: dateInputSchema.optional(),
     endsAt: dateInputSchema.optional(),

--- a/server/presentation/dto/circle.ts
+++ b/server/presentation/dto/circle.ts
@@ -1,4 +1,5 @@
 import { z } from "zod";
+import { CIRCLE_NAME_MAX_LENGTH } from "@/server/domain/models/circle/circle";
 import { circleIdSchema } from "@/server/presentation/dto/ids";
 
 export const circleDtoSchema = z.object({
@@ -16,14 +17,14 @@ export const circleGetInputSchema = z.object({
 export type CircleGetInput = z.infer<typeof circleGetInputSchema>;
 
 export const circleCreateInputSchema = z.object({
-  name: z.string().trim().min(1).max(50),
+  name: z.string().trim().min(1).max(CIRCLE_NAME_MAX_LENGTH),
 });
 
 export type CircleCreateInput = z.infer<typeof circleCreateInputSchema>;
 
 export const circleRenameInputSchema = z.object({
   circleId: circleIdSchema,
-  name: z.string().trim().min(1).max(50),
+  name: z.string().trim().min(1).max(CIRCLE_NAME_MAX_LENGTH),
 });
 
 export type CircleRenameInput = z.infer<typeof circleRenameInputSchema>;


### PR DESCRIPTION
## Summary

Closes #531

- Domain層に `CIRCLE_NAME_MAX_LENGTH` (50) と `CIRCLE_SESSION_TITLE_MAX_LENGTH` (100) を定数として定義
- Presentation層（Zod スキーマ）とFrontend層（`maxLength` 属性）からこれらの定数を参照するよう変更
- マジックナンバーの重複を排除し、値の変更時に一箇所の修正で済むようにした

## 変更ファイル

| ファイル | 変更内容 |
|---|---|
| `server/domain/models/circle/circle.ts` | `CIRCLE_NAME_MAX_LENGTH = 50` を定義・使用 |
| `server/domain/models/circle-session/circle-session.ts` | `CIRCLE_SESSION_TITLE_MAX_LENGTH = 100` を定義・使用 |
| `server/presentation/dto/circle.ts` | Zodスキーマで定数を参照 |
| `server/presentation/dto/circle-session.ts` | Zodスキーマで定数を参照 |
| `app/components/circle-create-dialog.tsx` | `maxLength` 属性で定数を参照 |

## Test plan

- [x] `npm run test:run` が全件パス
- [x] `npx tsc --noEmit` が型エラーなし
- [x] `npm run lint` がエラーなし
- [x] 研究会作成ダイアログで50文字制限が従来通り動作する

🤖 Generated with [Claude Code](https://claude.com/claude-code)