### PR TITLE
refactor: CircleSession 更新時のバリデーションをドメイン層に委譲

### DIFF
--- a/server/application/circle-session/circle-session-service.test.ts
+++ b/server/application/circle-session/circle-session-service.test.ts
@@ -7,7 +7,11 @@ import {
   createMockCircleSessionParticipationRepository,
 } from "@/server/application/test-helpers/mock-repositories";
 import { circleId, circleSessionId, userId } from "@/server/domain/common/ids";
-import { createCircleSession } from "@/server/domain/models/circle-session/circle-session";
+import {
+  CIRCLE_SESSION_NOTE_MAX_LENGTH,
+  CIRCLE_SESSION_TITLE_MAX_LENGTH,
+  createCircleSession,
+} from "@/server/domain/models/circle-session/circle-session";
 import { createCircle } from "@/server/domain/models/circle/circle";
 import { CircleSessionRole } from "@/server/domain/services/authz/roles";
 import { beforeEach, describe, expect, test, vi } from "vitest";
@@ -146,6 +150,42 @@ describe("CircleSession サービス", () => {
 
     expect(circleSessionRepository.save).toHaveBeenCalledWith(updated);
     expect(updated.startsAt.toISOString()).toBe("2024-02-01T00:00:00.000Z");
+  });
+
+  test("updateCircleSessionDetails はタイトルが最大文字数超過時にエラー", async () => {
+    const existing = createCircleSession({
+      ...baseSessionParams,
+      createdAt: new Date("2024-01-01T00:00:00Z"),
+    });
+    vi.mocked(circleSessionRepository.findById).mockResolvedValue(existing);
+
+    await expect(
+      service.updateCircleSessionDetails("user-1", existing.id, {
+        title: "a".repeat(CIRCLE_SESSION_TITLE_MAX_LENGTH + 1),
+      }),
+    ).rejects.toThrow(
+      `CircleSession title must be at most ${CIRCLE_SESSION_TITLE_MAX_LENGTH} characters`,
+    );
+
+    expect(circleSessionRepository.save).not.toHaveBeenCalled();
+  });
+
+  test("updateCircleSessionDetails はノートが最大文字数超過時にエラー", async () => {
+    const existing = createCircleSession({
+      ...baseSessionParams,
+      createdAt: new Date("2024-01-01T00:00:00Z"),
+    });
+    vi.mocked(circleSessionRepository.findById).mockResolvedValue(existing);
+
+    await expect(
+      service.updateCircleSessionDetails("user-1", existing.id, {
+        note: "a".repeat(CIRCLE_SESSION_NOTE_MAX_LENGTH + 1),
+      }),
+    ).rejects.toThrow(
+      `CircleSession note must be at most ${CIRCLE_SESSION_NOTE_MAX_LENGTH} characters`,
+    );
+
+    expect(circleSessionRepository.save).not.toHaveBeenCalled();
   });
 
   test("updateCircleSessionDetails はタイトル・場所・メモを更新する", async () => {

--- a/server/application/circle-session/circle-session-service.ts
+++ b/server/application/circle-session/circle-session-service.ts
@@ -1,11 +1,12 @@
 import type { CircleSession } from "@/server/domain/models/circle-session/circle-session";
 import {
   createCircleSession,
+  renameCircleSession,
   rescheduleCircleSession,
+  updateCircleSessionNote,
 } from "@/server/domain/models/circle-session/circle-session";
 import type { CircleId, CircleSessionId } from "@/server/domain/common/ids";
 import { userId } from "@/server/domain/common/ids";
-import { assertNonEmpty } from "@/server/domain/common/validation";
 import type { CircleRepository } from "@/server/domain/models/circle/circle-repository";
 import type { CircleSessionRepository } from "@/server/domain/models/circle-session/circle-session-repository";
 import type { CircleSessionParticipationRepository } from "@/server/domain/models/circle-session/circle-session-participation-repository";
@@ -142,10 +143,7 @@ export const createCircleSessionService = (deps: CircleSessionServiceDeps) => {
       }
 
       if (params.title !== undefined) {
-        updated = {
-          ...updated,
-          title: assertNonEmpty(params.title, "CircleSession title"),
-        };
+        updated = renameCircleSession(updated, params.title);
       }
 
       if (params.location !== undefined) {
@@ -156,10 +154,7 @@ export const createCircleSessionService = (deps: CircleSessionServiceDeps) => {
       }
 
       if (params.note !== undefined) {
-        updated = {
-          ...updated,
-          note: params.note.trim(),
-        };
+        updated = updateCircleSessionNote(updated, params.note);
       }
 
       await deps.circleSessionRepository.save(updated);

--- a/server/domain/models/circle-session/circle-session.test.ts
+++ b/server/domain/models/circle-session/circle-session.test.ts
@@ -2,8 +2,11 @@ import { describe, expect, test } from "vitest";
 import { circleId, circleSessionId } from "@/server/domain/common/ids";
 import {
   CIRCLE_SESSION_NOTE_MAX_LENGTH,
+  CIRCLE_SESSION_TITLE_MAX_LENGTH,
   createCircleSession,
+  renameCircleSession,
   rescheduleCircleSession,
+  updateCircleSessionNote,
 } from "@/server/domain/models/circle-session/circle-session";
 
 describe("CircleSession ドメイン", () => {
@@ -147,5 +150,98 @@ describe("CircleSession ドメイン", () => {
     });
 
     expect(session.note).toBe("");
+  });
+
+  describe("renameCircleSession", () => {
+    const base = createCircleSession({
+      id: circleSessionId("session-1"),
+      circleId: circleId("circle-1"),
+      title: "旧タイトル",
+      startsAt: new Date("2024-01-01T10:00:00Z"),
+      endsAt: new Date("2024-01-01T12:00:00Z"),
+    });
+
+    test("タイトルを更新できる", () => {
+      const renamed = renameCircleSession(base, "新タイトル");
+      expect(renamed.title).toBe("新タイトル");
+    });
+
+    test("前後の空白をトリムする", () => {
+      const renamed = renameCircleSession(base, "  新タイトル  ");
+      expect(renamed.title).toBe("新タイトル");
+    });
+
+    test("空文字を拒否する", () => {
+      expect(() => renameCircleSession(base, "")).toThrow(
+        "CircleSession title is required",
+      );
+    });
+
+    test("空白のみを拒否する", () => {
+      expect(() => renameCircleSession(base, "   ")).toThrow(
+        "CircleSession title is required",
+      );
+    });
+
+    test("最大文字数超過を拒否する", () => {
+      expect(() =>
+        renameCircleSession(base, "a".repeat(CIRCLE_SESSION_TITLE_MAX_LENGTH + 1)),
+      ).toThrow(
+        `CircleSession title must be at most ${CIRCLE_SESSION_TITLE_MAX_LENGTH} characters`,
+      );
+    });
+
+    test("最大文字数ちょうどなら許可する", () => {
+      const renamed = renameCircleSession(
+        base,
+        "a".repeat(CIRCLE_SESSION_TITLE_MAX_LENGTH),
+      );
+      expect(renamed.title.length).toBe(CIRCLE_SESSION_TITLE_MAX_LENGTH);
+    });
+  });
+
+  describe("updateCircleSessionNote", () => {
+    const base = createCircleSession({
+      id: circleSessionId("session-1"),
+      circleId: circleId("circle-1"),
+      title: "研究会",
+      startsAt: new Date("2024-01-01T10:00:00Z"),
+      endsAt: new Date("2024-01-01T12:00:00Z"),
+      note: "旧メモ",
+    });
+
+    test("ノートを更新できる", () => {
+      const updated = updateCircleSessionNote(base, "新メモ");
+      expect(updated.note).toBe("新メモ");
+    });
+
+    test("前後の空白をトリムする", () => {
+      const updated = updateCircleSessionNote(base, "  新メモ  ");
+      expect(updated.note).toBe("新メモ");
+    });
+
+    test("空文字を許可する", () => {
+      const updated = updateCircleSessionNote(base, "");
+      expect(updated.note).toBe("");
+    });
+
+    test("最大文字数超過を拒否する", () => {
+      expect(() =>
+        updateCircleSessionNote(
+          base,
+          "a".repeat(CIRCLE_SESSION_NOTE_MAX_LENGTH + 1),
+        ),
+      ).toThrow(
+        `CircleSession note must be at most ${CIRCLE_SESSION_NOTE_MAX_LENGTH} characters`,
+      );
+    });
+
+    test("最大文字数ちょうどなら許可する", () => {
+      const updated = updateCircleSessionNote(
+        base,
+        "a".repeat(CIRCLE_SESSION_NOTE_MAX_LENGTH),
+      );
+      expect(updated.note.length).toBe(CIRCLE_SESSION_NOTE_MAX_LENGTH);
+    });
   });
 });

--- a/server/domain/models/circle-session/circle-session.ts
+++ b/server/domain/models/circle-session/circle-session.ts
@@ -59,6 +59,30 @@ export const createCircleSession = (
   };
 };
 
