### PR TITLE
feat: Content Security Policy (CSP) ヘッダーを追加する

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -1,5 +1,20 @@
 import type { NextConfig } from "next";
 
+const cspDirectives = [
+  "default-src 'self'",
+  "script-src 'self' 'unsafe-inline'",
+  "style-src 'self' 'unsafe-inline'",
+  "img-src 'self' https://lh3.googleusercontent.com",
+  "font-src 'self'",
+  "connect-src 'self'",
+  "form-action 'self'",
+  "frame-ancestors 'none'",
+  "base-uri 'self'",
+  "frame-src 'none'",
+  "object-src 'none'",
+  "upgrade-insecure-requests",
+].join("; ");
+
 const nextConfig: NextConfig = {
   experimental: {
     authInterrupts: true,
@@ -11,6 +26,19 @@ const nextConfig: NextConfig = {
         hostname: "lh3.googleusercontent.com",
       },
     ],
+  },
+  async headers() {
+    return [
+      {
+        source: "/:path*",
+        headers: [
+          {
+            key: "Content-Security-Policy",
+            value: cspDirectives,
+          },
+        ],
+      },
+    ];
   },
 };
 


### PR DESCRIPTION
## Summary

Closes #648

- `next.config.ts` に `headers()` 関数を追加し、Content Security Policy ヘッダーをすべてのルートに付与
- XSS緩和、リソース読み込み制限、フレーム埋め込み防止などを設定

### CSP ディレクティブ

| ディレクティブ | 値 | 目的 |
|---|---|---|
| `default-src` | `'self'` | デフォルトで自サイトのみ |
| `script-src` | `'self' 'unsafe-inline'` | Next.jsインラインスクリプト互換 |
| `style-src` | `'self' 'unsafe-inline'` | Reactインラインスタイル互換 |
| `img-src` | `'self' https://lh3.googleusercontent.com` | Googleアバター画像 |
| `font-src` | `'self'` | 自サイトフォントのみ |
| `connect-src` | `'self'` | tRPC API等 |
| `form-action` | `'self'` | フォーム送信先制限 |
| `frame-ancestors` | `'none'` | 他サイトからの埋め込み防止 |
| `frame-src` | `'none'` | iframe読み込み防止 |
| `base-uri` | `'self'` | base要素の制限 |
| `object-src` | `'none'` | object/embed要素の無効化 |
| `upgrade-insecure-requests` | - | HTTP→HTTPSアップグレード |

### 既知の制限

- `script-src 'unsafe-inline'` によりXSS緩和効果は限定的（nonceベースCSPは #651 で対応予定）
- `style-src 'unsafe-inline'` はReactインラインスタイルとの互換性のため必要

## Test plan

- [x] `npm run dev` で起動し、DevTools NetworkタブでCSPヘッダーが付与されることを確認
- [x] CSP違反エラーがコンソールに出ないことを確認しながら以下を操作:
  - [x] ログインページの表示
  - [x] メール/パスワードでのログイン
  - [x] Google OAuthでのログイン
  - [x] Googleアバター画像の表示
  - [x] セッション一覧・詳細ページの表示
  - [x] tRPC APIの正常動作
  - [x] HMR（ホットリロード）の動作

## Related issues

- #650 セキュリティヘッダーを追加する（X-Content-Type-Options, Referrer-Policy 等）
- #651 nonceベースのCSPを導入して 'unsafe-inline' を排除する

🤖 Generated with [Claude Code](https://claude.com/claude-code)