### PR TITLE
feat: セッション作成フォームのタイトル入力に maxLength を追加

### DIFF
--- a/app/(authenticated)/circles/[circleId]/sessions/new/circle-session-create-form.tsx
+++ b/app/(authenticated)/circles/[circleId]/sessions/new/circle-session-create-form.tsx
@@ -8,6 +8,7 @@ import { Input } from "@/components/ui/input";
 import { Textarea } from "@/components/ui/textarea";
 import { trpc } from "@/lib/trpc/client";
 import { trimWithFullwidth } from "@/lib/string";
+import { CIRCLE_SESSION_TITLE_MAX_LENGTH } from "@/server/domain/models/circle-session/circle-session";
 import { useRouter } from "next/navigation";
 
 type CircleSessionCreateFormProps = {
@@ -126,6 +127,7 @@ export function CircleSessionCreateForm({
               setTitleError("");
             }}
             placeholder="第1回 定例研究会"
+            maxLength={CIRCLE_SESSION_TITLE_MAX_LENGTH}
             aria-required="true"
             aria-invalid={titleError ? "true" : undefined}
             aria-describedby={titleError ? "title-error" : undefined}


### PR DESCRIPTION
## Summary

- セッション作成フォームの `<Input>` に `maxLength={CIRCLE_SESSION_TITLE_MAX_LENGTH}` を追加
- サーバー側（Zod + Domain 層）で定義済みの上限値 100 をクライアント側でも適用
- 研究会名入力（`circle-create-dialog.tsx`）との一貫性を確保

Closes #536

## 検証手順

1. `/circles/{circleId}/sessions/new` を開く
2. タイトル入力欄に101文字以上を入力しようとする
3. 100文字で入力が止まることを確認

## レビューポイント

- `CIRCLE_SESSION_TITLE_MAX_LENGTH` の import パスが適切か
- 既存の `circle-create-dialog.tsx` の `maxLength` 実装と一貫しているか

🤖 Generated with [Claude Code](https://claude.com/claude-code)