### PR TITLE
docs: Ubiquitous Language を正式辞書として確立

### DIFF
--- a/docs/design/07_bounded_contexts.md
+++ b/docs/design/07_bounded_contexts.md
@@ -20,8 +20,9 @@
 
 ### 主要エンティティ/値
 
-- Circle
+- **Circle**（Aggregate Root）
 - CircleMembership（研究会参加）
+- **CircleInviteLink**（独立した Aggregate Root）
 
 ### 代表的な不変条件
 
@@ -43,7 +44,7 @@
 
 ### 主要エンティティ/値
 
-- CircleSession
+- **CircleSession**（Aggregate Root）
 - CircleSessionMembership（セッション参加）
 
 ### 代表的な不変条件
@@ -67,7 +68,7 @@
 
 ### 主要エンティティ/値
 
-- Match
+- **Match**（Aggregate Root）
 - MatchHistory
 
 ### 代表的な不変条件
@@ -89,7 +90,7 @@
 
 ### 主要エンティティ/値
 
-- User（登録済みユーザー）
+- **User**（Aggregate Root）
 - CircleRole / CircleSessionRole
 
 ### 代表的な不変条件

--- a/docs/glossary.md
+++ b/docs/glossary.md
@@ -26,3 +26,157 @@
 | -------------- | ----------------------- | ----------------------------------------------- |
 | 研究会参加     | CircleMembership        | ユーザーと研究会の関連（ロールを 1 つ保持）     |
 | セッション参加 | CircleSessionMembership | ユーザーとセッションの関連（ロールを 1 つ保持） |
