### PR TITLE
docs: Match Context に MatchWithCircle（Read Model）を追記

### DIFF
--- a/docs/design/07_bounded_contexts.md
+++ b/docs/design/07_bounded_contexts.md
@@ -75,6 +75,7 @@
 
 - **Match**（Aggregate Root）
 - MatchId（Value Object — Branded Type）
+- MatchWithCircle（Read Model）
 
 ### 代表的な不変条件
 


### PR DESCRIPTION
## Summary

- Match Context の「主要エンティティ/値オブジェクト」セクションに `MatchWithCircle（Read Model）` を追記
- コード上のファイル配置（`match-read-models.ts`）および JSDoc と整合する分類

Closes #592

## Scope

Issue #592 の確認事項のうち、`MatchWithCircle` のドキュメント反映のみを対応。
`UserOutcome` / `UserMatchStatistics` / `CircleMatchStatistics` はオーナー判断により本 issue のスコープ外とし、全コンテキストの Read Model 一括追記として #595 で対応予定。

## Verification

- [ ] `docs/design/07_bounded_contexts.md` の Match Context セクションに `MatchWithCircle（Read Model）` が追記されていること
- [ ] 既存の箇条書きフォーマット（`- 名前（分類）`）と一致していること
- [ ] コード上の定義（`server/domain/models/match/match-read-models.ts`）と整合していること

## Review Points

- Finding 3（他コンテキストの Read Model との一貫性）は #595 で対応
- セクションタイトル変更の検討も #595 に含む

🤖 Generated with [Claude Code](https://claude.com/claude-code)