### PR TITLE
fix: P2002 エラーハンドリングで制約対象フィールドを検証する (#613)

### DIFF
--- a/server/infrastructure/repository/circle-session/prisma-circle-session-repository.test.ts
+++ b/server/infrastructure/repository/circle-session/prisma-circle-session-repository.test.ts
@@ -414,11 +414,12 @@ describe("Prisma CircleSession メンバーシップリポジトリ", () => {
     });
   });
 
-  test("addMembership は P2002（一意制約違反）で ConflictError をスローする", async () => {
+  test("addMembership は P2002（userId+circleSessionId 一意制約違反）で ConflictError をスローする", async () => {
     mockedPrisma.circleSessionMembership.create.mockRejectedValueOnce(
       new Prisma.PrismaClientKnownRequestError("Unique constraint failed", {
         code: "P2002",
         clientVersion: "0.0.0",
+        meta: { target: ["userId", "circleSessionId"] },
       }),
     );
 
@@ -429,6 +430,26 @@ describe("Prisma CircleSession メンバーシップリポジトリ", () => {
         "CircleSessionMember",
       ),
     ).rejects.toThrow(ConflictError);
+  });
+
+  test("addMembership は P2002 で target が期待と異なる場合そのまま再スローする", async () => {
+    const error = new Prisma.PrismaClientKnownRequestError(
+      "Unique constraint failed",
+      {
+        code: "P2002",
+        clientVersion: "0.0.0",
+        meta: { target: ["other_field"] },
+      },
+    );
+    mockedPrisma.circleSessionMembership.create.mockRejectedValueOnce(error);
+
+    await expect(
+      prismaCircleSessionRepository.addMembership(
+        circleSessionId("session-1"),
+        userId("user-1"),
+        "CircleSessionMember",
+      ),
+    ).rejects.toThrow(error);
   });
 
   test("addMembership は P2002 以外の Prisma エラーはそのまま伝播する", async () => {

--- a/server/infrastructure/repository/circle-session/prisma-circle-session-repository.ts
+++ b/server/infrastructure/repository/circle-session/prisma-circle-session-repository.ts
@@ -142,7 +142,15 @@ export const createPrismaCircleSessionRepository = (
         error instanceof Prisma.PrismaClientKnownRequestError &&
         error.code === "P2002"
       ) {
-        throw new ConflictError("Membership already exists");
+        const target = error.meta?.target;
+        if (
+          Array.isArray(target) &&
+          target.includes("userId") &&
+          target.includes("circleSessionId")
+        ) {
+          throw new ConflictError("Membership already exists");
+        }
+        throw error;
       }
       throw error;
     }

--- a/server/infrastructure/repository/circle/prisma-circle-repository.test.ts
+++ b/server/infrastructure/repository/circle/prisma-circle-repository.test.ts
@@ -242,11 +242,12 @@ describe("Prisma Circle メンバーシップリポジトリ", () => {
     });
   });
 
-  test("addMembership は P2002（一意制約違反）で ConflictError をスローする", async () => {
+  test("addMembership は P2002（userId+circleId 一意制約違反）で ConflictError をスローする", async () => {
     mockedPrisma.circleMembership.create.mockRejectedValueOnce(
       new Prisma.PrismaClientKnownRequestError("Unique constraint failed", {
         code: "P2002",
         clientVersion: "0.0.0",
+        meta: { target: ["userId", "circleId"] },
       }),
     );
 
@@ -257,6 +258,26 @@ describe("Prisma Circle メンバーシップリポジトリ", () => {
         "CircleMember",
       ),
     ).rejects.toThrow(ConflictError);
+  });
+
+  test("addMembership は P2002 で target が期待と異なる場合そのまま再スローする", async () => {
+    const error = new Prisma.PrismaClientKnownRequestError(
+      "Unique constraint failed",
+      {
+        code: "P2002",
+        clientVersion: "0.0.0",
+        meta: { target: ["other_field"] },
+      },
+    );
+    mockedPrisma.circleMembership.create.mockRejectedValueOnce(error);
+
+    await expect(
+      prismaCircleRepository.addMembership(
+        circleId("circle-1"),
+        userId("user-1"),
+        "CircleMember",
+      ),
+    ).rejects.toThrow(error);
   });
 
   test("addMembership は P2002 以外の Prisma エラーはそのまま伝播する", async () => {

--- a/server/infrastructure/repository/circle/prisma-circle-repository.ts
+++ b/server/infrastructure/repository/circle/prisma-circle-repository.ts
@@ -120,7 +120,15 @@ export const createPrismaCircleRepository = (
         error instanceof Prisma.PrismaClientKnownRequestError &&
         error.code === "P2002"
       ) {
-        throw new ConflictError("Membership already exists");
+        const target = error.meta?.target;
+        if (
+          Array.isArray(target) &&
+          target.includes("userId") &&
+          target.includes("circleId")
+        ) {
+          throw new ConflictError("Membership already exists");
+        }
+        throw error;
       }
       throw error;
     }

--- a/server/infrastructure/repository/user/prisma-user-repository.test.ts
+++ b/server/infrastructure/repository/user/prisma-user-repository.test.ts
@@ -109,11 +109,12 @@ describe("Prisma User リポジトリ", () => {
     });
   });
 
-  test("createUser は P2002（一意制約違反）で ConflictError をスローする", async () => {
+  test("createUser は P2002（email 一意制約違反）で ConflictError をスローする", async () => {
     mockedPrisma.user.create.mockRejectedValueOnce(
       new Prisma.PrismaClientKnownRequestError("Unique constraint failed", {
         code: "P2002",
         clientVersion: "0.0.0",
+        meta: { target: ["email"] },
       }),
     );
 
@@ -124,6 +125,26 @@ describe("Prisma User リポジトリ", () => {
         name: "Test",
       }),
     ).rejects.toThrow(ConflictError);
+  });
+
+  test("createUser は P2002 で target が期待と異なる場合そのまま再スローする", async () => {
+    const error = new Prisma.PrismaClientKnownRequestError(
+      "Unique constraint failed",
+      {
+        code: "P2002",
+        clientVersion: "0.0.0",
+        meta: { target: ["other_field"] },
+      },
+    );
+    mockedPrisma.user.create.mockRejectedValueOnce(error);
+
+    await expect(
+      prismaUserRepository.createUser({
+        email: "test@example.com",
+        passwordHash: "hashed",
+        name: "Test",
+      }),
+    ).rejects.toThrow(error);
   });
 
   test("createUser は P2002 以外の Prisma エラーはそのまま伝播する", async () => {

--- a/server/infrastructure/repository/user/prisma-user-repository.ts
+++ b/server/infrastructure/repository/user/prisma-user-repository.ts
@@ -142,7 +142,11 @@ export const createPrismaUserRepository = (
         error instanceof Prisma.PrismaClientKnownRequestError &&
         error.code === "P2002"
       ) {
-        throw new ConflictError("User already exists");
+        const target = error.meta?.target;
+        if (Array.isArray(target) && target.includes("email")) {
+          throw new ConflictError("User already exists");
+        }
+        throw error;
       }
       throw error;
     }


### PR DESCRIPTION
## Summary

Closes #613

P2002（一意制約違反）エラーのキャッチ時に `error.meta?.target` を検証し、期待する制約フィールドに一致する場合のみ `ConflictError` に変換するよう修正。

- **User**: `email` 一意制約のみ ConflictError に変換
- **CircleMembership**: `userId` + `circleId` 一意制約のみ ConflictError に変換
- **CircleSessionMembership**: `userId` + `circleSessionId` 一意制約のみ ConflictError に変換
- target が不一致の場合はそのまま再スロー

## Test plan

- [x] 既存テストのモックに `meta: { target: [...] }` を追加し、正常系が引き続きパスすることを確認
- [x] 各リポジトリに target 不一致時の再スローテストを追加
- [x] 全47テストがパス
- [x] TypeScript 型チェック エラーなし

## Review points

- `error.meta?.target` が文字列（インデックス名）を返す Prisma 環境への防御は将来課題（現 Prisma 6.x + PostgreSQL では常に配列）

🤖 Generated with [Claude Code](https://claude.com/claude-code)