### PR TITLE
fix: changePasswordRateLimiter のレート制限を引き締める（3回/15分）

### DIFF
--- a/server/presentation/trpc/context.ts
+++ b/server/presentation/trpc/context.ts
@@ -20,8 +20,8 @@ import { createInMemoryRateLimiter } from "@/server/infrastructure/rate-limit/in
 const getSession = createGetSession(nextAuthSessionService);
 const japaneseHolidayProvider = createJapaneseHolidayProvider();
 const changePasswordRateLimiter = createInMemoryRateLimiter({
-  maxAttempts: 5,
-  windowMs: 60_000,
+  maxAttempts: 3,
+  windowMs: 15 * 60 * 1000,
 });
 
 const buildServiceContainer = (): ServiceContainer =>


### PR DESCRIPTION
## Summary

- `changePasswordRateLimiter` のレート制限を 5回/60秒 → 3回/15分 に変更
- 攻撃スループットを 25 倍削減（7,200回/日 → 288回/日）

Closes #620

## Changes

- `server/presentation/trpc/context.ts`: `maxAttempts: 5, windowMs: 60_000` → `maxAttempts: 3, windowMs: 15 * 60 * 1000`

## Verification

1. `server/presentation/trpc/context.ts` L22-25 の設定値を確認
2. 型チェック・全テスト通過済み（742 tests passed）

## Review Points

- レート制限ウィンドウの拡大（60秒→15分）により、正規ユーザーへの DoS 影響が微増する（攻撃者が不正パスワードで 3 回試行すると正規ユーザーが 15 分間ロックアウトされる）
- インメモリレートリミッターの既知制限（サーバーレス環境でのコールドスタート、IP ベースキーイングなし）は #624, #625 で別途対応予定

🤖 Generated with [Claude Code](https://claude.com/claude-code)