### PR TITLE
feat: nonce-based CSP に移行して unsafe-inline を除去する

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -3,6 +3,7 @@ import "./globals.css";
 import { Toaster } from "@/components/ui/sonner";
 import { Metadata } from "next";
 import { Shippori_Mincho_B1, Zen_Maru_Gothic } from "next/font/google";
+import { headers } from "next/headers";
 import Providers from "./providers";
 
 const zenMaru = Zen_Maru_Gothic({
@@ -27,17 +28,19 @@ export const metadata: Metadata = {
   manifest: "/manifest.webmanifest",
 };
 
-export default function RootLayout({
+export default async function RootLayout({
   children,
 }: {
   children: React.ReactNode;
 }) {
+  const nonce = (await headers()).get("x-nonce") ?? undefined;
+
   return (
     <html lang="ja" suppressHydrationWarning>
       <body
         className={`${zenMaru.variable} ${shippori.variable} min-h-svh w-screen overflow-x-hidden`}
       >
-        <Providers>{children}</Providers>
+        <Providers nonce={nonce}>{children}</Providers>
         <Toaster />
       </body>
     </html>

--- a/app/providers.tsx
+++ b/app/providers.tsx
@@ -7,12 +7,18 @@ import { TrpcProvider } from "@/lib/trpc/client";
 
 type ProvidersProps = {
   children: ReactNode;
+  nonce?: string;
 };
 
-export default function Providers({ children }: ProvidersProps) {
+export default function Providers({ children, nonce }: ProvidersProps) {
   return (
     <SessionProvider>
-      <ThemeProvider attribute="class" defaultTheme="system" enableSystem>
+      <ThemeProvider
+        attribute="class"
+        defaultTheme="system"
+        enableSystem
+        nonce={nonce}
+      >
         <TrpcProvider>{children}</TrpcProvider>
       </ThemeProvider>
     </SessionProvider>

--- a/middleware.ts
+++ b/middleware.ts
@@ -1,0 +1,43 @@
+import { NextResponse } from "next/server";
+import type { NextRequest } from "next/server";
+
+export function middleware(request: NextRequest) {
+  const nonce = crypto.randomUUID();
+
+  const cspDirectives = [
+    "default-src 'self'",
+    `script-src 'self' 'nonce-${nonce}'`,
+    "style-src 'self' 'unsafe-inline'",
+    "img-src 'self' https://lh3.googleusercontent.com",
+    "font-src 'self' data:",
+    "connect-src 'self'",
+    "form-action 'self'",
+    "frame-ancestors 'none'",
+    "base-uri 'self'",
+    "frame-src 'none'",
+    "object-src 'none'",
+    "upgrade-insecure-requests",
+  ].join("; ");
+
+  const requestHeaders = new Headers(request.headers);
+  requestHeaders.set("Content-Security-Policy", cspDirectives);
+  requestHeaders.set("x-nonce", nonce);
+
+  const response = NextResponse.next({ request: { headers: requestHeaders } });
+  response.headers.set("Content-Security-Policy", cspDirectives);
+
+  return response;
+}
+
+export const config = {
+  matcher: [
+    {
+      source:
+        "/((?!_next/static|_next/image|favicon\\.ico|manifest\\.webmanifest|.*\\.(?:svg|png|jpg|jpeg|gif|webp|ico)$).*)",
+      missing: [
+        { type: "header", key: "next-router-prefetch" },
+        { type: "header", key: "purpose", value: "prefetch" },
+      ],
+    },
+  ],
+};

--- a/next.config.ts
+++ b/next.config.ts
@@ -1,20 +1,5 @@
 import type { NextConfig } from "next";
 
-const cspDirectives = [
-  "default-src 'self'",
-  "script-src 'self' 'unsafe-inline'",
-  "style-src 'self' 'unsafe-inline'",
-  "img-src 'self' https://lh3.googleusercontent.com",
-  "font-src 'self' data:",
-  "connect-src 'self'",
-  "form-action 'self'",
-  "frame-ancestors 'none'",
-  "base-uri 'self'",
-  "frame-src 'none'",
-  "object-src 'none'",
-  "upgrade-insecure-requests",
-].join("; ");
-
 const nextConfig: NextConfig = {
   experimental: {
     authInterrupts: true,
@@ -32,10 +17,6 @@ const nextConfig: NextConfig = {
       {
         source: "/:path*",
         headers: [
-          {
-            key: "Content-Security-Policy",
-            value: cspDirectives,
-          },
           {
             key: "X-Content-Type-Options",
             value: "nosniff",


### PR DESCRIPTION
## Summary

- middleware でリクエストごとに一意の nonce を生成し、`script-src 'self' 'unsafe-inline'` を `script-src 'self' 'nonce-<value>'` に置換
- CSP ヘッダーを `next.config.ts` の静的設定から `middleware.ts` の動的生成に移動
- nonce を `layout.tsx` → `providers.tsx` → `ThemeProvider` に伝播し、テーマ切り替えスクリプトの CSP 準拠を維持

Closes #653

## Changed Files

| File | Change |
|------|--------|
| `middleware.ts` | 新規: nonce 生成 + CSP ヘッダー設定 |
| `app/layout.tsx` | `x-nonce` ヘッダー取得 → Providers に prop 渡し |
| `app/providers.tsx` | ThemeProvider に `nonce` prop を伝播 |
| `next.config.ts` | CSP ディレクティブ定義と CSP ヘッダー設定を削除 |

## Verification Steps

1. `npm run dev` で開発サーバーを起動
2. DevTools > Network で `Content-Security-Policy` ヘッダーに `nonce-<UUID>` が含まれることを確認
3. `script-src` に `'unsafe-inline'` がないことを確認
4. リロードで nonce が毎回変わることを確認
5. Console に CSP 違反エラーがないことを確認
6. テーマ切り替え（ダーク/ライト/システム）が正常に動作すること

## Automated Tests

- TypeScript type check: PASS
- ESLint: PASS
- Tests: 762/762 PASS

## Follow-up Issues

- #655 middleware の単体テストを追加する
- #656 CSP nonce の生成を crypto.getRandomValues に改善する
- #657 middleware の matcher で API ルートを除外する

🤖 Generated with [Claude Code](https://claude.com/claude-code)