### PR TITLE
feat: ヘルプページにお問い合わせフォームリンクを追加する

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -11,3 +11,6 @@ NEXTAUTH_URL="http://localhost:3000"
 # Google OAuth
 GOOGLE_CLIENT_ID="your-google-client-id"
 GOOGLE_CLIENT_SECRET="your-google-client-secret"
+
+# お問い合わせフォーム（任意: 省略するとヘルプ画面のお問い合わせリンクが非表示になる）
+# NEXT_PUBLIC_CONTACT_FORM_URL="https://docs.google.com/forms/d/your-form-id"

--- a/app/(authenticated)/help/page.tsx
+++ b/app/(authenticated)/help/page.tsx
@@ -1,3 +1,7 @@
+import { ExternalLink } from "lucide-react";
+
+const contactFormUrl = process.env.NEXT_PUBLIC_CONTACT_FORM_URL;
+
 export default function HelpPage() {
   return (
     <div className="mx-auto flex w-full max-w-3xl flex-col gap-6">
@@ -145,6 +149,26 @@ export default function HelpPage() {
           </li>
         </ul>
       </section>
+
+      {contactFormUrl && (
+        <section className="rounded-2xl border border-border/60 bg-white/90 p-6 shadow-sm">
+          <h2 className="text-lg font-semibold text-(--brand-ink)">
+            お問い合わせ
+          </h2>
+          <p className="mt-4 text-sm text-(--brand-ink-muted)">
+            ご意見・ご要望・不具合の報告などは、以下のフォームからお寄せください。
+          </p>
+          <a
+            href={contactFormUrl}
+            target="_blank"
+            rel="noopener noreferrer"
+            className="mt-4 inline-flex items-center gap-1.5 text-sm font-medium text-(--brand-moss) hover:underline"
+          >
+            お問い合わせフォームを開く
+            <ExternalLink className="size-4" />
+          </a>
+        </section>
+      )}
     </div>
   );
 }


### PR DESCRIPTION
## Summary

- ヘルプページにお問い合わせセクションを追加
- 環境変数 `NEXT_PUBLIC_CONTACT_FORM_URL` で外部フォーム（Google Forms等）のURLを設定可能
- 環境変数が未設定の場合、セクションは非表示

Closes #631

## 変更ファイル

| ファイル | 変更内容 |
|---|---|
| `.env.example` | `NEXT_PUBLIC_CONTACT_FORM_URL` の設定例を追加 |
| `app/(authenticated)/help/page.tsx` | お問い合わせセクションを条件付きレンダリング |

## 検証手順

1. `NEXT_PUBLIC_CONTACT_FORM_URL` を `.env` に設定せずに `/help` を開く → お問い合わせセクションが表示されないことを確認
2. `NEXT_PUBLIC_CONTACT_FORM_URL="https://example.com"` を `.env` に設定して `/help` を開く → お問い合わせセクションが表示されることを確認
3. リンクをクリック → 新しいタブで外部URLが開くことを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)