### PR TITLE
feat: 研究会作成ダイアログに文字数カウンターを表示する (#533)

### DIFF
--- a/app/components/circle-create-dialog.tsx
+++ b/app/components/circle-create-dialog.tsx
@@ -93,6 +93,21 @@ export function CircleCreateDialog() {
             aria-required="true"
             className="mt-2 bg-white"
           />
+          <p
+            className={`mt-1 text-right text-xs ${
+              name.length >= CIRCLE_NAME_MAX_LENGTH
+                ? "text-destructive"
+                : name.length >= CIRCLE_NAME_MAX_LENGTH * 0.8
+                  ? "text-amber-600"
+                  : "text-(--brand-ink-muted)"
+            }`}
+            aria-live={
+              name.length >= CIRCLE_NAME_MAX_LENGTH * 0.8 ? "polite" : "off"
+            }
+            aria-label="研究会名の文字数"
+          >
+            {name.length} / {CIRCLE_NAME_MAX_LENGTH}
+          </p>
           {createCircle.error ? (
             <p role="alert" className="mt-2 text-xs text-red-600">
               {createCircle.error.message}


### PR DESCRIPTION
## Summary

- 研究会作成ダイアログの名前入力欄に文字数カウンター (`現在 / 50`) を追加
- 80%以上 (40文字〜) で amber 色、上限到達で destructive 色に変化
- `aria-live="polite"` + `aria-label` でアクセシビリティ対応

Closes #533

## Test plan

- [x] 研究会作成ダイアログを開き、カウンターが `0 / 50` で表示されることを確認
- [x] 文字を入力するとカウンターがリアルタイムで更新されることを確認
- [x] 40文字以上で amber 色に変化することを確認
- [x] 50文字（上限）で destructive 色に変化することを確認
- [ ] スクリーンリーダーで40文字以上入力時にカウンターが読み上げられることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)