### PR TITLE
docs: Auth Context のクロスコンテキスト依存関係を明記

### DIFF
--- a/docs/design/07_bounded_contexts.md
+++ b/docs/design/07_bounded_contexts.md
@@ -104,6 +104,13 @@
 - 認証状態の確認
 - 認可ポリシーの判定
 
+### コンテキスト間の依存
+
+Auth Context は認可判定のために以下の型を参照する:
+
+- Circle Context: CircleRole, CircleMembershipRepository
+- CircleSession Context: CircleSessionRole, CircleSessionMembershipRepository
+
 ## Context 間の関係
 
 - CircleSession は Circle に従属する


### PR DESCRIPTION
## Summary

- Auth Context が Circle Context / CircleSession Context の ValueObject・Repository を参照する依存方向を `07_bounded_contexts.md` に明記

Closes #584

## Test plan

- [ ] `docs/design/07_bounded_contexts.md` の Auth Context セクションに「コンテキスト間の依存」が追記されていること
- [ ] Circle Context: CircleRole, CircleMembershipRepository が記載されていること
- [ ] CircleSession Context: CircleSessionRole, CircleSessionMembershipRepository が記載されていること
- [ ] 既存の記述との整合性に問題がないこと

🤖 Generated with [Claude Code](https://claude.com/claude-code)