### PR TITLE
feat: 研究会名変更ダイアログに文字数カウンターを追加する

### DIFF
--- a/app/(authenticated)/circles/components/circle-overview-view.test.tsx
+++ b/app/(authenticated)/circles/components/circle-overview-view.test.tsx
@@ -40,6 +40,15 @@ vi.mock(
   }),
 );
 
+vi.mock(
+  "@/app/(authenticated)/circles/components/circle-rename-dialog",
+  () => ({
+    CircleRenameDialog: () => (
+      <button data-testid="circle-rename-dialog">名前変更</button>
+    ),
+  }),
+);
+
 afterEach(() => {
   cleanup();
 });
@@ -58,6 +67,7 @@ function buildOverview(
     members: [],
     holidayDates: [],
     canDeleteCircle: false,
+    canRenameCircle: false,
     ...overrides,
   };
 }
@@ -125,6 +135,28 @@ describe("CircleOverviewView ロールベース表示制御", () => {
     const calendar = screen.getByTestId("calendar");
     expect(calendar.dataset.createHref).toBe("");
     expect(screen.queryByTestId("create-link")).not.toBeInTheDocument();
+  });
+
+  it("canRenameCircle が true の場合、名前変更ダイアログが表示される", () => {
+    render(
+      <CircleOverviewView
+        overview={buildOverview({ canRenameCircle: true })}
+      />,
+    );
+
+    expect(screen.getByTestId("circle-rename-dialog")).toBeInTheDocument();
+  });
+
+  it("canRenameCircle が false の場合、名前変更ダイアログが表示されない", () => {
+    render(
+      <CircleOverviewView
+        overview={buildOverview({ canRenameCircle: false })}
+      />,
+    );
+
+    expect(
+      screen.queryByTestId("circle-rename-dialog"),
+    ).not.toBeInTheDocument();
   });
 
   it("canDeleteCircle が true の場合、削除ボタンが表示される", () => {

--- a/app/(authenticated)/circles/components/circle-overview-view.tsx
+++ b/app/(authenticated)/circles/components/circle-overview-view.tsx
@@ -1,5 +1,6 @@
 import { CircleDeleteButton } from "@/app/(authenticated)/circles/components/circle-delete-button";
 import { CircleOverviewCalendar } from "@/app/(authenticated)/circles/components/circle-overview-calendar";
+import { CircleRenameDialog } from "@/app/(authenticated)/circles/components/circle-rename-dialog";
 import { CircleWithdrawButton } from "@/app/(authenticated)/circles/components/circle-withdraw-button";
 import type {
   CircleOverviewMember,
@@ -75,6 +76,12 @@ export function CircleOverviewView({
         <h1 className="text-3xl font-(--font-display) text-(--brand-ink) sm:text-4xl">
           {overview.circleName}
         </h1>
+        {overview.canRenameCircle ? (
+          <CircleRenameDialog
+            circleId={overview.circleId}
+            circleName={overview.circleName}
+          />
+        ) : null}
         {roleLabel ? (
           <span
             className={`rounded-full px-2.5 py-0.5 text-xs ${roleBadgeClassName}`}

--- a/app/(authenticated)/circles/components/circle-rename-dialog.tsx
+++ b/app/(authenticated)/circles/components/circle-rename-dialog.tsx
@@ -1,0 +1,138 @@
+"use client";
+
+import { Button } from "@/components/ui/button";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+  DialogTrigger,
+} from "@/components/ui/dialog";
+import { Input } from "@/components/ui/input";
+import { trpc } from "@/lib/trpc/client";
+import { CIRCLE_NAME_MAX_LENGTH } from "@/server/domain/models/circle/circle";
+import { Pencil } from "lucide-react";
+import { useRouter } from "next/navigation";
+import type { FormEvent } from "react";
+import { useState } from "react";
+
+type CircleRenameDialogProps = {
+  circleId: string;
+  circleName: string;
+};
+
+export function CircleRenameDialog({
+  circleId,
+  circleName,
+}: CircleRenameDialogProps) {
+  const [open, setOpen] = useState(false);
+  const [name, setName] = useState(circleName);
+  const router = useRouter();
+  const renameCircle = trpc.circles.rename.useMutation({
+    onSuccess: () => {
+      setOpen(false);
+      router.refresh();
+    },
+  });
+
+  const trimmed = name.trim();
+  const canSubmit =
+    trimmed.length > 0 && trimmed !== circleName && !renameCircle.isPending;
+
+  const handleSubmit = (event: FormEvent<HTMLFormElement>) => {
+    event.preventDefault();
+    if (!canSubmit) return;
+    renameCircle.mutate({ circleId, name: trimmed });
+  };
+
+  const handleOpenChange = (nextOpen: boolean) => {
+    setOpen(nextOpen);
+    if (!nextOpen) {
+      setName(circleName);
+      renameCircle.reset();
+    }
+  };
+
+  return (
+    <Dialog open={open} onOpenChange={handleOpenChange}>
+      <DialogTrigger asChild>
+        <Button
+          variant="ghost"
+          size="icon"
+          className="size-8 text-(--brand-ink-muted) hover:text-(--brand-ink)"
+          aria-label="研究会名を変更"
+        >
+          <Pencil className="size-3.5" />
+        </Button>
+      </DialogTrigger>
+
+      <DialogContent className="max-w-md rounded-2xl border-border/60 bg-white p-6 shadow-xl">
+        <DialogHeader>
+          <DialogTitle className="text-lg font-semibold text-(--brand-ink)">
+            研究会名を変更
+          </DialogTitle>
+          <DialogDescription className="sr-only">
+            研究会の名前を変更します
+          </DialogDescription>
+        </DialogHeader>
+
+        <form onSubmit={handleSubmit}>
+          <label
+            htmlFor="circle-rename"
+            className="block text-xs font-semibold text-(--brand-ink-muted)"
+          >
+            研究会名
+          </label>
+          <Input
+            id="circle-rename"
+            value={name}
+            onChange={(event) => setName(event.target.value)}
+            placeholder="研究会名"
+            maxLength={CIRCLE_NAME_MAX_LENGTH}
+            aria-required="true"
+            className="mt-2 bg-white"
+          />
+          <p
+            className={`mt-1 text-right text-xs ${
+              name.length >= CIRCLE_NAME_MAX_LENGTH
+                ? "text-destructive"
+                : name.length >= CIRCLE_NAME_MAX_LENGTH * 0.8
+                  ? "text-amber-600"
+                  : "text-(--brand-ink-muted)"
+            }`}
+            aria-live={
+              name.length >= CIRCLE_NAME_MAX_LENGTH * 0.8 ? "polite" : "off"
+            }
+            aria-label="研究会名の文字数"
+          >
+            {name.length} / {CIRCLE_NAME_MAX_LENGTH}
+          </p>
+          {renameCircle.error ? (
+            <p role="alert" className="mt-2 text-xs text-red-600">
+              {renameCircle.error.message}
+            </p>
+          ) : null}
+          <DialogFooter className="mt-6">
+            <Button
+              type="button"
+              variant="outline"
+              className="border-(--brand-ink)/20 bg-white/80 text-(--brand-ink)"
+              onClick={() => handleOpenChange(false)}
+            >
+              キャンセル
+            </Button>
+            <Button
+              type="submit"
+              className="bg-(--brand-moss) text-white hover:bg-(--brand-moss)/90"
+              disabled={!canSubmit}
+            >
+              {renameCircle.isPending ? "変更中..." : "変更"}
+            </Button>
+          </DialogFooter>
+        </form>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/server/presentation/providers/circle-overview-provider.ts
+++ b/server/presentation/providers/circle-overview-provider.ts
@@ -58,12 +58,15 @@ export async function getCircleOverviewViewModel(
 
   const viewerId = ctx.actorId ?? null;
 
-  const [users, canDeleteCircle] = await Promise.all([
+  const [users, canDeleteCircle, canRenameCircle] = await Promise.all([
     caller.users.list({
       userIds: memberships.map((m) => m.userId),
     }),
     viewerId
       ? ctx.accessService.canDeleteCircle(viewerId, circleId)
+      : Promise.resolve(false),
+    viewerId
+      ? ctx.accessService.canEditCircle(viewerId, circleId)
       : Promise.resolve(false),
   ]);
   const userNameById = new Map(users.map((user) => [user.id, user.name]));
@@ -105,6 +108,7 @@ export async function getCircleOverviewViewModel(
     })),
     holidayDates: ctx.holidayProvider.getHolidayDateStringsForRange(),
     canDeleteCircle,
+    canRenameCircle,
   };
 
   return overview;

--- a/server/presentation/view-models/circle-overview.ts
+++ b/server/presentation/view-models/circle-overview.ts
@@ -29,4 +29,5 @@ export type CircleOverviewViewModel = {
   members: CircleOverviewMember[];
   holidayDates: string[];
   canDeleteCircle: boolean;
+  canRenameCircle: boolean;
 };


### PR DESCRIPTION
## Summary

Closes #665

- 研究会概要ページに研究会名変更ダイアログを新規作成
- 研究会作成ダイアログと同一パターンの3段階カラー文字数カウンターを実装
- `canRenameCircle` による認可ベースの表示制御

## Changes

| ファイル | 変更内容 |
|---------|---------|
| `circle-rename-dialog.tsx` | 新規: 文字数カウンター付き名前変更ダイアログ |
| `circle-overview.ts` | `canRenameCircle: boolean` を ViewModel に追加 |
| `circle-overview-provider.ts` | `canEditCircle` を `Promise.all` で並列取得 |
| `circle-overview-view.tsx` | h1 横にダイアログ配置（`canRenameCircle` で表示制御） |
| `circle-overview-view.test.tsx` | `canRenameCircle` の表示制御テスト追加 |

## Verification

### 自動テスト

- `npm run test:run -- circle-overview-view.test.tsx`: 9 tests passed
- `npx tsc --noEmit`: clean

### 手動確認手順

1. `npm run db:seed` → `npm run dev`
2. オーナー（sota@example.com / demo-pass-1）でログイン
3. 「京大将棋研究会」概要ページで鉛筆アイコンを確認
4. ダイアログを開き、文字数カウンターの3段階カラーを確認（0-39: muted, 40-49: amber, 50: destructive）
5. 名前未変更時・空入力時に「変更」ボタンが disabled であることを確認
6. 名前を変更して送信 → ページが更新されることを確認
7. メンバー（ito@example.com / demo-pass-4）でログインし、鉛筆アイコンが非表示であることを確認

## Review Points

- `canRenameCircle` は `canEditCircle`（Owner / Manager）を使用。`canDeleteCircle`（Owner only）とは異なる認可レベル
- 文字数カウンターは `circle-create-dialog.tsx` と同一パターン（重複は #668 で対応予定）
- ダイアログ専用テストは #669 で対応予定

## Related Issues

- #668 文字数カウンターを共通コンポーネントとして抽出する
- #669 ダイアログコンポーネントの単体テストを追加する

🤖 Generated with [Claude Code](https://claude.com/claude-code)