### PR TITLE
refactor: changePasswordRateLimiter を ServiceContainerDeps 経由で注入 (#566)

### DIFF
--- a/server/infrastructure/service-container.test.ts
+++ b/server/infrastructure/service-container.test.ts
@@ -41,6 +41,11 @@ describe("Service container", () => {
       signupRepository,
       circleInviteLinkRepository,
       passwordUtils: { hash: vi.fn(), verify: vi.fn() },
+      changePasswordRateLimiter: {
+        check: vi.fn(),
+        recordFailure: vi.fn(),
+        reset: vi.fn(),
+      },
       holidayProvider: {
         getHolidayDateStrings: vi.fn(),
         getHolidayDateStringsForRange: vi.fn(),

--- a/server/infrastructure/service-container.ts
+++ b/server/infrastructure/service-container.ts
@@ -8,7 +8,7 @@ import { createUserService } from "@/server/application/user/user-service";
 import { createSignupService } from "@/server/application/auth/signup-service";
 import { createCircleInviteLinkService } from "@/server/application/circle/circle-invite-link-service";
 import { createUserStatisticsService } from "@/server/application/user/user-statistics-service";
-import { createInMemoryRateLimiter } from "@/server/infrastructure/rate-limit/in-memory-rate-limiter";
+import type { RateLimiter } from "@/server/application/common/rate-limiter";
 import type { CircleRepository } from "@/server/domain/models/circle/circle-repository";
 import type { CircleMembershipRepository } from "@/server/domain/models/circle/circle-membership-repository";
 import type { CircleSessionRepository } from "@/server/domain/models/circle-session/circle-session-repository";
@@ -51,6 +51,7 @@ export type ServiceContainerDeps = {
   signupRepository: SignupRepository;
   circleInviteLinkRepository: CircleInviteLinkRepository;
   passwordUtils: PasswordUtils;
+  changePasswordRateLimiter: RateLimiter;
   holidayProvider: HolidayProvider;
   unitOfWork?: UnitOfWork;
 };
@@ -103,10 +104,7 @@ export const createServiceContainer = (
       userRepository: deps.userRepository,
       accessService,
       passwordUtils: deps.passwordUtils,
-      changePasswordRateLimiter: createInMemoryRateLimiter({
-        maxAttempts: 5,
-        windowMs: 60_000,
-      }),
+      changePasswordRateLimiter: deps.changePasswordRateLimiter,
     }),
     signupService: createSignupService({
       signupRepository: deps.signupRepository,

--- a/server/presentation/trpc/context.ts
+++ b/server/presentation/trpc/context.ts
@@ -18,6 +18,7 @@ import {
   verifyPassword,
 } from "@/server/infrastructure/auth/password";
 import { createJapaneseHolidayProvider } from "@/server/infrastructure/holiday/japanese-holiday-provider";
+import { createInMemoryRateLimiter } from "@/server/infrastructure/rate-limit/in-memory-rate-limiter";
 
 const getSession = createGetSession(nextAuthSessionService);
 const japaneseHolidayProvider = createJapaneseHolidayProvider();
@@ -35,6 +36,10 @@ const buildServiceContainer = (): ServiceContainer =>
     signupRepository: prismaSignupRepository,
     circleInviteLinkRepository: prismaCircleInviteLinkRepository,
     passwordUtils: { hash: hashPassword, verify: verifyPassword },
+    changePasswordRateLimiter: createInMemoryRateLimiter({
+      maxAttempts: 5,
+      windowMs: 60_000,
+    }),
     holidayProvider: japaneseHolidayProvider,
     unitOfWork: prismaUnitOfWork,
   });


### PR DESCRIPTION
## Summary

- `service-container.ts` 内でハードコードされていた `createInMemoryRateLimiter` を `ServiceContainerDeps` に追加し、外部から注入するように変更
- `context.ts`（composition root）で `createInMemoryRateLimiter` を生成して注入
- テストにモック `RateLimiter` を追加

Closes #566

## Verification

| Check | Result |
|-------|--------|
| `npx tsc --noEmit` | Pass |
| `npm run test:run` | Pass (59 files, 735 tests) |
| `npm run lint` | Pass |

## Review points

- 設定値（`maxAttempts: 5, windowMs: 60_000`）は変更なし
- `service-container.ts` の import が具象実装 → `RateLimiter` 型（application 層）に変わり、依存方向が改善
- **既存バグ**: `createContext()` 内で毎回 RateLimiter が生成されるため、レート制限状態がリクエスト間で共有されない問題あり → #568 で対応予定

🤖 Generated with [Claude Code](https://claude.com/claude-code)