### PR TITLE
feat: セキュリティヘッダーを追加する（X-Content-Type-Options, Referrer-Policy 等）

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -36,6 +36,22 @@ const nextConfig: NextConfig = {
             key: "Content-Security-Policy",
             value: cspDirectives,
           },
+          {
+            key: "X-Content-Type-Options",
+            value: "nosniff",
+          },
+          {
+            key: "Referrer-Policy",
+            value: "strict-origin-when-cross-origin",
+          },
+          {
+            key: "X-Frame-Options",
+            value: "DENY",
+          },
+          {
+            key: "Permissions-Policy",
+            value: "camera=(), microphone=(), geolocation=()",
+          },
         ],
       },
     ];


### PR DESCRIPTION
## Summary

Closes #650

- `next.config.ts` の `headers()` に4つのセキュリティヘッダーを追加
  - `X-Content-Type-Options: nosniff` — MIMEタイプスニッフィング防止
  - `Referrer-Policy: strict-origin-when-cross-origin` — リファラー情報漏洩の制御
  - `X-Frame-Options: DENY` — クリックジャッキング防止（CSP frame-ancestors の補完）
  - `Permissions-Policy: camera=(), microphone=(), geolocation=()` — 不要なブラウザ機能の制限

## Test plan

- [x] `npm run dev` → `curl -I http://localhost:3000/` で4つのヘッダーが返されることを確認
- [x] `npx tsc --noEmit` でエラーなし（確認済み）
- [ ] デプロイ後 https://securityheaders.com/ でスキャンし A/A+ 評価を確認

## Related

- #648 で導入した CSP に続くセキュリティヘッダーの追加
- #653 nonce-based CSP 移行（フォローアップ issue）

🤖 Generated with [Claude Code](https://claude.com/claude-code)