### PR TITLE
feat: セッション説明欄に maxLength 属性を追加

### DIFF
--- a/app/(authenticated)/circles/[circleId]/sessions/new/circle-session-create-form.tsx
+++ b/app/(authenticated)/circles/[circleId]/sessions/new/circle-session-create-form.tsx
@@ -8,7 +8,10 @@ import { Input } from "@/components/ui/input";
 import { Textarea } from "@/components/ui/textarea";
 import { trpc } from "@/lib/trpc/client";
 import { trimWithFullwidth } from "@/lib/string";
-import { CIRCLE_SESSION_TITLE_MAX_LENGTH } from "@/server/domain/models/circle-session/circle-session";
+import {
+  CIRCLE_SESSION_NOTE_MAX_LENGTH,
+  CIRCLE_SESSION_TITLE_MAX_LENGTH,
+} from "@/server/domain/models/circle-session/circle-session";
 import { useRouter } from "next/navigation";
 
 type CircleSessionCreateFormProps = {
@@ -202,6 +205,7 @@ export function CircleSessionCreateForm({
             id="note"
             value={note}
             onChange={(e) => setNote(e.target.value)}
+            maxLength={CIRCLE_SESSION_NOTE_MAX_LENGTH}
             rows={3}
             className="bg-white"
           />

--- a/server/domain/models/circle-session/circle-session.test.ts
+++ b/server/domain/models/circle-session/circle-session.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, test } from "vitest";
 import { circleId, circleSessionId } from "@/server/domain/common/ids";
 import {
+  CIRCLE_SESSION_NOTE_MAX_LENGTH,
   createCircleSession,
   rescheduleCircleSession,
 } from "@/server/domain/models/circle-session/circle-session";
@@ -108,6 +109,32 @@ describe("CircleSession ドメイン", () => {
         new Date("2024-01-02T12:00:00Z"),
       ),
     ).toThrow("CircleSession start must be before or equal to end");
+  });
+
+  test("createCircleSession は note が最大文字数ちょうどなら作成できる", () => {
+    const session = createCircleSession({
+      id: circleSessionId("session-1"),
+      circleId: circleId("circle-1"),
+      title: "第1回 研究会",
+      startsAt: new Date("2024-01-01T10:00:00Z"),
+      endsAt: new Date("2024-01-01T12:00:00Z"),
+      note: "a".repeat(CIRCLE_SESSION_NOTE_MAX_LENGTH),
+    });
+
+    expect(session.note.length).toBe(CIRCLE_SESSION_NOTE_MAX_LENGTH);
+  });
+
+  test("createCircleSession は note が最大文字数を超える場合拒否する", () => {
+    expect(() =>
+      createCircleSession({
+        id: circleSessionId("session-1"),
+        circleId: circleId("circle-1"),
+        title: "第1回 研究会",
+        startsAt: new Date("2024-01-01T10:00:00Z"),
+        endsAt: new Date("2024-01-01T12:00:00Z"),
+        note: "a".repeat(CIRCLE_SESSION_NOTE_MAX_LENGTH + 1),
+      }),
+    ).toThrow(`CircleSession note must be at most ${CIRCLE_SESSION_NOTE_MAX_LENGTH} characters`);
   });
 
   test("createCircleSession は note 未指定時に空文字を設定する", () => {

--- a/server/domain/models/circle-session/circle-session.ts
+++ b/server/domain/models/circle-session/circle-session.ts
@@ -7,6 +7,7 @@ import {
 } from "@/server/domain/common/validation";
 
 export const CIRCLE_SESSION_TITLE_MAX_LENGTH = 100;
+export const CIRCLE_SESSION_NOTE_MAX_LENGTH = 500;
 
 export type CircleSession = {
   id: CircleSessionId;
@@ -49,7 +50,11 @@ export const createCircleSession = (
     startsAt,
     endsAt,
     location: params.location ?? null,
-    note: params.note?.trim() ?? "",
+    note: assertMaxLength(
+      params.note?.trim() ?? "",
+      CIRCLE_SESSION_NOTE_MAX_LENGTH,
+      "CircleSession note",
+    ),
     createdAt: params.createdAt ?? new Date(),
   };
 };

--- a/server/presentation/dto/circle-session.test.ts
+++ b/server/presentation/dto/circle-session.test.ts
@@ -88,6 +88,24 @@ describe("circleSessionCreateInputSchema", () => {
     });
     expect(result.success).toBe(false);
   });
