### PR TITLE
fix: サインアップ時の email 重複で P2002 エラーをドメインエラーに変換 (#605)

### DIFF
--- a/server/application/auth/signup-service.test.ts
+++ b/server/application/auth/signup-service.test.ts
@@ -1,0 +1,62 @@
+import { describe, expect, test, vi } from "vitest";
+import type { UserRepository } from "@/server/domain/models/user/user-repository";
+import { userId } from "@/server/domain/common/ids";
+import { ConflictError } from "@/server/domain/common/errors";
+import {
+  createSignupService,
+  type SignupServiceDeps,
+} from "@/server/application/auth/signup-service";
+
+const validInput = {
+  email: "test@example.com",
+  password: "password123",
+  name: "Test User",
+};
+
+const createDeps = (
+  repoOverrides?: Partial<UserRepository>,
+): SignupServiceDeps => ({
+  userRepository: {
+    emailExists: vi.fn().mockResolvedValue(false),
+    createUser: vi.fn().mockResolvedValue(userId("new-user-id")),
+    findById: vi.fn(),
+    findByIds: vi.fn(),
+    findByEmail: vi.fn(),
+    save: vi.fn(),
+    updateProfile: vi.fn(),
+    findPasswordHashById: vi.fn(),
+    findPasswordChangedAt: vi.fn(),
+    updatePasswordHash: vi.fn(),
+    updateProfileVisibility: vi.fn(),
+    ...repoOverrides,
+  },
+  passwordUtils: {
+    hash: vi.fn().mockReturnValue("hashed-password"),
+    verify: vi.fn(),
+  },
+});
+
+describe("SignupService", () => {
+  test("createUser が ConflictError をスローした場合 email_exists を返す", async () => {
+    const deps = createDeps({
+      createUser: vi
+        .fn()
+        .mockRejectedValue(new ConflictError("User already exists")),
+    });
+    const service = createSignupService(deps);
+
+    const result = await service.signup(validInput);
+
+    expect(result).toEqual({ success: false, error: "email_exists" });
+  });
+
+  test("createUser が ConflictError 以外をスローした場合はそのまま伝播する", async () => {
+    const otherError = new Error("Database connection failed");
+    const deps = createDeps({
+      createUser: vi.fn().mockRejectedValue(otherError),
+    });
+    const service = createSignupService(deps);
+
+    await expect(service.signup(validInput)).rejects.toThrow(otherError);
+  });
+});

--- a/server/application/auth/signup-service.ts
+++ b/server/application/auth/signup-service.ts
@@ -1,6 +1,7 @@
 import type { UserId } from "@/server/domain/common/ids";
 import type { UserRepository } from "@/server/domain/models/user/user-repository";
 import type { PasswordUtils } from "@/server/application/user/user-service";
+import { ConflictError } from "@/server/domain/common/errors";
 
 const MIN_PASSWORD_LENGTH = 8;
 
@@ -43,12 +44,19 @@ export const createSignupService = (deps: SignupServiceDeps) => ({
 
     const passwordHash = deps.passwordUtils.hash(password);
 
-    const userId = await deps.userRepository.createUser({
-      email,
-      passwordHash,
-      name,
-    });
+    try {
+      const userId = await deps.userRepository.createUser({
+        email,
+        passwordHash,
+        name,
+      });
 
-    return { success: true, userId };
+      return { success: true, userId };
+    } catch (error) {
+      if (error instanceof ConflictError) {
+        return { success: false, error: "email_exists" };
+      }
+      throw error;
+    }
   },
 });

--- a/server/infrastructure/repository/user/prisma-user-repository.test.ts
+++ b/server/infrastructure/repository/user/prisma-user-repository.test.ts
@@ -6,13 +6,15 @@ vi.mock("@/server/infrastructure/db", () => ({
       findUnique: vi.fn(),
       findMany: vi.fn(),
       upsert: vi.fn(),
+      create: vi.fn(),
     },
   },
 }));
 
-import type { User as PrismaUser } from "@/generated/prisma/client";
+import { type User as PrismaUser, Prisma } from "@/generated/prisma/client";
 import { prisma } from "@/server/infrastructure/db";
 import { userId } from "@/server/domain/common/ids";
+import { ConflictError } from "@/server/domain/common/errors";
 import { createUser } from "@/server/domain/models/user/user";
 import { prismaUserRepository } from "@/server/infrastructure/repository/user/prisma-user-repository";
 import { mapUserToPersistence } from "@/server/infrastructure/mappers/user-mapper";
