### PR TITLE
fix: RateLimiter をモジュールスコープでシングルトン化する

### DIFF
--- a/server/presentation/trpc/context.ts
+++ b/server/presentation/trpc/context.ts
@@ -19,6 +19,10 @@ import { createInMemoryRateLimiter } from "@/server/infrastructure/rate-limit/in
 
 const getSession = createGetSession(nextAuthSessionService);
 const japaneseHolidayProvider = createJapaneseHolidayProvider();
+const changePasswordRateLimiter = createInMemoryRateLimiter({
+  maxAttempts: 5,
+  windowMs: 60_000,
+});
 
 const buildServiceContainer = (): ServiceContainer =>
   createServiceContainer({
@@ -29,10 +33,7 @@ const buildServiceContainer = (): ServiceContainer =>
     authzRepository: prismaAuthzRepository,
     circleInviteLinkRepository: prismaCircleInviteLinkRepository,
     passwordUtils: { hash: hashPassword, verify: verifyPassword },
-    changePasswordRateLimiter: createInMemoryRateLimiter({
-      maxAttempts: 5,
-      windowMs: 60_000,
-    }),
+    changePasswordRateLimiter,
     holidayProvider: japaneseHolidayProvider,
     unitOfWork: prismaUnitOfWork,
   });


### PR DESCRIPTION
## Summary

- `changePasswordRateLimiter` を `buildServiceContainer()` 内部からモジュールスコープに移動し、リクエスト間でレート制限状態が共有されるよう修正

Closes #568

## 変更内容

`createContext()` が呼ばれるたびに `buildServiceContainer()` が実行され、`createInMemoryRateLimiter` も毎回新規生成されていた。これにより内部の `Map` が毎回空になり、レート制限が実質的に機能していなかった。

`getSession` / `japaneseHolidayProvider` と同じパターンで、モジュールスコープに配置しシングルトン化。

## 検証手順

- [x] 全テスト通過（60 files, 742 tests passed）
- [x] 型チェック通過（`tsc --noEmit`）
- [ ] デプロイ後、同一ユーザーで60秒以内にパスワード変更を6回試行 → 6回目が拒否されることを確認

## Follow-up Issues

- #620 レート制限値の引き締め（3回/15分）
- #621 context.ts のワイヤリング統合テスト追加
- #622 Retry-After 情報のクライアント返却

🤖 Generated with [Claude Code](https://claude.com/claude-code)