### PR TITLE
feat: 招待リンク生成UIにアイコンを追加して視認性を向上する

### DIFF
--- a/app/(authenticated)/circles/[circleId]/invite-link/invite-link-generator.tsx
+++ b/app/(authenticated)/circles/[circleId]/invite-link/invite-link-generator.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { useState } from "react";
-import { Copy, Check, Link } from "lucide-react";
+import { Copy, Check, Link, Clock, RefreshCw } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import { trpc } from "@/lib/trpc/client";
 
@@ -86,7 +86,8 @@ export function InviteLinkGenerator({ circleId }: InviteLinkGeneratorProps) {
               {copied ? "コピー済み" : "コピー"}
             </Button>
           </div>
-          <p className="text-xs text-(--brand-ink-muted)">
+          <p className="flex items-center gap-1 text-xs text-(--brand-ink-muted)">
+            <Clock className="size-3.5" aria-hidden="true" />
             有効期限:{" "}
             {createInviteLink.data.expiresAt.toLocaleDateString("ja-JP")}
           </p>
@@ -98,6 +99,7 @@ export function InviteLinkGenerator({ circleId }: InviteLinkGeneratorProps) {
             }}
             className="self-start"
           >
+            <RefreshCw className="size-4" />
             別のリンクを作成
           </Button>
         </div>

--- a/app/(authenticated)/circles/[circleId]/invite-link/page.tsx
+++ b/app/(authenticated)/circles/[circleId]/invite-link/page.tsx
@@ -2,7 +2,7 @@ import { appRouter } from "@/server/presentation/trpc/router";
 import { createContext } from "@/server/presentation/trpc/context";
 import { notFound } from "next/navigation";
 import Link from "next/link";
-import { ChevronLeft } from "lucide-react";
+import { ChevronLeft, UserPlus } from "lucide-react";
 import { InviteLinkGenerator } from "./invite-link-generator";
 
 type InviteLinkPageProps = {
@@ -31,7 +31,8 @@ export default async function InviteLinkPage({ params }: InviteLinkPageProps) {
         <ChevronLeft className="size-4" />
         {circle.name} に戻る
       </Link>
-      <h1 className="text-2xl font-(--font-display) text-(--brand-ink)">
+      <h1 className="flex items-center gap-2 text-2xl font-(--font-display) text-(--brand-ink)">
+        <UserPlus className="size-6" aria-hidden="true" />
         メンバーを招待
       </h1>
       <InviteLinkGenerator circleId={circleId} />

--- a/app/(authenticated)/circles/components/circle-overview-view.tsx
+++ b/app/(authenticated)/circles/components/circle-overview-view.tsx
@@ -6,6 +6,7 @@ import type {
   CircleOverviewViewModel,
   CircleRoleKey,
 } from "@/server/presentation/view-models/circle-overview";
+import { UserPlus } from "lucide-react";
 import Link from "next/link";
 import type { ReactNode } from "react";
 
@@ -151,8 +152,9 @@ export function CircleOverviewView({
               {getInviteLinkHref?.() ? (
                 <Link
                   href={getInviteLinkHref()!}
-                  className="rounded-md px-2 py-1 text-xs font-semibold text-(--brand-moss) hover:bg-(--brand-moss)/10"
+                  className="flex items-center gap-1 rounded-md px-2 py-1 text-xs font-semibold text-(--brand-moss) hover:bg-(--brand-moss)/10"
                 >
+                  <UserPlus className="size-3.5" aria-hidden="true" />
                   招待リンク
                 </Link>
               ) : null}


### PR DESCRIPTION
## Summary

Closes #586

招待リンク生成UIの視認性を向上するため、各要素にアイコンを追加しました。

- 招待リンクページのタイトル（`メンバーを招待`）に `UserPlus` アイコンを追加
- 有効期限表示に `Clock` アイコンを追加
- 「別のリンクを作成」ボタンに `RefreshCw` アイコンを追加
- 研究会概要ページの「招待リンク」ボタンに `UserPlus` アイコンを追加

## Test plan

- [ ] 招待リンクページ（`/circles/{circleId}/invite-link`）にアクセスし、タイトルに UserPlus アイコンが表示されることを確認
- [ ] リンク生成後、有効期限の横に Clock アイコンが表示されることを確認
- [ ] 「別のリンクを作成」ボタンに RefreshCw アイコンが表示されることを確認
- [ ] 研究会概要ページの「招待リンク」ボタンに UserPlus アイコンが表示されることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)