### PR TITLE
refactor: updatePasswordHash から暗黙の passwordChangedAt 付与を除去

### DIFF
--- a/server/application/user/user-service.test.ts
+++ b/server/application/user/user-service.test.ts
@@ -167,6 +167,7 @@ describe("changePassword", () => {
     expect(userRepository.updatePasswordHash).toHaveBeenCalledWith(
       actorId,
       "hashed:newpass12",
+      expect.any(Date),
     );
   });
 

--- a/server/application/user/user-service.ts
+++ b/server/application/user/user-service.ts
@@ -99,7 +99,12 @@ export const createUserService = (deps: UserServiceDeps) => ({
 
     deps.changePasswordRateLimiter.reset(actorId);
     const newHash = deps.passwordUtils.hash(newPassword);
-    await deps.userRepository.updatePasswordHash(actorId, newHash);
+    const passwordChangedAt = new Date();
+    await deps.userRepository.updatePasswordHash(
+      actorId,
+      newHash,
+      passwordChangedAt,
+    );
   },
 
   async updateProfileVisibility(

--- a/server/domain/models/user/user-repository.ts
+++ b/server/domain/models/user/user-repository.ts
@@ -20,7 +20,11 @@ export type UserRepository = {
   emailExists(email: string, excludeUserId?: UserId): Promise<boolean>;
   findPasswordHashById(id: UserId): Promise<string | null>;
   findPasswordChangedAt(id: UserId): Promise<Date | null>;
-  updatePasswordHash(id: UserId, passwordHash: string): Promise<void>;
+  updatePasswordHash(
+    id: UserId,
+    passwordHash: string,
+    passwordChangedAt: Date,
+  ): Promise<void>;
   updateProfileVisibility(
     id: UserId,
     visibility: ProfileVisibility,

--- a/server/infrastructure/repository/user/prisma-user-repository.ts
+++ b/server/infrastructure/repository/user/prisma-user-repository.ts
@@ -104,10 +104,14 @@ export const createPrismaUserRepository = (
     return found?.passwordChangedAt ?? null;
   },
 
-  async updatePasswordHash(id: UserId, passwordHash: string): Promise<void> {
+  async updatePasswordHash(
+    id: UserId,
+    passwordHash: string,
+    passwordChangedAt: Date,
+  ): Promise<void> {
     await client.user.update({
       where: { id: toPersistenceId(id) },
-      data: { passwordHash, passwordChangedAt: new Date() },
+      data: { passwordHash, passwordChangedAt },
     });
   },
 


### PR DESCRIPTION
## Summary

Closes #602

- `UserRepository.updatePasswordHash` のシグネチャに `passwordChangedAt: Date` 引数を追加
- `PrismaUserRepository` から暗黙の `new Date()` 付与を除去し、渡された値をそのまま永続化
- `UserService.changePassword` で `passwordChangedAt` を生成し、Repository に明示的に渡すよう変更
- テストを更新（`expect.any(Date)` による第3引数の検証を追加）

## Why

Repository が `passwordChangedAt` を暗黙に決定していたため、DDD の Repository 責務（純粋なデータアクセス）に違反していた。状態遷移ロジックの決定を Application 層に移すことで責務を明確に分離する。

## Test plan

- [x] `npm run test:run -- server/application/user/user-service.test.ts` — changePassword テストが pass
- [x] `npx tsc --noEmit` — 型エラーなし

🤖 Generated with [Claude Code](https://claude.com/claude-code)