### PR TITLE
refactor: hashPassword を Repository から Application 層に移動 (#601)

### DIFF
--- a/app/api/auth/signup/route.ts
+++ b/app/api/auth/signup/route.ts
@@ -1,9 +1,14 @@
 import { NextResponse } from "next/server";
 import { createSignupService } from "@/server/application/auth/signup-service";
 import { prismaUserRepository } from "@/server/infrastructure/repository/user/prisma-user-repository";
+import {
+  hashPassword,
+  verifyPassword,
+} from "@/server/infrastructure/auth/password";
 
 const signupService = createSignupService({
   userRepository: prismaUserRepository,
+  passwordUtils: { hash: hashPassword, verify: verifyPassword },
 });
 
 type SignupPayload = {

--- a/server/application/auth/signup-service.ts
+++ b/server/application/auth/signup-service.ts
@@ -1,10 +1,12 @@
 import type { UserId } from "@/server/domain/common/ids";
 import type { UserRepository } from "@/server/domain/models/user/user-repository";
+import type { PasswordUtils } from "@/server/application/user/user-service";
 
 const MIN_PASSWORD_LENGTH = 8;
 
 export type SignupServiceDeps = {
   userRepository: UserRepository;
+  passwordUtils: PasswordUtils;
 };
 
 export type SignupInput = {
@@ -39,9 +41,11 @@ export const createSignupService = (deps: SignupServiceDeps) => ({
       return { success: false, error: "email_exists" };
     }
 
+    const passwordHash = deps.passwordUtils.hash(password);
+
     const userId = await deps.userRepository.createUser({
       email,
-      password,
+      passwordHash,
       name,
     });
 

--- a/server/domain/models/user/user-repository.ts
+++ b/server/domain/models/user/user-repository.ts
@@ -3,7 +3,7 @@ import type { User, ProfileVisibility } from "@/server/domain/models/user/user";
 
 export type SignupData = {
   email: string;
-  password: string;
+  passwordHash: string;
   name: string | null;
 };
 

--- a/server/infrastructure/repository/user/prisma-user-repository.ts
+++ b/server/infrastructure/repository/user/prisma-user-repository.ts
@@ -14,7 +14,6 @@ import {
   toPersistenceId,
   toPersistenceIds,
 } from "@/server/infrastructure/common/id-utils";
-import { hashPassword } from "@/server/infrastructure/auth/password";
 
 export const createPrismaUserRepository = (
   client: PrismaClientLike,
@@ -126,12 +125,11 @@ export const createPrismaUserRepository = (
   },
 
   async createUser(data: SignupData): Promise<UserId> {
-    const passwordHash = hashPassword(data.password);
     const user = await client.user.create({
       data: {
         email: data.email,
         name: data.name,
-        passwordHash,
+        passwordHash: data.passwordHash,
       },
       select: { id: true },
     });

--- a/server/infrastructure/service-container.ts
+++ b/server/infrastructure/service-container.ts
@@ -94,6 +94,7 @@ export const createServiceContainer = (
     }),
     signupService: createSignupService({
       userRepository: deps.userRepository,
+      passwordUtils: deps.passwordUtils,
     }),
     circleInviteLinkService: createCircleInviteLinkService({
       circleInviteLinkRepository: deps.circleInviteLinkRepository,


### PR DESCRIPTION
## Summary

- `PrismaUserRepository.createUser` 内の `hashPassword()` 呼び出しを `SignupService` に移動
- `SignupData.password` を `SignupData.passwordHash` にリネームし、型レベルでハッシュ済みであることを明示
- `SignupService` に `PasswordUtils` を DI で注入し、テスタビリティを向上

Closes #601

## Test plan

- [x] `npx tsc --noEmit`: 型エラーなし
- [x] `npm run test:run`: 735 テスト全パス
- [x] `POST /api/auth/signup` で新規ユーザー登録が正常に完了すること
- [x] 登録したユーザーでログインできること
- [x] 不正入力（短いパスワード、無効なメール、重複メール）で適切なエラーが返ること

## Notes

- verify で検出された既存課題は follow-up issue として起票済み: #609, #610, #611

🤖 Generated with [Claude Code](https://claude.com/claude-code)