+
+  test("noteが500文字ちょうどは成功する", () => {
+    const result = circleSessionCreateInputSchema.safeParse({
+      ...validBase,
+      title: "例会",
+      note: "あ".repeat(500),
+    });
+    expect(result.success).toBe(true);
+  });
+
+  test("noteが501文字以上はバリデーションエラーになる", () => {
+    const result = circleSessionCreateInputSchema.safeParse({
+      ...validBase,
+      title: "例会",
+      note: "あ".repeat(501),
+    });
+    expect(result.success).toBe(false);
+  });
 });
 
 describe("circleSessionUpdateInputSchema", () => {
@@ -174,6 +192,22 @@ describe("circleSessionUpdateInputSchema", () => {
     const result = circleSessionUpdateInputSchema.safeParse({
       ...updateBase,
       title: "あ".repeat(101),
+    });
+    expect(result.success).toBe(false);
+  });
+
+  test("noteが500文字ちょうどは成功する", () => {
+    const result = circleSessionUpdateInputSchema.safeParse({
+      ...updateBase,
+      note: "あ".repeat(500),
+    });
+    expect(result.success).toBe(true);
+  });
+
+  test("noteが501文字以上はバリデーションエラーになる", () => {
+    const result = circleSessionUpdateInputSchema.safeParse({
+      ...updateBase,
+      note: "あ".repeat(501),
     });
     expect(result.success).toBe(false);
   });

--- a/server/presentation/dto/circle-session.ts
+++ b/server/presentation/dto/circle-session.ts
@@ -1,5 +1,8 @@
 import { z } from "zod";
-import { CIRCLE_SESSION_TITLE_MAX_LENGTH } from "@/server/domain/models/circle-session/circle-session";
+import {
+  CIRCLE_SESSION_NOTE_MAX_LENGTH,
+  CIRCLE_SESSION_TITLE_MAX_LENGTH,
+} from "@/server/domain/models/circle-session/circle-session";
 import {
   circleIdSchema,
   circleSessionIdSchema,
@@ -44,7 +47,7 @@ export const circleSessionCreateInputSchema = z.object({
   startsAt: dateInputSchema,
   endsAt: dateInputSchema,
   location: z.string().nullable().optional(),
-  note: z.string().optional(),
+  note: z.string().max(CIRCLE_SESSION_NOTE_MAX_LENGTH).optional(),
 });
 
 export type CircleSessionCreateInput = z.infer<
@@ -62,7 +65,7 @@ export const circleSessionUpdateInputSchema = z
     startsAt: dateInputSchema.optional(),
     endsAt: dateInputSchema.optional(),
     location: z.string().nullable().optional(),
-    note: z.string().optional(),
+    note: z.string().max(CIRCLE_SESSION_NOTE_MAX_LENGTH).optional(),
   })
   .refine(
     (value) =>


### PR DESCRIPTION
## Summary

Closes #538

- ドメイン層に `CIRCLE_SESSION_NOTE_MAX_LENGTH` (500) 定数を定義し、`createCircleSession` で文字数上限バリデーションを追加
- DTO の Zod スキーマ（create / update）に `.max(CIRCLE_SESSION_NOTE_MAX_LENGTH)` を追加
- セッション作成フォームの `<Textarea>` に `maxLength` 属性を追加

## Test plan

- [x] `npm run test:run -- server/domain/models/circle-session/circle-session.test.ts` でドメイン層テストが通ること
- [x] `npm run test:run -- server/presentation/dto/circle-session.test.ts` で DTO テストが通ること
- [x] セッション作成画面で説明欄に 500 文字以上入力できないことを確認
- [x] `npx tsc --noEmit` で型エラーがないこと

🤖 Generated with [Claude Code](https://claude.com/claude-code)