### PR TITLE
refactor: UserOutcome / classifyOutcomeForUser をドメイン層からアプリケーション層に移動

### DIFF
--- a/server/application/match/match-outcome.test.ts
+++ b/server/application/match/match-outcome.test.ts
@@ -1,0 +1,36 @@
+import { describe, expect, test } from "vitest";
+import { classifyOutcomeForUser } from "@/server/application/match/match-outcome";
+
+describe("classifyOutcomeForUser", () => {
+  test("P1_WIN でプレイヤー1の場合 win を返す", () => {
+    expect(classifyOutcomeForUser("P1_WIN", true)).toBe("win");
+  });
+
+  test("P1_WIN でプレイヤー2の場合 loss を返す", () => {
+    expect(classifyOutcomeForUser("P1_WIN", false)).toBe("loss");
+  });
+
+  test("P2_WIN でプレイヤー1の場合 loss を返す", () => {
+    expect(classifyOutcomeForUser("P2_WIN", true)).toBe("loss");
+  });
+
+  test("P2_WIN でプレイヤー2の場合 win を返す", () => {
+    expect(classifyOutcomeForUser("P2_WIN", false)).toBe("win");
+  });
+
+  test("DRAW でプレイヤー1の場合 draw を返す", () => {
+    expect(classifyOutcomeForUser("DRAW", true)).toBe("draw");
+  });
+
+  test("DRAW でプレイヤー2の場合 draw を返す", () => {
+    expect(classifyOutcomeForUser("DRAW", false)).toBe("draw");
+  });
+
+  test("UNKNOWN でプレイヤー1の場合 null を返す", () => {
+    expect(classifyOutcomeForUser("UNKNOWN", true)).toBeNull();
+  });
+
+  test("UNKNOWN でプレイヤー2の場合 null を返す", () => {
+    expect(classifyOutcomeForUser("UNKNOWN", false)).toBeNull();
+  });
+});

--- a/server/application/match/match-outcome.ts
+++ b/server/application/match/match-outcome.ts
@@ -1,0 +1,23 @@
+import type { MatchOutcome } from "@/server/domain/models/match/match";
+
+export type UserOutcome = "win" | "loss" | "draw";
+
+export const classifyOutcomeForUser = (
+  outcome: MatchOutcome,
+  isPlayer1: boolean,
+): UserOutcome | null => {
+  switch (outcome) {
+    case "UNKNOWN":
+      return null;
+    case "DRAW":
+      return "draw";
+    case "P1_WIN":
+      return isPlayer1 ? "win" : "loss";
+    case "P2_WIN":
+      return isPlayer1 ? "loss" : "win";
+    default: {
+      const _exhaustive: never = outcome;
+      return _exhaustive;
+    }
+  }
+};

--- a/server/application/user/user-statistics-service.ts
+++ b/server/application/user/user-statistics-service.ts
@@ -1,7 +1,7 @@
 import type { CircleId, UserId } from "@/server/domain/common/ids";
 import type { MatchRepository } from "@/server/domain/models/match/match-repository";
 import type { UserRepository } from "@/server/domain/models/user/user-repository";
-import { classifyOutcomeForUser } from "@/server/domain/models/match/match";
+import { classifyOutcomeForUser } from "@/server/application/match/match-outcome";
 import type {
   CircleMatchStatistics,
   UserMatchStatistics,

--- a/server/domain/models/match/match.test.ts
+++ b/server/domain/models/match/match.test.ts
@@ -1,7 +1,6 @@
 import { describe, expect, test } from "vitest";
 import { circleSessionId, matchId, userId } from "@/server/domain/common/ids";
 import {
-  classifyOutcomeForUser,
   createMatch,
   deleteMatch,
   hasDifferentPlayers,
@@ -171,39 +170,5 @@ describe("Match ドメイン", () => {
 
   test("hasDifferentPlayers は同一プレイヤーで false を返す", () => {
     expect(hasDifferentPlayers(userId("user-1"), userId("user-1"))).toBe(false);
-  });
-
-  describe("classifyOutcomeForUser", () => {
-    test("P1_WIN でプレイヤー1の場合 win を返す", () => {
-      expect(classifyOutcomeForUser("P1_WIN", true)).toBe("win");
-    });
-
-    test("P1_WIN でプレイヤー2の場合 loss を返す", () => {
-      expect(classifyOutcomeForUser("P1_WIN", false)).toBe("loss");
-    });
-
-    test("P2_WIN でプレイヤー1の場合 loss を返す", () => {
-      expect(classifyOutcomeForUser("P2_WIN", true)).toBe("loss");
-    });
-
-    test("P2_WIN でプレイヤー2の場合 win を返す", () => {
-      expect(classifyOutcomeForUser("P2_WIN", false)).toBe("win");
-    });
-
-    test("DRAW でプレイヤー1の場合 draw を返す", () => {
-      expect(classifyOutcomeForUser("DRAW", true)).toBe("draw");
-    });
-
-    test("DRAW でプレイヤー2の場合 draw を返す", () => {
-      expect(classifyOutcomeForUser("DRAW", false)).toBe("draw");
-    });
-
-    test("UNKNOWN でプレイヤー1の場合 null を返す", () => {
-      expect(classifyOutcomeForUser("UNKNOWN", true)).toBeNull();
-    });
-
-    test("UNKNOWN でプレイヤー2の場合 null を返す", () => {
-      expect(classifyOutcomeForUser("UNKNOWN", false)).toBeNull();
-    });
   });
 });

--- a/server/domain/models/match/match.ts
+++ b/server/domain/models/match/match.ts
@@ -101,25 +101,3 @@ export const deleteMatch = (match: Match, deletedAt?: Date): Match => ({
   ...match,
   deletedAt: deletedAt ?? new Date(),
 });
-
-export type UserOutcome = "win" | "loss" | "draw";
-
-export const classifyOutcomeForUser = (
-  outcome: MatchOutcome,
-  isPlayer1: boolean,
-): UserOutcome | null => {
-  switch (outcome) {
-    case "UNKNOWN":
-      return null;
-    case "DRAW":
-      return "draw";
-    case "P1_WIN":
-      return isPlayer1 ? "win" : "loss";
-    case "P2_WIN":
-      return isPlayer1 ? "loss" : "win";
-    default: {
-      const _exhaustive: never = outcome;
-      return _exhaustive;
-    }
-  }
-};


### PR DESCRIPTION
## Summary

Closes #596

- `UserOutcome` 型と `classifyOutcomeForUser` 関数を `server/domain/models/match/match.ts` から除去
- `server/application/match/match-outcome.ts` に移動（表示・集計用途の変換ロジックであるため）
- `user-statistics-service.ts` のインポートパスを更新
- テストも `match-outcome.test.ts` として application 層に移動

## Test plan

- [x] `npm run test:run` — 全 735 テスト pass
- [x] `npx tsc --noEmit` — 型エラーなし
- [ ] domain の `match.ts` から `UserOutcome` / `classifyOutcomeForUser` が除去されていること
- [ ] application の `match-outcome.ts` に同等コードが配置されていること
- [ ] テスト数に変化がないこと（domain: 21→13, application: +8 = 合計 21）

🤖 Generated with [Claude Code](https://claude.com/claude-code)