### PR TITLE
refactor: authz 判別共用体型を MembershipStatus にリネーム

### DIFF
--- a/docs/glossary.md
+++ b/docs/glossary.md
@@ -165,6 +165,6 @@ Circle（研究会）
 
 ### 既知の用語不整合
 
-#### authz 型の名前衝突
+#### ~~authz 型の名前衝突~~（解消済み）
 
-`server/domain/services/authz/memberships.ts` では認可状態を表す判別共用体型として `CircleMembership` / `CircleSessionMembership` を定義している。これはドメインエンティティ（`server/domain/models/circle/circle-membership.ts` の `CircleMembership`）とも Prisma モデル（`CircleMembership` / `CircleSessionMembership`）とも異なる別の型であるが、同名のため混同に注意が必要。
+`server/domain/services/authz/memberships.ts` の認可状態を表す判別共用体型を `CircleMembershipStatus` / `CircleSessionMembershipStatus` にリネームし、ドメインエンティティ（`CircleMembership`）・Prisma モデル（`CircleMembership` / `CircleSessionMembership`）との名前衝突を解消した。

--- a/server/application/authz/access-service.test.ts
+++ b/server/application/authz/access-service.test.ts
@@ -4,14 +4,14 @@ import {
   createMockUserRepository,
 } from "@/server/application/test-helpers/mock-repositories";
 import type {
-  CircleMembership,
-  CircleSessionMembership,
+  CircleMembershipStatus,
+  CircleSessionMembershipStatus,
 } from "@/server/domain/services/authz/memberships";
 import {
-  circleMembership,
-  circleSessionMembership,
-  noCircleMembership,
-  noCircleSessionMembership,
+  circleMembershipStatus,
+  circleSessionMembershipStatus,
+  noCircleMembershipStatus,
+  noCircleSessionMembershipStatus,
 } from "@/server/domain/services/authz/memberships";
 import type {
   CircleRole,
@@ -43,20 +43,22 @@ const mockedFindCircleSessionMembership = vi.mocked(
   repository.findCircleSessionMembership,
 );
 
-const member = (role: CircleRole): CircleMembership => circleMembership(role);
-const noMember = (): CircleMembership => noCircleMembership();
-const sessionMember = (role: CircleSessionRole): CircleSessionMembership =>
-  circleSessionMembership(role);
-const noSessionMember = (): CircleSessionMembership =>
-  noCircleSessionMembership();
+const member = (role: CircleRole): CircleMembershipStatus =>
+  circleMembershipStatus(role);
+const noMember = (): CircleMembershipStatus => noCircleMembershipStatus();
+const sessionMember = (
+  role: CircleSessionRole,
+): CircleSessionMembershipStatus => circleSessionMembershipStatus(role);
+const noSessionMember = (): CircleSessionMembershipStatus =>
+  noCircleSessionMembershipStatus();
 
-const setCircleMembership = (membership: CircleMembership) => {
+const setCircleMembership = (membership: CircleMembershipStatus) => {
   mockedFindCircleMembership.mockResolvedValue(membership);
 };
 
 const setCircleMemberships = (
-  actorMembership: CircleMembership,
-  targetMembership: CircleMembership,
+  actorMembership: CircleMembershipStatus,
+  targetMembership: CircleMembershipStatus,
 ) => {
   mockedFindCircleMembership.mockImplementation(
     async (requestedUserId: string) =>
@@ -64,13 +66,15 @@ const setCircleMemberships = (
   );
 };
 
-const setCircleSessionMembership = (membership: CircleSessionMembership) => {
+const setCircleSessionMembership = (
+  membership: CircleSessionMembershipStatus,
+) => {
   mockedFindCircleSessionMembership.mockResolvedValue(membership);
 };
 
 const setCircleSessionMemberships = (
-  actorMembership: CircleSessionMembership,
-  targetMembership: CircleSessionMembership,
+  actorMembership: CircleSessionMembershipStatus,
+  targetMembership: CircleSessionMembershipStatus,
 ) => {
   mockedFindCircleSessionMembership.mockImplementation(
     async (requestedUserId: string) =>
@@ -81,9 +85,9 @@ const setCircleSessionMemberships = (
 beforeEach(() => {
   vi.clearAllMocks();
   mockedIsRegisteredUser.mockResolvedValue(false);
-  mockedFindCircleMembership.mockResolvedValue(noCircleMembership());
+  mockedFindCircleMembership.mockResolvedValue(noCircleMembershipStatus());
   mockedFindCircleSessionMembership.mockResolvedValue(
-    noCircleSessionMembership(),
+    noCircleSessionMembershipStatus(),
   );
 });
 
@@ -163,7 +167,7 @@ describe("認可ポリシー", () => {
 
     describe("canEditCircle（研究会編集）", () => {
       const cases: Array<{
-        membership: CircleMembership;
+        membership: CircleMembershipStatus;
         expected: boolean;
       }> = [
         { membership: member("CircleOwner"), expected: true },
@@ -182,7 +186,7 @@ describe("認可ポリシー", () => {
 
     describe("canDeleteCircle（研究会削除）", () => {
       const cases: Array<{
-        membership: CircleMembership;
+        membership: CircleMembershipStatus;
         expected: boolean;
       }> = [
         { membership: member("CircleOwner"), expected: true },
@@ -200,7 +204,7 @@ describe("認可ポリシー", () => {
 
     describe("canRemoveCircleMember（研究会参加者削除）", () => {
       const cases: Array<{
-        membership: CircleMembership;
+        membership: CircleMembershipStatus;
         expected: boolean;
       }> = [
         { membership: member("CircleOwner"), expected: true },
@@ -219,7 +223,7 @@ describe("認可ポリシー", () => {
 
     describe("canTransferCircleOwnership（研究会オーナー移譲）", () => {
       const cases: Array<{
-        membership: CircleMembership;
+        membership: CircleMembershipStatus;
         expected: boolean;
       }> = [
         { membership: member("CircleOwner"), expected: true },
@@ -281,7 +285,7 @@ describe("認可ポリシー", () => {
   describe("セッション", () => {
     describe("canCreateCircleSession（セッション作成）", () => {
       const cases: Array<{
-        membership: CircleMembership;
+        membership: CircleMembershipStatus;
         expected: boolean;
       }> = [
         { membership: member("CircleOwner"), expected: true },
@@ -300,8 +304,8 @@ describe("認可ポリシー", () => {
 
     describe("canViewCircleSession（セッション閲覧）", () => {
       const cases: Array<{
-        circleMembership: CircleMembership;
-        sessionMembership: CircleSessionMembership;
+        circleMembership: CircleMembershipStatus;
+        sessionMembership: CircleSessionMembershipStatus;
         expected: boolean;
       }> = [
         {
@@ -356,7 +360,7 @@ describe("認可ポリシー", () => {
 
     describe("canEditCircleSession（セッション編集）", () => {
       const cases: Array<{
-        membership: CircleSessionMembership;
+        membership: CircleSessionMembershipStatus;
         expected: boolean;
       }> = [
         { membership: sessionMember("CircleSessionOwner"), expected: true },
@@ -375,7 +379,7 @@ describe("認可ポリシー", () => {
 
     describe("canDeleteCircleSession（セッション削除）", () => {
       const cases: Array<{
-        membership: CircleSessionMembership;
+        membership: CircleSessionMembershipStatus;
         expected: boolean;
       }> = [
         { membership: sessionMember("CircleSessionOwner"), expected: true },
@@ -393,7 +397,7 @@ describe("認可ポリシー", () => {
 
     describe("canRemoveCircleSessionMember（セッション参加取消）", () => {
       const cases: Array<{
-        membership: CircleSessionMembership;
+        membership: CircleSessionMembershipStatus;
         expected: boolean;
       }> = [
         { membership: sessionMember("CircleSessionOwner"), expected: true },
@@ -412,7 +416,7 @@ describe("認可ポリシー", () => {
 
     describe("canTransferCircleSessionOwnership（セッションオーナー移譲）", () => {
       const cases: Array<{
-        membership: CircleSessionMembership;
+        membership: CircleSessionMembershipStatus;
         expected: boolean;
       }> = [
         { membership: sessionMember("CircleSessionOwner"), expected: true },
@@ -484,8 +488,8 @@ describe("認可ポリシー", () => {
 
   describe("対局結果", () => {
     const membershipCases: Array<{
-      circleMembership: CircleMembership;
-      sessionMembership: CircleSessionMembership;
+      circleMembership: CircleMembershipStatus;
+      sessionMembership: CircleSessionMembershipStatus;
       expected: boolean;
     }> = [
       {

--- a/server/application/authz/access-service.ts
+++ b/server/application/authz/access-service.ts
@@ -3,8 +3,8 @@ import type { UserRepository } from "@/server/domain/models/user/user-repository
 import { ProfileVisibility } from "@/server/domain/models/user/user";
 import type { UserId } from "@/server/domain/common/ids";
 import {
-  isCircleMember,
-  isCircleSessionMember,
+  isCircleMemberStatus,
+  isCircleSessionMemberStatus,
 } from "@/server/domain/services/authz/memberships";
 import {
   CircleRole,
@@ -50,7 +50,7 @@ export function createAccessService(deps: AccessServiceDeps) {
 
     async canViewCircle(userId: string, circleId: string): Promise<boolean> {
       const membership = await findCircleMembership(userId, circleId);
-      return isCircleMember(membership);
+      return isCircleMemberStatus(membership);
     },
 
     async canWithdrawFromCircle(
@@ -58,20 +58,20 @@ export function createAccessService(deps: AccessServiceDeps) {
       circleId: string,
     ): Promise<boolean> {
       const membership = await findCircleMembership(userId, circleId);
-      return isCircleMember(membership);
+      return isCircleMemberStatus(membership);
     },
 
     async canEditCircle(userId: string, circleId: string): Promise<boolean> {
       const membership = await findCircleMembership(userId, circleId);
       return (
-        isCircleMember(membership) &&
+        isCircleMemberStatus(membership) &&
         (membership.role === CircleOwner || membership.role === CircleManager)
       );
     },
 
     async canDeleteCircle(userId: string, circleId: string): Promise<boolean> {
       const membership = await findCircleMembership(userId, circleId);
-      return isCircleMember(membership) && membership.role === CircleOwner;
+      return isCircleMemberStatus(membership) && membership.role === CircleOwner;
     },
 
     async canAddCircleMember(
@@ -79,7 +79,7 @@ export function createAccessService(deps: AccessServiceDeps) {
       circleId: string,
     ): Promise<boolean> {
       const membership = await findCircleMembership(userId, circleId);
-      return isCircleMember(membership);
+      return isCircleMemberStatus(membership);
     },
 
     async canRemoveCircleMember(
@@ -88,7 +88,7 @@ export function createAccessService(deps: AccessServiceDeps) {
     ): Promise<boolean> {
       const membership = await findCircleMembership(userId, circleId);
       return (
-        isCircleMember(membership) &&
+        isCircleMemberStatus(membership) &&
         (membership.role === CircleOwner || membership.role === CircleManager)
       );
     },
@@ -103,8 +103,8 @@ export function createAccessService(deps: AccessServiceDeps) {
         findCircleMembership(targetId, circleId),
       ]);
       if (
-        !isCircleMember(actorMembership) ||
-        !isCircleMember(targetMembership)
+        !isCircleMemberStatus(actorMembership) ||
+        !isCircleMemberStatus(targetMembership)
       ) {
         return false;
       }
@@ -122,7 +122,7 @@ export function createAccessService(deps: AccessServiceDeps) {
       circleId: string,
     ): Promise<boolean> {
       const membership = await findCircleMembership(userId, circleId);
-      return isCircleMember(membership) && membership.role === CircleOwner;
+      return isCircleMemberStatus(membership) && membership.role === CircleOwner;
     },
 
     async canCreateCircleSession(
@@ -131,7 +131,7 @@ export function createAccessService(deps: AccessServiceDeps) {
     ): Promise<boolean> {
       const membership = await findCircleMembership(userId, circleId);
       return (
-        isCircleMember(membership) &&
+        isCircleMemberStatus(membership) &&
         (membership.role === CircleOwner || membership.role === CircleManager)
       );
     },
@@ -146,8 +146,8 @@ export function createAccessService(deps: AccessServiceDeps) {
         findCircleSessionMembership(userId, circleSessionId),
       ]);
       return (
-        isCircleMember(circleMembership) ||
-        isCircleSessionMember(sessionMembership)
+        isCircleMemberStatus(circleMembership) ||
+        isCircleSessionMemberStatus(sessionMembership)
       );
     },
 
@@ -159,7 +159,7 @@ export function createAccessService(deps: AccessServiceDeps) {
         userId,
         circleSessionId,
       );
-      return isCircleSessionMember(membership);
+      return isCircleSessionMemberStatus(membership);
     },
 
     async canEditCircleSession(
@@ -171,7 +171,7 @@ export function createAccessService(deps: AccessServiceDeps) {
         circleSessionId,
       );
       return (
-        isCircleSessionMember(membership) &&
+        isCircleSessionMemberStatus(membership) &&
         (membership.role === CircleSessionOwner ||
           membership.role === CircleSessionManager)
       );
@@ -186,7 +186,7 @@ export function createAccessService(deps: AccessServiceDeps) {
         circleSessionId,
       );
       return (
-        isCircleSessionMember(membership) &&
+        isCircleSessionMemberStatus(membership) &&
         membership.role === CircleSessionOwner
       );
     },
@@ -199,7 +199,7 @@ export function createAccessService(deps: AccessServiceDeps) {
         userId,
         circleSessionId,
       );
-      return isCircleSessionMember(membership);
+      return isCircleSessionMemberStatus(membership);
     },
 
     async canRemoveCircleSessionMember(
@@ -211,7 +211,7 @@ export function createAccessService(deps: AccessServiceDeps) {
         circleSessionId,
       );
       return (
-        isCircleSessionMember(membership) &&
+        isCircleSessionMemberStatus(membership) &&
         (membership.role === CircleSessionOwner ||
           membership.role === CircleSessionManager)
       );
@@ -227,8 +227,8 @@ export function createAccessService(deps: AccessServiceDeps) {
         findCircleSessionMembership(targetId, circleSessionId),
       ]);
       if (
-        !isCircleSessionMember(actorMembership) ||
-        !isCircleSessionMember(targetMembership)
+        !isCircleSessionMemberStatus(actorMembership) ||
+        !isCircleSessionMemberStatus(targetMembership)
       ) {
         return false;
       }
@@ -250,7 +250,7 @@ export function createAccessService(deps: AccessServiceDeps) {
         circleSessionId,
       );
       return (
-        isCircleSessionMember(membership) &&
+        isCircleSessionMemberStatus(membership) &&
         membership.role === CircleSessionOwner
       );
     },
@@ -265,8 +265,8 @@ export function createAccessService(deps: AccessServiceDeps) {
         findCircleSessionMembership(userId, circleSessionId),
       ]);
       return (
-        isCircleMember(circleMembership) ||
-        isCircleSessionMember(sessionMembership)
+        isCircleMemberStatus(circleMembership) ||
+        isCircleSessionMemberStatus(sessionMembership)
       );
     },
 
@@ -280,8 +280,8 @@ export function createAccessService(deps: AccessServiceDeps) {
         findCircleSessionMembership(userId, circleSessionId),
       ]);
       return (
-        isCircleMember(circleMembership) ||
-        isCircleSessionMember(sessionMembership)
+        isCircleMemberStatus(circleMembership) ||
+        isCircleSessionMemberStatus(sessionMembership)
       );
     },
 
@@ -295,8 +295,8 @@ export function createAccessService(deps: AccessServiceDeps) {
         findCircleSessionMembership(userId, circleSessionId),
       ]);
       return (
-        isCircleMember(circleMembership) ||
-        isCircleSessionMember(sessionMembership)
+        isCircleMemberStatus(circleMembership) ||
+        isCircleSessionMemberStatus(sessionMembership)
       );
     },
 
@@ -310,8 +310,8 @@ export function createAccessService(deps: AccessServiceDeps) {
         findCircleSessionMembership(userId, circleSessionId),
       ]);
       return (
-        isCircleMember(circleMembership) ||
-        isCircleSessionMember(sessionMembership)
+        isCircleMemberStatus(circleMembership) ||
+        isCircleSessionMemberStatus(sessionMembership)
       );
     },
 
@@ -325,8 +325,8 @@ export function createAccessService(deps: AccessServiceDeps) {
         findCircleSessionMembership(userId, circleSessionId),
       ]);
       return (
-        isCircleMember(circleMembership) ||
-        isCircleSessionMember(sessionMembership)
+        isCircleMemberStatus(circleMembership) ||
+        isCircleSessionMemberStatus(sessionMembership)
       );
     },
 

--- a/server/domain/services/authz/authz-repository.ts
+++ b/server/domain/services/authz/authz-repository.ts
@@ -1,6 +1,6 @@
 import type {
-  CircleMembership,
-  CircleSessionMembership,
+  CircleMembershipStatus,
+  CircleSessionMembershipStatus,
 } from "@/server/domain/services/authz/memberships";
 
 export type AuthzRepository = {
@@ -8,9 +8,9 @@ export type AuthzRepository = {
   findCircleMembership(
     userId: string,
     circleId: string,
-  ): Promise<CircleMembership>;
+  ): Promise<CircleMembershipStatus>;
   findCircleSessionMembership(
     userId: string,
     circleSessionId: string,
-  ): Promise<CircleSessionMembership>;
+  ): Promise<CircleSessionMembershipStatus>;
 };

--- a/server/domain/services/authz/memberships.test.ts
+++ b/server/domain/services/authz/memberships.test.ts
@@ -1,87 +1,93 @@
 import { describe, expect, test } from "vitest";
 import {
-  circleMembership,
-  circleMembershipFromRole,
-  circleSessionMembership,
-  circleSessionMembershipFromRole,
-  isCircleMember,
-  isCircleSessionMember,
-  noCircleMembership,
-  noCircleSessionMembership,
+  circleMembershipStatus,
+  circleMembershipStatusFromRole,
+  circleSessionMembershipStatus,
+  circleSessionMembershipStatusFromRole,
+  isCircleMemberStatus,
+  isCircleSessionMemberStatus,
+  noCircleMembershipStatus,
+  noCircleSessionMembershipStatus,
 } from "@/server/domain/services/authz/memberships";
 import {
   CircleRole,
   CircleSessionRole,
 } from "@/server/domain/services/authz/roles";
 
-describe("メンバーシップ", () => {
-  test("circleMembership は member を返す", () => {
-    expect(circleMembership(CircleRole.CircleOwner)).toEqual({
+describe("メンバーシップステータス", () => {
+  test("circleMembershipStatus は member を返す", () => {
+    expect(circleMembershipStatus(CircleRole.CircleOwner)).toEqual({
       kind: "member",
       role: CircleRole.CircleOwner,
     });
   });
 
-  test("noCircleMembership は none を返す", () => {
-    expect(noCircleMembership()).toEqual({ kind: "none" });
+  test("noCircleMembershipStatus は none を返す", () => {
+    expect(noCircleMembershipStatus()).toEqual({ kind: "none" });
   });
 
-  test("circleMembershipFromRole は null で none を返す", () => {
-    expect(circleMembershipFromRole(null)).toEqual({ kind: "none" });
+  test("circleMembershipStatusFromRole は null で none を返す", () => {
+    expect(circleMembershipStatusFromRole(null)).toEqual({ kind: "none" });
   });
 
-  test("circleMembershipFromRole は role で member を返す", () => {
-    expect(circleMembershipFromRole(CircleRole.CircleMember)).toEqual({
+  test("circleMembershipStatusFromRole は role で member を返す", () => {
+    expect(circleMembershipStatusFromRole(CircleRole.CircleMember)).toEqual({
       kind: "member",
       role: CircleRole.CircleMember,
     });
   });
 
-  test("isCircleMember は member で true", () => {
-    expect(isCircleMember(circleMembership(CircleRole.CircleManager))).toBe(
-      true,
-    );
-  });
-
-  test("isCircleMember は none で false", () => {
-    expect(isCircleMember(noCircleMembership())).toBe(false);
-  });
-
-  test("circleSessionMembership は member を返す", () => {
+  test("isCircleMemberStatus は member で true", () => {
     expect(
-      circleSessionMembership(CircleSessionRole.CircleSessionOwner),
+      isCircleMemberStatus(circleMembershipStatus(CircleRole.CircleManager)),
+    ).toBe(true);
+  });
+
+  test("isCircleMemberStatus は none で false", () => {
+    expect(isCircleMemberStatus(noCircleMembershipStatus())).toBe(false);
+  });
+
+  test("circleSessionMembershipStatus は member を返す", () => {
+    expect(
+      circleSessionMembershipStatus(CircleSessionRole.CircleSessionOwner),
     ).toEqual({
       kind: "member",
       role: CircleSessionRole.CircleSessionOwner,
     });
   });
 
-  test("noCircleSessionMembership は none を返す", () => {
-    expect(noCircleSessionMembership()).toEqual({ kind: "none" });
+  test("noCircleSessionMembershipStatus は none を返す", () => {
+    expect(noCircleSessionMembershipStatus()).toEqual({ kind: "none" });
   });
 
-  test("circleSessionMembershipFromRole は null で none を返す", () => {
-    expect(circleSessionMembershipFromRole(null)).toEqual({ kind: "none" });
+  test("circleSessionMembershipStatusFromRole は null で none を返す", () => {
+    expect(circleSessionMembershipStatusFromRole(null)).toEqual({
+      kind: "none",
+    });
   });
 
-  test("circleSessionMembershipFromRole は role で member を返す", () => {
+  test("circleSessionMembershipStatusFromRole は role で member を返す", () => {
     expect(
-      circleSessionMembershipFromRole(CircleSessionRole.CircleSessionMember),
+      circleSessionMembershipStatusFromRole(
+        CircleSessionRole.CircleSessionMember,
+      ),
     ).toEqual({
       kind: "member",
       role: CircleSessionRole.CircleSessionMember,
     });
   });
 
-  test("isCircleSessionMember は member で true", () => {
+  test("isCircleSessionMemberStatus は member で true", () => {
     expect(
-      isCircleSessionMember(
-        circleSessionMembership(CircleSessionRole.CircleSessionManager),
+      isCircleSessionMemberStatus(
+        circleSessionMembershipStatus(CircleSessionRole.CircleSessionManager),
       ),
     ).toBe(true);
   });
 
-  test("isCircleSessionMember は none で false", () => {
-    expect(isCircleSessionMember(noCircleSessionMembership())).toBe(false);
+  test("isCircleSessionMemberStatus は none で false", () => {
+    expect(
+      isCircleSessionMemberStatus(noCircleSessionMembershipStatus()),
+    ).toBe(false);
   });
 });

--- a/server/domain/services/authz/memberships.ts
+++ b/server/domain/services/authz/memberships.ts
@@ -3,47 +3,55 @@ import type {
   CircleSessionRole,
 } from "@/server/domain/services/authz/roles";
 
-export type CircleMembership =
+export type CircleMembershipStatus =
   | { kind: "none" }
   | { kind: "member"; role: CircleRole };
 
-export type CircleSessionMembership =
+export type CircleSessionMembershipStatus =
   | { kind: "none" }
   | { kind: "member"; role: CircleSessionRole };
 
-export const circleMembership = (role: CircleRole): CircleMembership => ({
+export const circleMembershipStatus = (
+  role: CircleRole,
+): CircleMembershipStatus => ({
   kind: "member",
   role,
 });
 
-export const noCircleMembership = (): CircleMembership => ({ kind: "none" });
-
-export const circleMembershipFromRole = (
-  role: CircleRole | null,
-): CircleMembership => (role ? circleMembership(role) : noCircleMembership());
-
-export const isCircleMember = (
-  membership: CircleMembership,
-): membership is { kind: "member"; role: CircleRole } =>
-  membership.kind === "member";
-
-export const circleSessionMembership = (
-  role: CircleSessionRole,
-): CircleSessionMembership => ({
-  kind: "member",
-  role,
-});
-
-export const noCircleSessionMembership = (): CircleSessionMembership => ({
+export const noCircleMembershipStatus = (): CircleMembershipStatus => ({
   kind: "none",
 });
 
-export const circleSessionMembershipFromRole = (
-  role: CircleSessionRole | null,
-): CircleSessionMembership =>
-  role ? circleSessionMembership(role) : noCircleSessionMembership();
+export const circleMembershipStatusFromRole = (
+  role: CircleRole | null,
+): CircleMembershipStatus =>
+  role ? circleMembershipStatus(role) : noCircleMembershipStatus();
 
-export const isCircleSessionMember = (
-  membership: CircleSessionMembership,
+export const isCircleMemberStatus = (
+  membership: CircleMembershipStatus,
+): membership is { kind: "member"; role: CircleRole } =>
+  membership.kind === "member";
+
+export const circleSessionMembershipStatus = (
+  role: CircleSessionRole,
+): CircleSessionMembershipStatus => ({
+  kind: "member",
+  role,
+});
+
+export const noCircleSessionMembershipStatus =
+  (): CircleSessionMembershipStatus => ({
+    kind: "none",
+  });
+
+export const circleSessionMembershipStatusFromRole = (
+  role: CircleSessionRole | null,
+): CircleSessionMembershipStatus =>
+  role
+    ? circleSessionMembershipStatus(role)
+    : noCircleSessionMembershipStatus();
+
+export const isCircleSessionMemberStatus = (
+  membership: CircleSessionMembershipStatus,
 ): membership is { kind: "member"; role: CircleSessionRole } =>
   membership.kind === "member";

--- a/server/infrastructure/mappers/authz-mapper.ts
+++ b/server/infrastructure/mappers/authz-mapper.ts
@@ -3,12 +3,12 @@ import type {
   CircleSessionRole as PrismaCircleSessionRole,
 } from "@/generated/prisma/enums";
 import type {
-  CircleMembership,
-  CircleSessionMembership,
+  CircleMembershipStatus,
+  CircleSessionMembershipStatus,
 } from "@/server/domain/services/authz/memberships";
 import {
-  circleMembershipFromRole,
-  circleSessionMembershipFromRole,
+  circleMembershipStatusFromRole,
+  circleSessionMembershipStatusFromRole,
 } from "@/server/domain/services/authz/memberships";
 import type {
   CircleRole,
@@ -24,12 +24,12 @@ export const mapCircleSessionRoleToDomain = (
 
 export const mapCircleMembershipFromPersistence = (
   role: PrismaCircleRole | null,
-): CircleMembership =>
-  circleMembershipFromRole(role ? mapCircleRoleToDomain(role) : null);
+): CircleMembershipStatus =>
+  circleMembershipStatusFromRole(role ? mapCircleRoleToDomain(role) : null);
 
 export const mapCircleSessionMembershipFromPersistence = (
   role: PrismaCircleSessionRole | null,
-): CircleSessionMembership =>
-  circleSessionMembershipFromRole(
+): CircleSessionMembershipStatus =>
+  circleSessionMembershipStatusFromRole(
     role ? mapCircleSessionRoleToDomain(role) : null,
   );


### PR DESCRIPTION
## Summary

- authz 判別共用体型 `CircleMembership` / `CircleSessionMembership` を `CircleMembershipStatus` / `CircleSessionMembershipStatus` にリネーム
- 関連するファクトリ関数・型ガード関数も同様にリネーム（例: `isCircleMember` → `isCircleMemberStatus`）
- `docs/glossary.md` の「authz 型の名前衝突」セクションを解消済みに更新

Closes #558

## 変更ファイル（7ファイル）

| ファイル | 変更内容 |
|---|---|
| `server/domain/services/authz/memberships.ts` | 型・関数の定義元リネーム |
| `server/domain/services/authz/authz-repository.ts` | 戻り値型のリネーム |
| `server/application/authz/access-service.ts` | 使用箇所のリネーム |
| `server/infrastructure/mappers/authz-mapper.ts` | マッパーのリネーム |
| `server/domain/services/authz/memberships.test.ts` | テストのリネーム |
| `server/application/authz/access-service.test.ts` | テストのリネーム |
| `docs/glossary.md` | 名前衝突セクションを解消済みに更新 |

## Test plan

- [ ] `npm run test:run -- server/domain/services/authz/memberships.test.ts` が通ること
- [ ] `npm run test:run -- server/application/authz/access-service.test.ts` が通ること
- [ ] `npx tsc --noEmit` で型エラーがないこと

🤖 Generated with [Claude Code](https://claude.com/claude-code)