### PR TITLE
docs: Aggregate Root の設計意図を Ubiquitous Language に補足

### DIFF
--- a/docs/glossary.md
+++ b/docs/glossary.md
@@ -42,6 +42,8 @@
 | Match             | MatchHistory                    | MatchRepository                    | Match          |
 | User              | -                               | UserRepository                     | Auth           |
 
+※ 本プロジェクトでは Aggregate Root を「主要エンティティであり、他の集約からは ID でのみ参照される境界」として使用している。厳密な DDD の整合性境界（不変条件の強制、Root 経由の排他的アクセス）は現時点では実装していない。ドメインエンティティはプレーンな TypeScript 型（Anemic Domain Model）であり、関連エンティティごとに独立した Repository を持つ構造になっている。
+
 ### 用語階層構造
 
 ```


### PR DESCRIPTION
## Summary

- `docs/glossary.md` の Bounded Context / Aggregate Root 一覧表の直下に、本プロジェクトにおける Aggregate Root の設計意図を補足する注記を追加
- 厳密な DDD の整合性境界ではなく「主要エンティティ + ID 参照境界」として使用している旨を明記

Closes #556

## Verification

- `docs/glossary.md` の注記が Bounded Context 一覧表の直後に配置されていること
- 注記の内容が Issue #556 の Suggested Approach と一致していること

## Review Points

- 注記の文言・配置位置が適切か
- 将来的に DDD を厳密に適用する際に更新が必要になる箇所の明示が十分か

🤖 Generated with [Claude Code](https://claude.com/claude-code)