@@ -105,5 +107,38 @@ describe("Prisma User リポジトリ", () => {
       },
       create: data,
     });
+  });
+
+  test("createUser は P2002（一意制約違反）で ConflictError をスローする", async () => {
+    mockedPrisma.user.create.mockRejectedValueOnce(
+      new Prisma.PrismaClientKnownRequestError("Unique constraint failed", {
+        code: "P2002",
+        clientVersion: "0.0.0",
+      }),
+    );
+
+    await expect(
+      prismaUserRepository.createUser({
+        email: "test@example.com",
+        passwordHash: "hashed",
+        name: "Test",
+      }),
+    ).rejects.toThrow(ConflictError);
+  });
+
+  test("createUser は P2002 以外の Prisma エラーはそのまま伝播する", async () => {
+    const otherError = new Prisma.PrismaClientKnownRequestError(
+      "Foreign key constraint failed",
+      { code: "P2003", clientVersion: "0.0.0" },
+    );
+    mockedPrisma.user.create.mockRejectedValueOnce(otherError);
+
+    await expect(
+      prismaUserRepository.createUser({
+        email: "test@example.com",
+        passwordHash: "hashed",
+        name: "Test",
+      }),
+    ).rejects.toThrow(otherError);
   });
 });

--- a/server/infrastructure/repository/user/prisma-user-repository.ts
+++ b/server/infrastructure/repository/user/prisma-user-repository.ts
@@ -14,6 +14,8 @@ import {
   toPersistenceId,
   toPersistenceIds,
 } from "@/server/infrastructure/common/id-utils";
+import { ConflictError } from "@/server/domain/common/errors";
+import { Prisma } from "@/generated/prisma/client";
 
 export const createPrismaUserRepository = (
   client: PrismaClientLike,
@@ -125,15 +127,25 @@ export const createPrismaUserRepository = (
   },
 
   async createUser(data: SignupData): Promise<UserId> {
-    const user = await client.user.create({
-      data: {
-        email: data.email,
-        name: data.name,
-        passwordHash: data.passwordHash,
-      },
-      select: { id: true },
-    });
-    return userId(user.id);
+    try {
+      const user = await client.user.create({
+        data: {
+          email: data.email,
+          name: data.name,
+          passwordHash: data.passwordHash,
+        },
+        select: { id: true },
+      });
+      return userId(user.id);
+    } catch (error) {
+      if (
+        error instanceof Prisma.PrismaClientKnownRequestError &&
+        error.code === "P2002"
+      ) {
+        throw new ConflictError("User already exists");
+      }
+      throw error;
+    }
   },
 });
 


### PR DESCRIPTION
## Summary

- `PrismaUserRepository.createUser` で Prisma P2002（一意制約違反）を `ConflictError` に変換
- `SignupService.signup` で `ConflictError` を `{ success: false, error: "email_exists" }` に変換
- レースコンディション時にもユーザーにフレンドリーなエラーを返す

Closes #605

## 変更ファイル

| ファイル | 変更内容 |
|---------|---------|
| `server/infrastructure/repository/user/prisma-user-repository.ts` | P2002 → ConflictError 変換を追加 |
| `server/infrastructure/repository/user/prisma-user-repository.test.ts` | P2002 / 非P2002 のテスト追加 |
| `server/application/auth/signup-service.ts` | ConflictError → email_exists Result 変換を追加 |
| `server/application/auth/signup-service.test.ts` | ConflictError / 非ConflictError のテスト追加（新規） |

## Verification

### 自動テスト
```bash
npm run test:run -- server/application/auth/signup-service.test.ts server/infrastructure/repository/user/prisma-user-repository.test.ts
```
8 tests passed (2 files)

### 手動確認手順
1. `npm run db:reset` → `npm run dev`
2. 既存メール（sota@example.com）でサインアップ → フレンドリーエラー表示を確認
3. （レースコンディション）2タブから同時に同一メールでサインアップ → 片方が email_exists を返すことを確認

## Review points

- `error.meta?.target` によるフィールド特定は行っていない（既存パターンと一貫、#613 で別途対応予定）
- 共有 P2002 ユーティリティ抽出は #614 で別途対応予定

🤖 Generated with [Claude Code](https://claude.com/claude-code)