### PR TITLE
docs: ID 系 Branded Type を Bounded Context ドキュメントに追記

### DIFF
--- a/docs/design/07_bounded_contexts.md
+++ b/docs/design/07_bounded_contexts.md
@@ -23,6 +23,7 @@
 - **Circle**（Aggregate Root）
 - CircleMembership（研究会参加）
 - **CircleInviteLink**（独立した Aggregate Root）
+- CircleId / CircleInviteLinkId / InviteLinkToken（Value Object — Branded Type）
 
 ### 代表的な不変条件
 
@@ -46,6 +47,7 @@
 
 - **CircleSession**（Aggregate Root）
 - CircleSessionMembership（セッション参加）
+- CircleSessionId（Value Object — Branded Type）
 
 ### 代表的な不変条件
 
@@ -69,6 +71,7 @@
 ### 主要エンティティ/値
 
 - **Match**（Aggregate Root）
+- MatchId（Value Object — Branded Type）
 
 ### 代表的な不変条件
 
@@ -88,6 +91,7 @@
 ### 主要エンティティ/値
 
 - **User**（Aggregate Root）
+- UserId（Value Object — Branded Type）
 - CircleRole / CircleSessionRole
 
 ### 代表的な不変条件


### PR DESCRIPTION
## Summary
- `07_bounded_contexts.md` の各 Context「主要エンティティ/値」セクションに、`server/domain/common/ids.ts` で定義済みの ID 系 ValueObject（Branded Type）を追記

Closes #572

## Test plan
- [ ] ドキュメントの記載が `ids.ts` の定義と一致していることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)