### PR TITLE
docs: レイヤー別ディレクトリ方針を Bounded Context ドキュメントに追記 (#577)

### DIFF
--- a/docs/design/07_bounded_contexts.md
+++ b/docs/design/07_bounded_contexts.md
@@ -133,3 +133,55 @@
   - `server/domain/services/authz/*`
   - `server/application/authz/*`
   - `server/infrastructure/repository/authz/*`
+
+## レイヤーごとのディレクトリ方針
+
+レイヤー間でディレクトリの粒度が異なるのは意図的な設計判断である。各レイヤーの責務に応じて最適な粒度を選択している。
+
+### Domain 層 / Infrastructure リポジトリ層 — Aggregate Root 単位
+
+Domain 層（`server/domain/models/`）と Infrastructure リポジトリ層（`server/infrastructure/repository/`）は、**Aggregate Root ごとにディレクトリを分離** する。
+
+```
+domain/models/
+├── circle/                  # Circle（Aggregate Root）
+├── circle-membership/       # CircleMembership
+├── circle-invite-link/      # CircleInviteLink（独立 Aggregate Root）
+├── circle-session/          # CircleSession（Aggregate Root）+ CircleSessionMembership
+├── match/                   # Match（Aggregate Root）
+└── user/                    # User（Aggregate Root）
+```
+
+**理由**: エンティティとリポジトリインターフェースは 1:1 で対応するため、Aggregate Root 単位でまとめるのが最も自然な粒度となる。CircleInviteLink のように独立した Aggregate Root は、同じ Bounded Context 内であっても専用ディレクトリに配置する。
+
+### Application 層 — Bounded Context 単位
+
+Application 層（`server/application/`）は、**Bounded Context 単位でディレクトリをグルーピング** する。
+
+```
+application/
+├── circle/                  # Circle Context のサービス群
+│   ├── circle-service.ts
+│   ├── circle-membership-service.ts
+│   └── circle-invite-link-service.ts
+├── circle-session/          # CircleSession Context のサービス群
+│   ├── circle-session-service.ts
+│   └── circle-session-membership-service.ts
+├── match/                   # Match Context
+├── authz/                   # Auth Context
+└── user/                    # Identity Context
+```
+
+**理由**: Application サービスは複数の Aggregate Root を調整する役割を持つ。たとえば `circle/` ディレクトリには Circle・CircleMembership・CircleInviteLink の 3 つのサービスが同居する。これらは同じ Bounded Context に属し、相互に関連するユースケースを扱うため、Context 単位でまとめるほうが見通しがよい。
+
+### Presentation 層（DTO・マッパー・tRPC ルーター） — フラット
+
+Presentation 層の DTO（`server/presentation/dto/`）、マッパー（`server/presentation/mappers/`）、tRPC ルーター（`server/presentation/trpc/routers/`）は、**サブディレクトリを作らずフラットに配置** する。
+
+**理由**: Presentation 層のファイルは 1 エンティティにつき 1 ファイルの単純な構造であり、ファイル数も限定的である。サブディレクトリに分けるとナビゲーションが深くなるだけで見通しが悪化するため、フラットな配置が適切である。
+
+### Infrastructure マッパー層 — フラット
+
+Infrastructure マッパー（`server/infrastructure/mappers/`）は、**サブディレクトリを作らずフラットに配置** する。
+
+**理由**: Prisma モデルとドメインモデルの変換は 1 エンティティにつき 1 マッパーの単純な対応関係であり、Presentation 層のマッパーと同様にフラットな配置で十分である。


### PR DESCRIPTION
## Summary

- `docs/design/07_bounded_contexts.md` にレイヤーごとのディレクトリ方針セクションを追加
- Domain層（Aggregate Root単位）、Application層（Bounded Context単位）、Presentation/Infrastructureマッパー層（フラット）の粒度の違いと、その設計理由を明記
- レイヤー間の粒度の違いが不整合ではなく意図的な設計判断であることを文書化

Closes #577

## Test plan

- [ ] `docs/design/07_bounded_contexts.md` の追記内容が、実際のディレクトリ構造と一致していることを確認
- [ ] 記載されたディレクトリツリーの例が現在のコードベースを正しく反映していることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)