### PR TITLE
docs: Membership Repository の記載整合性を修正

### DIFF
--- a/docs/design/07_bounded_contexts.md
+++ b/docs/design/07_bounded_contexts.md
@@ -105,8 +105,8 @@
 Auth Context は認可判定のために以下の型を参照する:
 
 - Identity Context: UserRepository（認証時のユーザー解決）
-- Circle Context: CircleRole, CircleMembershipRepository
-- CircleSession Context: CircleSessionRole, CircleSessionMembershipRepository
+- Circle Context: CircleRole, CircleRepository（Membership の参照も CircleRepository 経由）
+- CircleSession Context: CircleSessionRole, CircleSessionRepository
 
 ## Identity Context（ユーザー）
 
@@ -140,12 +140,9 @@ Auth Context は認可判定のために以下の型を参照する:
 ## 実装上の配置（目安）
 
 - Circle Context
-  - `server/domain/models/circle/*`
+  - `server/domain/models/circle/*`（CircleMembership を含む）
   - `server/application/circle/*`
-  - `server/infrastructure/repository/circle/*`
-  - CircleMembership は専用ディレクトリに配置:
-    - `server/domain/models/circle-membership/*`
-    - `server/infrastructure/repository/circle-membership/*`
+  - `server/infrastructure/repository/circle/*`（CircleMembership の永続化を含む）
   - 独立 Aggregate Root の CircleInviteLink は専用ディレクトリに配置:
     - `server/domain/models/circle-invite-link/*`
     - `server/infrastructure/repository/circle-invite-link/*`
@@ -176,8 +173,7 @@ Domain 層（`server/domain/models/`）と Infrastructure リポジトリ層（`
 
 ```
 domain/models/
-├── circle/                  # Circle（Aggregate Root）
-├── circle-membership/       # CircleMembership
+├── circle/                  # Circle（Aggregate Root）+ CircleMembership
 ├── circle-invite-link/      # CircleInviteLink（独立 Aggregate Root）
 ├── circle-session/          # CircleSession（Aggregate Root）+ CircleSessionMembership
 ├── match/                   # Match（Aggregate Root）

--- a/docs/glossary.md
+++ b/docs/glossary.md
@@ -81,8 +81,8 @@ Circle（研究会）
 | Entity           | ID 型               | 定義ファイル                                       |
 | ---------------- | -------------------- | -------------------------------------------------- |
 | Circle           | CircleId             | `server/domain/models/circle/circle.ts`            |
-| CircleMembership | CircleMembershipId   | `server/domain/models/circle-membership/circle-membership.ts` |
-| CircleInviteLink | CircleInviteLinkId   | `server/domain/models/circle/circle-invite-link.ts` |
+| CircleMembership | CircleMembershipId   | `server/domain/models/circle/circle-membership.ts` |
+| CircleInviteLink | CircleInviteLinkId   | `server/domain/models/circle-invite-link/circle-invite-link.ts` |
 | CircleSession    | CircleSessionId      | `server/domain/models/circle-session/circle-session.ts` |
 | CircleSessionMembership | CircleSessionMembershipId | `server/domain/models/circle-session/circle-session-membership.ts` |
 | Match            | MatchId              | `server/domain/models/match/match.ts`              |
@@ -117,10 +117,8 @@ Circle（研究会）
 | Repository                              | 所属 Context   | 対象 Entity              |
 | --------------------------------------- | -------------- | ------------------------ |
 | CircleRepository                        | Circle         | Circle                   |
-| CircleMembershipRepository              | Circle         | CircleMembership         |
 | CircleInviteLinkRepository              | Circle         | CircleInviteLink         |
 | CircleSessionRepository                 | CircleSession  | CircleSession            |
-| CircleSessionMembershipRepository       | CircleSession  | CircleSessionMembership  |
 | MatchRepository                         | Match          | Match                    |
 | UserRepository                          | Auth           | User                     |
 | SignupRepository                        | Auth           | User（登録専用）         |


### PR DESCRIPTION
Closes #591

## Summary
- `CircleMembershipRepository` / `CircleSessionMembershipRepository` のドキュメント記載を削除（コードに存在しない独立 Repository への参照）
- CircleMembership の定義ファイルパスを `circle-membership/` → `circle/` に修正
- CircleInviteLink の定義ファイルパスを修正（レビュー中に発見した同種の不整合）
- Auth Context 依存の Repository 名を実態（`CircleRepository` / `CircleSessionRepository`）に合わせて修正

## Test plan
- [ ] `docs/glossary.md` の Repository 一覧に `CircleMembershipRepository` / `CircleSessionMembershipRepository` が含まれていないことを確認
- [ ] `docs/glossary.md` の Entity 一覧の CircleMembership ファイルパスが `server/domain/models/circle/circle-membership.ts` であることを確認
- [ ] `docs/design/07_bounded_contexts.md` の Auth Context 依存記述が `CircleRepository` / `CircleSessionRepository` になっていることを確認
- [ ] コード変更なし — テスト・型チェック・lint への影響なし

🤖 Generated with [Claude Code](https://claude.com/claude-code)