### PR TITLE
refactor: softDelete 系 removeMembership の deletedAt 生成を Application 層に移動

### DIFF
--- a/server/application/circle-session/circle-session-membership-service.test.ts
+++ b/server/application/circle-session/circle-session-membership-service.test.ts
@@ -359,7 +359,7 @@ describe("CircleSession セッションメンバーシップサービス", () =>
 
     expect(
       circleSessionRepository.removeMembership,
-    ).toHaveBeenCalledWith(circleSessionId("session-1"), userId("user-1"));
+    ).toHaveBeenCalledWith(circleSessionId("session-1"), userId("user-1"), expect.any(Date));
   });
 
   describe("withdrawMembership", () => {
@@ -386,6 +386,7 @@ describe("CircleSession セッションメンバーシップサービス", () =>
       ).toHaveBeenCalledWith(
         circleSessionId("session-1"),
         userId("user-actor"),
+        expect.any(Date),
       );
     });
 
@@ -437,6 +438,7 @@ describe("CircleSession セッションメンバーシップサービス", () =>
       ).toHaveBeenCalledWith(
         circleSessionId("session-1"),
         userId("user-actor"),
+        expect.any(Date),
       );
     });
 

--- a/server/application/circle-session/circle-session-membership-service.ts
+++ b/server/application/circle-session/circle-session-membership-service.ts
@@ -307,9 +307,11 @@ export const createCircleSessionMembershipService = (
 
     assertCanRemoveCircleSessionMember(target.role);
 
+    const deletedAt = new Date();
     await deps.circleSessionRepository.removeMembership(
       params.circleSessionId,
       params.userId,
+      deletedAt,
     );
   },
 
@@ -346,9 +348,11 @@ export const createCircleSessionMembershipService = (
 
     assertCanWithdrawFromSession(actor.role);
 
+    const deletedAt = new Date();
     await deps.circleSessionRepository.removeMembership(
       params.circleSessionId,
       userId(params.actorId),
+      deletedAt,
     );
   },
 });

--- a/server/application/circle/circle-membership-service.test.ts
+++ b/server/application/circle/circle-membership-service.test.ts
@@ -340,7 +340,7 @@ describe("Circle メンバーシップサービス", () => {
 
       expect(
         circleRepository.removeMembership,
-      ).toHaveBeenCalledWith(circleId("circle-1"), userId("user-manager"));
+      ).toHaveBeenCalledWith(circleId("circle-1"), userId("user-manager"), expect.any(Date));
     });
 
     test("Member は退会できる", async () => {
@@ -368,7 +368,7 @@ describe("Circle メンバーシップサービス", () => {
 
       expect(
         circleRepository.removeMembership,
-      ).toHaveBeenCalledWith(circleId("circle-1"), userId("user-member"));
+      ).toHaveBeenCalledWith(circleId("circle-1"), userId("user-member"), expect.any(Date));
     });
 
     test("Owner は退会を拒否される", async () => {
@@ -484,7 +484,7 @@ describe("Circle メンバーシップサービス", () => {
 
     expect(
       circleRepository.removeMembership,
-    ).toHaveBeenCalledWith(circleId("circle-1"), userId("user-2"));
+    ).toHaveBeenCalledWith(circleId("circle-1"), userId("user-2"), expect.any(Date));
   });
 });
 
