### PR TITLE
feat: 研究会削除機能を追加

### DIFF
--- a/app/(authenticated)/circles/components/circle-delete-button.tsx
+++ b/app/(authenticated)/circles/components/circle-delete-button.tsx
@@ -1,0 +1,117 @@
+"use client";
+
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+  AlertDialogTrigger,
+} from "@/components/ui/alert-dialog";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { trpc } from "@/lib/trpc/client";
+import { Trash2 } from "lucide-react";
+import { useRouter } from "next/navigation";
+import { useState } from "react";
+import { toast } from "sonner";
+
+type CircleDeleteButtonProps = {
+  circleId: string;
+  circleName: string;
+};
+
+export function CircleDeleteButton({
+  circleId,
+  circleName,
+}: CircleDeleteButtonProps) {
+  const [open, setOpen] = useState(false);
+  const [confirmText, setConfirmText] = useState("");
+  const router = useRouter();
+
+  const deleteCircle = trpc.circles.delete.useMutation({
+    onSuccess: () => {
+      router.push("/");
+    },
+    onError: () => {
+      setOpen(false);
+      toast.error("研究会の削除に失敗しました");
+    },
+  });
+
+  const handleDelete = () => {
+    deleteCircle.mutate({ circleId });
+  };
+
+  const isConfirmed = confirmText === circleName;
+
+  return (
+    <AlertDialog
+      open={open}
+      onOpenChange={(v) => {
+        if (!deleteCircle.isPending) {
+          setOpen(v);
+          if (!v) setConfirmText("");
+        }
+      }}
+    >
+      <AlertDialogTrigger asChild>
+        <Button
+          variant="destructive"
+          className="w-full"
+          aria-label={`「${circleName}」を削除`}
+        >
+          <Trash2 className="size-4" aria-hidden="true" />
+          研究会を削除
+        </Button>
+      </AlertDialogTrigger>
+      <AlertDialogContent>
+        <AlertDialogHeader>
+          <AlertDialogTitle>研究会を削除</AlertDialogTitle>
+          <AlertDialogDescription>
+            削除すると、セッション・参加者情報・対局結果もすべて削除されます。この操作は取り消せません。
+          </AlertDialogDescription>
+        </AlertDialogHeader>
+        <div className="space-y-3">
+          <div className="rounded-xl border border-border/60 bg-(--brand-ink)/5 px-3 py-2 text-sm font-semibold text-(--brand-ink)">
+            {circleName}
+          </div>
+          <div>
+            <p className="mb-1.5 text-sm text-(--brand-ink-muted)">
+              確認のため、研究会名
+              <span className="font-semibold text-(--brand-ink)">
+                {" "}
+                {circleName}{" "}
+              </span>
+              を入力してください
+            </p>
+            <Input
+              value={confirmText}
+              onChange={(e) => setConfirmText(e.target.value)}
+              placeholder={circleName}
+              disabled={deleteCircle.isPending}
+            />
+          </div>
+        </div>
+        <AlertDialogFooter>
+          <AlertDialogCancel disabled={deleteCircle.isPending}>
+            キャンセル
+          </AlertDialogCancel>
+          <AlertDialogAction
+            variant="destructive"
+            onClick={(e) => {
+              e.preventDefault();
+              handleDelete();
+            }}
+            disabled={!isConfirmed || deleteCircle.isPending}
+          >
+            {deleteCircle.isPending ? "削除中…" : "削除する"}
+          </AlertDialogAction>
+        </AlertDialogFooter>
+      </AlertDialogContent>
+    </AlertDialog>
+  );
+}

--- a/app/(authenticated)/circles/components/circle-overview-view.test.tsx
+++ b/app/(authenticated)/circles/components/circle-overview-view.test.tsx
@@ -31,6 +31,15 @@ vi.mock(
   }),
 );
 
+vi.mock(
+  "@/app/(authenticated)/circles/components/circle-delete-button",
+  () => ({
+    CircleDeleteButton: () => (
+      <button data-testid="circle-delete-button">削除</button>
+    ),
+  }),
+);
+
 afterEach(() => {
   cleanup();
 });
@@ -48,6 +57,7 @@ function buildOverview(
     sessions: [],
     members: [],
     holidayDates: [],
+    canDeleteCircle: false,
     ...overrides,
   };
 }
@@ -115,5 +125,27 @@ describe("CircleOverviewView ロールベース表示制御", () => {
     const calendar = screen.getByTestId("calendar");
     expect(calendar.dataset.createHref).toBe("");
     expect(screen.queryByTestId("create-link")).not.toBeInTheDocument();
+  });
+
+  it("canDeleteCircle が true の場合、削除ボタンが表示される", () => {
+    render(
+      <CircleOverviewView
+        overview={buildOverview({ canDeleteCircle: true })}
+      />,
+    );
+
+    expect(screen.getByTestId("circle-delete-button")).toBeInTheDocument();
+  });
+
+  it("canDeleteCircle が false の場合、削除ボタンが表示されない", () => {
+    render(
+      <CircleOverviewView
+        overview={buildOverview({ canDeleteCircle: false })}
+      />,
+    );
+
+    expect(
+      screen.queryByTestId("circle-delete-button"),
+    ).not.toBeInTheDocument();
   });
 });