+export const renameCircleSession = (
+  session: CircleSession,
+  title: string,
+): CircleSession => ({
+  ...session,
+  title: assertMaxLength(
+    assertNonEmpty(title, "CircleSession title"),
+    CIRCLE_SESSION_TITLE_MAX_LENGTH,
+    "CircleSession title",
+  ),
+});
+
+export const updateCircleSessionNote = (
+  session: CircleSession,
+  note: string,
+): CircleSession => ({
+  ...session,
+  note: assertMaxLength(
+    note.trim(),
+    CIRCLE_SESSION_NOTE_MAX_LENGTH,
+    "CircleSession note",
+  ),
+});
+
 export const rescheduleCircleSession = (
   session: CircleSession,
   startsAt: Date,


### PR DESCRIPTION
## Summary

- `renameCircleSession` / `updateCircleSessionNote` ドメイン関数を新設し、`CircleSessionService.updateCircleSessionDetails()` のインラインバリデーションを置き換え
- サービス層は薄いオーケストレーターとして、ドメイン関数に委譲する構成に統一
- tRPC Zod スキーマ（プレゼンテーション層）+ ドメインファクトリ（ドメイン層）の二重防御を実現

Closes #541

## Test plan

- [x] ドメインテスト 21件パス（`circle-session.test.ts`）
- [x] サービステスト 14件パス（`circle-session-service.test.ts`）
- [x] `npx tsc --noEmit` 型チェックパス
- [ ] `renameCircleSession`: 空文字拒否、空白のみ拒否、最大長超過拒否、最大長ちょうど許可、トリムを確認
- [ ] `updateCircleSessionNote`: 空文字許可、最大長超過拒否、最大長ちょうど許可、トリムを確認
- [ ] サービス層で認可チェックがバリデーション前に実行されることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)