@@ -538,6 +538,7 @@ describe("UnitOfWork 経路", () => {
     expect(repos.circleRepository.removeMembership).toHaveBeenCalledWith(
       circleId("circle-1"),
       userId("user-member"),
+      expect.any(Date),
     );
     // deps側のリポジトリは呼ばれない
     expect(depsCircleRepository.removeMembership).not.toHaveBeenCalled();
@@ -554,6 +555,7 @@ describe("UnitOfWork 経路", () => {
     expect(repos.circleRepository.removeMembership).toHaveBeenCalledWith(
       circleId("circle-1"),
       userId("user-member"),
+      expect.any(Date),
     );
     expect(depsCircleRepository.removeMembership).not.toHaveBeenCalled();
   });

--- a/server/application/circle/circle-membership-service.ts
+++ b/server/application/circle/circle-membership-service.ts
@@ -255,10 +255,12 @@ export const createCircleMembershipService = (
 
       assertCanWithdraw(actor.role);
 
+      const deletedAt = new Date();
       await uow(async (repos) => {
         await repos.circleRepository.removeMembership(
           params.circleId,
           actor.userId,
+          deletedAt,
         );
       });
     },
@@ -295,10 +297,12 @@ export const createCircleMembershipService = (
 
       assertCanRemoveCircleMember(target.role);
 
+      const deletedAt = new Date();
       await uow(async (repos) => {
         await repos.circleRepository.removeMembership(
           params.circleId,
           params.userId,
+          deletedAt,
         );
       });
     },

--- a/server/domain/models/circle-session/circle-session-repository.ts
+++ b/server/domain/models/circle-session/circle-session-repository.ts
@@ -36,5 +36,6 @@ export type CircleSessionRepository = {
   removeMembership(
     circleSessionId: CircleSessionId,
     userId: UserId,
+    deletedAt: Date,
   ): Promise<void>;
 };

--- a/server/domain/models/circle/circle-repository.ts
+++ b/server/domain/models/circle/circle-repository.ts
@@ -20,5 +20,9 @@ export type CircleRepository = {
     userId: UserId,
     role: CircleRole,
   ): Promise<void>;
-  removeMembership(circleId: CircleId, userId: UserId): Promise<void>;
+  removeMembership(
+    circleId: CircleId,
+    userId: UserId,
+    deletedAt: Date,
+  ): Promise<void>;
 };

--- a/server/infrastructure/repository/circle-session/prisma-circle-session-repository.test.ts
+++ b/server/infrastructure/repository/circle-session/prisma-circle-session-repository.test.ts
@@ -488,12 +488,14 @@ describe("Prisma CircleSession メンバーシップリポジトリ", () => {
 
   test("論理削除後の再参加で create が呼ばれる", async () => {
     // 1. removeMembership で論理削除
+    const deletedAt = new Date("2025-06-01T00:00:00Z");
     mockedPrisma.circleSessionMembership.updateMany.mockResolvedValueOnce({
       count: 1,
     });
     await prismaCircleSessionRepository.removeMembership(
       circleSessionId("session-1"),
       userId("user-1"),
+      deletedAt,
     );
 
     expect(
@@ -504,7 +506,7 @@ describe("Prisma CircleSession メンバーシップリポジトリ", () => {
         userId: "user-1",
         deletedAt: null,
       },
-      data: { deletedAt: expect.any(Date) },
+      data: { deletedAt },
     });
 
     // 2. addMembership で再参加（新レコード作成）
@@ -562,6 +564,7 @@ describe("Prisma CircleSession メンバーシップリポジトリ", () => {
   });
 
   test("removeMembership はレコードが見つからない場合エラーをスローする", async () => {
+    const deletedAt = new Date("2025-06-01T00:00:00Z");
     mockedPrisma.circleSessionMembership.updateMany.mockResolvedValueOnce({
       count: 0,
     });
@@ -570,17 +573,20 @@ describe("Prisma CircleSession メンバーシップリポジトリ", () => {
       prismaCircleSessionRepository.removeMembership(
         circleSessionId("session-1"),
         userId("user-1"),
+        deletedAt,
       ),
     ).rejects.toThrow("CircleSessionMembership not found");
   });
 
   test("removeMembership はメンバーシップを論理削除する", async () => {
+    const deletedAt = new Date("2025-06-01T00:00:00Z");
     mockedPrisma.circleSessionMembership.updateMany.mockResolvedValueOnce({
       count: 1,
     });
     await prismaCircleSessionRepository.removeMembership(
       circleSessionId("session-1"),
       userId("user-1"),
+      deletedAt,
     );
 
     expect(
@@ -591,7 +597,7 @@ describe("Prisma CircleSession メンバーシップリポジトリ", () => {
         userId: "user-1",
         deletedAt: null,
       },
-      data: { deletedAt: expect.any(Date) },
+      data: { deletedAt },
     });
   });
 });

--- a/server/infrastructure/repository/circle-session/prisma-circle-session-repository.ts
+++ b/server/infrastructure/repository/circle-session/prisma-circle-session-repository.ts
@@ -194,6 +194,7 @@ export const createPrismaCircleSessionRepository = (
   async removeMembership(
     circleSessionId: CircleSessionId,
     userId: UserId,
+    deletedAt: Date,
   ): Promise<void> {
     const persistedCircleSessionId = toPersistenceId(circleSessionId);
     const persistedUserId = toPersistenceId(userId);
@@ -204,7 +205,7 @@ export const createPrismaCircleSessionRepository = (
         userId: persistedUserId,
         deletedAt: null,
       },
-      data: { deletedAt: new Date() },
+      data: { deletedAt },
     });
     if (result.count === 0) {
       throw new NotFoundError("CircleSessionMembership");

--- a/server/infrastructure/repository/circle/prisma-circle-repository.test.ts
+++ b/server/infrastructure/repository/circle/prisma-circle-repository.test.ts
@@ -312,12 +312,14 @@ describe("Prisma Circle メンバーシップリポジトリ", () => {
 
   test("論理削除後の再参加で create が呼ばれる", async () => {
     // 1. removeMembership で論理削除
+    const deletedAt = new Date("2025-06-01T00:00:00Z");
     mockedPrisma.circleMembership.updateMany.mockResolvedValueOnce({
       count: 1,
     });
     await prismaCircleRepository.removeMembership(
       circleId("circle-1"),
       userId("user-1"),
+      deletedAt,
     );
 
     expect(mockedPrisma.circleMembership.updateMany).toHaveBeenCalledWith({
@@ -326,7 +328,7 @@ describe("Prisma Circle メンバーシップリポジトリ", () => {
         userId: "user-1",
         deletedAt: null,
       },
-      data: { deletedAt: expect.any(Date) },
+      data: { deletedAt },
     });
 
     // 2. addMembership で再参加（新レコード作成）
@@ -383,6 +385,7 @@ describe("Prisma Circle メンバーシップリポジトリ", () => {
   });
 
   test("removeMembership はレコードが見つからない場合エラーをスローする", async () => {
+    const deletedAt = new Date("2025-06-01T00:00:00Z");
     mockedPrisma.circleMembership.updateMany.mockResolvedValueOnce({
       count: 0,
     });
@@ -391,17 +394,20 @@ describe("Prisma Circle メンバーシップリポジトリ", () => {
       prismaCircleRepository.removeMembership(
         circleId("circle-1"),
         userId("user-1"),
+        deletedAt,
       ),
     ).rejects.toThrow("CircleMembership not found");
   });
 
   test("removeMembership は研究会メンバーシップを論理削除する", async () => {
+    const deletedAt = new Date("2025-06-01T00:00:00Z");
     mockedPrisma.circleMembership.updateMany.mockResolvedValueOnce({
       count: 1,
     });
     await prismaCircleRepository.removeMembership(
       circleId("circle-1"),
       userId("user-1"),
+      deletedAt,
     );
 
     expect(mockedPrisma.circleMembership.updateMany).toHaveBeenCalledWith({
@@ -410,7 +416,7 @@ describe("Prisma Circle メンバーシップリポジトリ", () => {
         userId: "user-1",
         deletedAt: null,
       },
-      data: { deletedAt: expect.any(Date) },
+      data: { deletedAt },
     });
   });
 });

--- a/server/infrastructure/repository/circle/prisma-circle-repository.ts
+++ b/server/infrastructure/repository/circle/prisma-circle-repository.ts
@@ -147,7 +147,11 @@ export const createPrismaCircleRepository = (
     }
   },
 
-  async removeMembership(circleId: CircleId, userId: UserId): Promise<void> {
+  async removeMembership(
+    circleId: CircleId,
+    userId: UserId,
+    deletedAt: Date,
+  ): Promise<void> {
     const persistedCircleId = toPersistenceId(circleId);
     const persistedUserId = toPersistenceId(userId);
 
@@ -157,7 +161,7 @@ export const createPrismaCircleRepository = (
         userId: persistedUserId,
         deletedAt: null,
       },
-      data: { deletedAt: new Date() },
+      data: { deletedAt },
     });
     if (result.count === 0) {
       throw new NotFoundError("CircleMembership");


### PR DESCRIPTION
## Summary

Closes #607

- `CircleRepository.removeMembership` / `CircleSessionRepository.removeMembership` で Infrastructure 層が内部生成していた `deletedAt: new Date()` を Application 層で生成して渡す方式に変更
- Domain インターフェースに `deletedAt: Date` パラメータを追加し、Repository は受け取った値をそのまま永続化する責務に徹する
- #602 の `passwordChangedAt` パターンとタイムスタンプ所有権ポリシーを統一

## Changes

| Layer | File | Change |
|---|---|---|
| Domain | `circle-repository.ts`, `circle-session-repository.ts` | `removeMembership` に `deletedAt: Date` パラメータ追加 |
| Application | `circle-membership-service.ts`, `circle-session-membership-service.ts` | `new Date()` 生成を追加、Repository に渡す |
| Infrastructure | `prisma-circle-repository.ts`, `prisma-circle-session-repository.ts` | `new Date()` 内部生成を削除、引数の `deletedAt` を使用 |
| Tests | 4ファイル（78 tests） | シグネチャ変更に対応 |

## Remaining (out of scope)

- #616: `MatchRepository.deleteMatch` のタイムスタンプ生成移動
- #617: Application テストの `deletedAt` アサーション精密化

## Test plan

- [x] `npx tsc --noEmit` — 型エラーなし
- [x] 関連テスト 4 ファイル（78 tests）全 Pass
- [x] Infrastructure 層に `new Date()` 残留なし（grep 確認済）
- [x] `npm run test:run` で全テスト通過
- [ ] 開発サーバーでメンバー削除・自己退会の動作確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)