--- a/app/(authenticated)/circles/components/circle-overview-view.tsx
+++ b/app/(authenticated)/circles/components/circle-overview-view.tsx
@@ -1,3 +1,4 @@
+import { CircleDeleteButton } from "@/app/(authenticated)/circles/components/circle-delete-button";
 import { CircleOverviewCalendar } from "@/app/(authenticated)/circles/components/circle-overview-calendar";
 import { CircleWithdrawButton } from "@/app/(authenticated)/circles/components/circle-withdraw-button";
 import type {
@@ -194,6 +195,21 @@ export function CircleOverviewView({
           </div>
         </div>
       </section>
+
+      {overview.canDeleteCircle ? (
+        <section className="rounded-2xl border border-red-200 bg-white/90 p-6 shadow-sm">
+          <p className="mb-1 text-sm font-semibold text-red-700">
+            危険な操作
+          </p>
+          <p className="mb-4 text-xs text-(--brand-ink-muted)">
+            研究会を削除すると、すべてのデータが完全に削除されます。この操作は取り消せません。
+          </p>
+          <CircleDeleteButton
+            circleId={overview.circleId}
+            circleName={overview.circleName}
+          />
+        </section>
+      ) : null}
     </div>
   );
 }

--- a/server/presentation/providers/circle-overview-provider.ts
+++ b/server/presentation/providers/circle-overview-provider.ts
@@ -56,12 +56,18 @@ export async function getCircleOverviewViewModel(
     throw new NotFoundError("Circle");
   }
 
-  const users = await caller.users.list({
-    userIds: participations.map((p) => p.userId),
-  });
+  const viewerId = ctx.actorId ?? null;
+
+  const [users, canDeleteCircle] = await Promise.all([
+    caller.users.list({
+      userIds: participations.map((p) => p.userId),
+    }),
+    viewerId
+      ? ctx.accessService.canDeleteCircle(viewerId, circleId)
+      : Promise.resolve(false),
+  ]);
   const userNameById = new Map(users.map((user) => [user.id, user.name]));
 
-  const viewerId = ctx.actorId ?? null;
   const viewerRole = getViewerRole(participations, viewerId);
 
   const allSessions = sessions
@@ -98,6 +104,7 @@ export async function getCircleOverviewViewModel(
       role: roleKeyByDto[participation.role] ?? "member",
     })),
     holidayDates: ctx.holidayProvider.getHolidayDateStringsForRange(),
+    canDeleteCircle,
   };
 
   return overview;

--- a/server/presentation/view-models/circle-overview.ts
+++ b/server/presentation/view-models/circle-overview.ts
@@ -28,4 +28,5 @@ export type CircleOverviewViewModel = {
   sessions: CircleOverviewSession[];
   members: CircleOverviewMember[];
   holidayDates: string[];
+  canDeleteCircle: boolean;
 };


### PR DESCRIPTION
## Summary

- Closes #547
- 研究会概要ページの最下部に、Owner のみに表示される「危険な操作」セクションと削除ボタンを追加
- GitHub のリポジトリ削除と同様に、研究会名の完全一致を入力させる確認ダイアログを実装
- 認可チェックは Provider（UI表示制御）・tRPC（認証）・Service（認可）の3層で実施

## Changes

| ファイル | 変更内容 |
|---------|---------|
| `circle-delete-button.tsx` | 新規: 確認入力付き削除ダイアログコンポーネント |
| `circle-overview-view.tsx` | 「危険な操作」セクションを追加（`canDeleteCircle` で表示制御） |
| `circle-overview.ts` | ViewModel に `canDeleteCircle: boolean` を追加 |
| `circle-overview-provider.ts` | `AccessService.canDeleteCircle()` による認可チェックを追加 |
| `circle-overview-view.test.tsx` | 削除ボタンの表示/非表示テスト2件追加 |

## Test plan

- [x] CircleOwner でログインし、研究会概要ページ最下部に「危険な操作」セクションと削除ボタンが表示されることを確認
- [x] Manager/Member でログインし、削除ボタンが表示されないことを確認
- [x] 削除ボタンクリックで確認ダイアログが開き、研究会名の完全一致で「削除する」ボタンが有効化されることを確認
- [x] 削除成功後 `/` にリダイレクトされることを確認
- [x] `npm run test:run -- app/(authenticated)/circles/components/circle-overview-view.test.tsx` が全通過
- [x] `npx tsc --noEmit` 型エラーなし

## Follow-up

- #549: CircleDeleteButton の単体テストを追加

🤖 Generated with [Claude Code](https://claude.com/claude-code)