+| 招待リンク     | CircleInviteLink        | 研究会への招待用リンク                          |
+
+## Ubiquitous Language
+
+本セクションでは、ドメイン用語の構造的な関係とコード上の名前の対応を整理する。
+
+### 集約（Aggregate）一覧
+
+| Aggregate Root    | 関連エンティティ                | Repository                         | Context        |
+| ----------------- | ------------------------------- | ---------------------------------- | -------------- |
+| Circle            | CircleMembership                | CircleRepository                   | Circle         |
+| CircleInviteLink  | -                               | CircleInviteLinkRepository         | Circle         |
+| CircleSession     | CircleSessionMembership         | CircleSessionRepository            | CircleSession  |
+| Match             | MatchHistory                    | MatchRepository                    | Match          |
+| User              | -                               | UserRepository                     | Auth           |
+
+### 用語階層構造
+
+```
+Circle（研究会）
+├── CircleMembership（研究会参加）
+│   └── CircleRole（CircleOwner / CircleManager / CircleMember）
+├── CircleSession（セッション）
+│   ├── CircleSessionMembership（セッション参加）
+│   │   └── CircleSessionRole（CircleSessionOwner / CircleSessionManager / CircleSessionMember）
+│   └── Match（対局結果）
+│       └── MatchHistory（対局結果の編集履歴）
+└── CircleInviteLink（招待リンク）
+```
+
+※ この階層はドメインのナビゲーション構造を示す。集約の所有関係は「集約（Aggregate）一覧」を参照。
+
+### Docs名⇔Code名 対応表
+
+ドキュメント上の用語（Docs名）と各レイヤーで使用されるコード上の名前の対応を示す。
+
+| Docs名                  | Domain Model               | Prisma Schema           | Presentation DTO              | Application Service                | 備考         |
+| ----------------------- | -------------------------- | ----------------------- | ----------------------------- | ---------------------------------- | ------------ |
+| Circle                  | Circle                     | Circle                  | CircleDto                     | CircleService                      | 統一済み     |
+| CircleMembership        | CircleParticipation        | CircleMembership        | CircleParticipationDto        | CircleParticipationService         | Code側で不統一 |
+| CircleInviteLink        | CircleInviteLink           | CircleInviteLink        | CircleInviteLinkDto           | CircleInviteLinkService            | 統一済み     |
+| CircleSession           | CircleSession              | CircleSession           | CircleSessionDto              | CircleSessionService               | 統一済み     |
+| CircleSessionMembership | CircleSessionParticipation | CircleSessionMembership | CircleSessionParticipationDto | CircleSessionParticipationService  | Code側で不統一 |
+| Match                   | Match                      | Match                   | MatchDto                      | MatchService                       | 統一済み     |
+| MatchHistory            | MatchHistory               | MatchHistory            | MatchHistoryDto               | MatchHistoryService                | 統一済み     |
+| User                    | User                       | User                    | UserDto                       | UserService                        | 統一済み     |
+
+### Entity / ValueObject 分類
+
+ドメイン層の型を Entity と ValueObject に分類する。
+
+#### Entity（識別子を持ち、ライフサイクルがある）
+
+| Entity           | ID 型               | 定義ファイル                                       |
+| ---------------- | -------------------- | -------------------------------------------------- |
+| Circle           | CircleId             | `server/domain/models/circle/circle.ts`            |
+| CircleMembership | CircleMembershipId   | `server/domain/models/circle/circle-participation.ts` |
+| CircleInviteLink | CircleInviteLinkId   | `server/domain/models/circle/circle-invite-link.ts` |
+| CircleSession    | CircleSessionId      | `server/domain/models/circle-session/circle-session.ts` |
+| CircleSessionMembership | CircleSessionMembershipId | `server/domain/models/circle-session/circle-session-participation.ts` |
+| Match            | MatchId              | `server/domain/models/match/match.ts`              |
+| MatchHistory     | MatchHistoryId       | `server/domain/models/match-history/match-history.ts` |
+| User             | UserId               | `server/domain/models/user/user.ts`                |
+
+#### ValueObject（識別子を持たず、値で等価判定する）
+
+| ValueObject          | 型の種類         | 定義ファイル                                        |
+| -------------------- | ---------------- | --------------------------------------------------- |
+| CircleRole           | リテラル共用体   | `server/domain/services/authz/roles.ts`             |
+| CircleSessionRole    | リテラル共用体   | `server/domain/services/authz/roles.ts`             |
+| MatchOutcome         | リテラル共用体   | `server/domain/models/match/match.ts`               |
+| MatchHistoryAction   | リテラル共用体   | `server/domain/models/match-history/match-history.ts` |
+| ProfileVisibility    | リテラル共用体   | `server/domain/models/user/user.ts`                 |
+| DomainErrorCode      | リテラル共用体   | `server/domain/common/errors.ts`                    |
+
+※ Branded Type ID（`CircleId`, `UserId` 等）は Entity の識別子として使用されるが、型としては不変の ValueObject である。定義は `server/domain/common/ids.ts`。
+
+### Repository 命名規則
+
+| 項目             | 規則                                                 | 例                                     |
+| ---------------- | ---------------------------------------------------- | -------------------------------------- |
+| インターフェース名 | `<Entity名>Repository`                              | `CircleRepository`                     |
+| インターフェース配置 | `server/domain/models/<domain>/` または `server/domain/services/<service>/` | `server/domain/models/circle/circle-repository.ts` |
+| 実装クラス名     | `Prisma<Entity名>Repository`                         | `PrismaCircleRepository`               |
+| 実装配置         | `server/infrastructure/repository/<domain>/`          | `server/infrastructure/repository/circle/` |
+| ファクトリ関数   | `createPrisma<Entity名>Repository(client)`            | `createPrismaCircleRepository(client)` |
+| シングルトン     | `prisma<Entity名>Repository`                          | `prismaCircleRepository`               |
+| ファイル名       | ケバブケース `-repository.ts`                         | `circle-repository.ts`                 |
+
+#### Repository 一覧
+
+| Repository                              | 所属 Context   | 対象 Entity              |
+| --------------------------------------- | -------------- | ------------------------ |
+| CircleRepository                        | Circle         | Circle                   |
+| CircleParticipationRepository           | Circle         | CircleMembership         |
+| CircleInviteLinkRepository              | Circle         | CircleInviteLink         |
+| CircleSessionRepository                 | CircleSession  | CircleSession            |
+| CircleSessionParticipationRepository    | CircleSession  | CircleSessionMembership  |
+| MatchRepository                         | Match          | Match                    |
+| MatchHistoryRepository                  | Match          | MatchHistory             |
+| UserRepository                          | Auth           | User                     |
+| SignupRepository                        | Auth           | User（登録専用）         |
+| AuthzRepository                         | Auth           | -（認可クエリ専用）      |
+
+※ CircleParticipationRepository / CircleSessionParticipationRepository は Membership への統一リネーム時に改名予定。
+
+### DomainService 責務整理
+
+ドメインサービスは `server/domain/services/` に配置され、単一の Entity に属さないドメインロジックを担う。
+
+#### authz モジュール（認可ドメインサービス）
+
+| ファイル         | 責務                                             |
+| ---------------- | ------------------------------------------------ |
+| `roles.ts`       | ロール定義と比較（`isSameOrHigherCircleRole` 等） |
+| `memberships.ts` | メンバーシップ状態の判別共用体型とファクトリ関数  |
+| `ownership.ts`   | 所有権の不変条件（単一オーナー制約、移譲ロジック） |
+| `authz-repository.ts` | 認可クエリ用リポジトリインターフェース       |
+
+#### auth モジュール
+
+| ファイル           | 責務                           |
+| ------------------ | ------------------------------ |
+| `session-service.ts` | セッション型定義（インターフェースのみ） |
+
+#### 技術語とドメイン語の境界
+
+| 用語                | 分類       | 説明                                                     |
+| ------------------- | ---------- | -------------------------------------------------------- |
+| CircleRole          | ドメイン語 | 研究会内のロール（Owner / Manager / Member）             |
+| CircleSessionRole   | ドメイン語 | セッション内のロール（Owner / Manager / Member）         |
+| AccessService       | 技術語     | 認可判定を集約するアプリケーションサービス（`server/application/authz/`） |
+| AuthzRepository     | 技術語     | 認可クエリ用リポジトリ（ドメインサービス層に定義）        |
+| Session（NextAuth） | 技術語     | 認証セッション（Auth インフラ関心事、UL 対象外）          |
+| UnitOfWork          | 技術語     | トランザクション境界の抽象化（インフラ関心事）            |
+
+### 既知の用語不整合
+
+#### Membership vs Participation
+
+ドキュメントと Prisma Schema では **Membership** を使用しているが、Domain Model・Application Service・Presentation DTO では **Participation** を使用している。
+
+| 対象                    | Docs / Prisma        | Domain 以降                |
+| ----------------------- | -------------------- | -------------------------- |
+| 研究会参加              | CircleMembership     | CircleParticipation        |
+| セッション参加          | CircleSessionMembership | CircleSessionParticipation |
+
+この不整合は歴史的経緯によるもので、現時点ではシステムの動作に影響はない。統一方針として **Membership に統一する** ことを決定済み。コード側のリネームは別 issue で実施する。
+
+なお、Branded Type ID（`CircleMembershipId`, `CircleSessionMembershipId`）はドメイン層でも Membership を使用しており、エンティティ名（Participation）との不一致がドメイン層内部にも存在する。
+
+#### authz 型の名前衝突
+
+`server/domain/services/authz/memberships.ts` では認可状態を表す判別共用体型として `CircleMembership` / `CircleSessionMembership` を定義している。これはドメインエンティティ（`CircleParticipation` / `CircleSessionParticipation`）とも Prisma モデル（`CircleMembership` / `CircleSessionMembership`）とも異なる別の型であるが、同名のため混同に注意が必要。


### PR DESCRIPTION
## Summary

Closes #555

- `docs/glossary.md` に Ubiquitous Language セクションを追加（集約一覧、用語階層、Docs⇔Code 対応表、Entity/VO 分類、Repository 命名規則、DomainService 責務整理、既知の用語不整合）
- `docs/design/07_bounded_contexts.md` の各 Context に Aggregate Root を明記
- CircleInviteLink を独立 Aggregate Root として追加

## Test plan

- [ ] glossary.md の Markdown テーブル・ツリー図が正しくレンダリングされること
- [ ] 07_bounded_contexts.md の各 Context に Aggregate Root 注釈が付与されていること
- [ ] 集約一覧と bounded_contexts の Aggregate Root 指定が一致すること
- [ ] Docs⇔Code 対応表がコードベースの実態と一致すること

## Follow-up

- #556: Aggregate Root の設計意図を Ubiquitous Language に明記する

🤖 Generated with [Claude Code](https://claude.com/claude-code)