### PR TITLE
refactor: ダイアログテストのモック基盤を共通ヘルパーに抽出する (#671)

### DIFF
--- a/app/(authenticated)/circles/components/circle-delete-button.test.tsx
+++ b/app/(authenticated)/circles/components/circle-delete-button.test.tsx
@@ -2,38 +2,33 @@
 import { cleanup, render, screen, within } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  type MutationBehavior,
+  makeMutationMock,
+} from "@/test-helpers/trpc-mutation-mock";
 import { CircleDeleteButton } from "./circle-delete-button";
 
 const pushMock = vi.fn();
 
-type MutationBehavior = "idle" | "success" | "error" | "pending";
 let deleteBehavior: MutationBehavior = "idle";
-let mutateSpy: ReturnType<typeof vi.fn>;
 
-function makeMutationMock(getBehavior: () => MutationBehavior) {
-  return (options?: { onSuccess?: () => void; onError?: () => void }) => {
-    const behavior = getBehavior();
-    mutateSpy = vi.fn(() => {
-      if (behavior === "success") {
-        options?.onSuccess?.();
-      } else if (behavior === "error") {
-        options?.onError?.();
-      }
-    });
-    return {
-      mutate: mutateSpy,
-      isPending: behavior === "pending",
-      data: null,
-      error: null,
-    };
-  };
-}
+const useMutationHolder = vi.hoisted(() => {
+  const noop = (): unknown => ({});
+  return { current: noop as (...args: unknown[]) => unknown };
+});
+
+const { useMutation, mutateSpyRef } = makeMutationMock(
+  () => deleteBehavior,
+  { hasReset: false },
+);
+useMutationHolder.current =
+  useMutation as unknown as typeof useMutationHolder.current;
 
 vi.mock("@/lib/trpc/client", () => ({
   trpc: {
     circles: {
       delete: {
-        useMutation: makeMutationMock(() => deleteBehavior),
+        useMutation: (...args: unknown[]) => useMutationHolder.current(...args),
       },
     },
   },
@@ -149,7 +144,7 @@ describe("CircleDeleteButton", () => {
     });
     await user.click(deleteButton);
 
-    expect(mutateSpy).toHaveBeenCalledWith({ circleId: "circle-1" });
+    expect(mutateSpyRef.current).toHaveBeenCalledWith({ circleId: "circle-1" });
     expect(pushMock).toHaveBeenCalledWith("/");
   });
 

--- a/app/(authenticated)/circles/components/circle-rename-dialog.test.tsx
+++ b/app/(authenticated)/circles/components/circle-rename-dialog.test.tsx
@@ -2,41 +2,33 @@
 import { cleanup, render, screen, within } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { afterEach, describe, expect, it, vi } from "vitest";
+import {
+  type MutationBehavior,
+  makeMutationMock,
+} from "@/test-helpers/trpc-mutation-mock";
 import { CircleRenameDialog } from "./circle-rename-dialog";
 
 const refreshMock = vi.fn();
 
-type MutationBehavior = "idle" | "success" | "error" | "pending";
 let renameBehavior: MutationBehavior = "idle";
-let mutateSpy: ReturnType<typeof vi.fn>;
-const resetSpy = vi.fn();
 
-function makeMutationMock(getBehavior: () => MutationBehavior) {
-  return (options?: { onSuccess?: () => void }) => {
-    const behavior = getBehavior();
-    mutateSpy = vi.fn(() => {
-      if (behavior === "success") {
-        options?.onSuccess?.();
-      }
-    });
-    return {
-      mutate: mutateSpy,
-      reset: resetSpy,
-      isPending: behavior === "pending",
-      data: null,
-      error:
-        behavior === "error"
-          ? { message: "変更に失敗しました" }
-          : null,
-    };
-  };
-}
+const useMutationHolder = vi.hoisted(() => {
+  const noop = (): unknown => ({});
+  return { current: noop as (...args: unknown[]) => unknown };
+});
+
+const { useMutation, mutateSpyRef, resetSpy } = makeMutationMock(
+  () => renameBehavior,
+  { errorMessage: "変更に失敗しました" },
+);
+useMutationHolder.current =
+  useMutation as unknown as typeof useMutationHolder.current;
 
 vi.mock("@/lib/trpc/client", () => ({
   trpc: {
     circles: {
       rename: {
-        useMutation: makeMutationMock(() => renameBehavior),
+        useMutation: (...args: unknown[]) => useMutationHolder.current(...args),
       },
     },
   },
@@ -55,6 +47,7 @@ afterEach(() => {
   cleanup();
   refreshMock.mockClear();
   resetSpy.mockClear();
+  mutateSpyRef.current.mockClear();
   renameBehavior = "idle";
 });
 
@@ -105,7 +98,7 @@ describe("CircleRenameDialog", () => {
     const submitButton = within(dialog).getByRole("button", { name: "変更" });
     await user.click(submitButton);
 
-    expect(mutateSpy).toHaveBeenCalledWith({
+    expect(mutateSpyRef.current).toHaveBeenCalledWith({
       circleId: CIRCLE_ID,
       name: "新しい名前",
     });
@@ -193,7 +186,7 @@ describe("CircleRenameDialog", () => {
     const submitButton = within(dialog).getByRole("button", { name: "変更" });
     await user.click(submitButton);
 
-    expect(mutateSpy).not.toHaveBeenCalled();
+    expect(mutateSpyRef.current).not.toHaveBeenCalled();
   });
 
   it("前後の空白を除去して mutate が呼ばれる", async () => {
@@ -206,7 +199,7 @@ describe("CircleRenameDialog", () => {
     const submitButton = within(dialog).getByRole("button", { name: "変更" });
     await user.click(submitButton);
 
-    expect(mutateSpy).toHaveBeenCalledWith({
+    expect(mutateSpyRef.current).toHaveBeenCalledWith({
       circleId: CIRCLE_ID,
       name: "新しい名前",
     });

--- a/app/components/circle-create-dialog.test.tsx
+++ b/app/components/circle-create-dialog.test.tsx
@@ -2,41 +2,35 @@
 import { cleanup, render, screen, within } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { afterEach, describe, expect, it, vi } from "vitest";
+import {
+  type MutationBehavior,
+  makeMutationMock,
+} from "@/test-helpers/trpc-mutation-mock";
 import { CircleCreateDialog } from "./circle-create-dialog";
 
 const pushMock = vi.fn();
 
-type MutationBehavior = "idle" | "success" | "error" | "pending";
 let createBehavior: MutationBehavior = "idle";
-let mutateSpy: ReturnType<typeof vi.fn>;
-const resetSpy = vi.fn();
 
-function makeMutationMock(getBehavior: () => MutationBehavior) {
-  return (options?: { onSuccess?: (data: { id: string }) => void }) => {
-    const behavior = getBehavior();
-    mutateSpy = vi.fn(() => {
-      if (behavior === "success") {
-        options?.onSuccess?.({ id: "new-circle-id" });
-      }
-    });
-    return {
-      mutate: mutateSpy,
-      reset: resetSpy,
-      isPending: behavior === "pending",
-      data: null,
-      error:
-        behavior === "error"
-          ? { message: "作成に失敗しました" }
-          : null,
-    };
-  };
-}
+const useMutationHolder = vi.hoisted(() => {
+  const noop = (): unknown => ({});
+  return { current: noop as (...args: unknown[]) => unknown };
+});
+
+const { useMutation, mutateSpyRef, resetSpy } = makeMutationMock<{
+  id: string;
+}>(() => createBehavior, {
+  errorMessage: "作成に失敗しました",
+  successData: { id: "new-circle-id" },
+});
+useMutationHolder.current =
+  useMutation as unknown as typeof useMutationHolder.current;
 
 vi.mock("@/lib/trpc/client", () => ({
   trpc: {
     circles: {
       create: {
-        useMutation: makeMutationMock(() => createBehavior),
+        useMutation: (...args: unknown[]) => useMutationHolder.current(...args),
       },
     },
   },
@@ -55,6 +49,7 @@ afterEach(() => {
   cleanup();
   pushMock.mockClear();
   resetSpy.mockClear();
+  mutateSpyRef.current.mockClear();
   createBehavior = "idle";
 });
 
@@ -74,7 +69,7 @@ describe("CircleCreateDialog", () => {
     const submitButton = within(dialog).getByRole("button", { name: "作成" });
     await user.click(submitButton);
 
-    expect(mutateSpy).not.toHaveBeenCalled();
+    expect(mutateSpyRef.current).not.toHaveBeenCalled();
   });
 
   it("有効な名前入力後に送信すると mutate が呼ばれる", async () => {
@@ -86,7 +81,7 @@ describe("CircleCreateDialog", () => {
     const submitButton = within(dialog).getByRole("button", { name: "作成" });
     await user.click(submitButton);
 
-    expect(mutateSpy).toHaveBeenCalledWith({ name: "新しい研究会" });
+    expect(mutateSpyRef.current).toHaveBeenCalledWith({ name: "新しい研究会" });
   });
 
   it("成功時に router.push が呼ばれダイアログが閉じる", async () => {
@@ -166,7 +161,7 @@ describe("CircleCreateDialog", () => {
     const submitButton = within(dialog).getByRole("button", { name: "作成" });
     await user.click(submitButton);
 
-    expect(mutateSpy).not.toHaveBeenCalled();
+    expect(mutateSpyRef.current).not.toHaveBeenCalled();
   });
 
   it("前後の空白を除去して mutate が呼ばれる", async () => {
@@ -178,7 +173,7 @@ describe("CircleCreateDialog", () => {
     const submitButton = within(dialog).getByRole("button", { name: "作成" });
     await user.click(submitButton);
 
-    expect(mutateSpy).toHaveBeenCalledWith({ name: "新しい研究会" });
+    expect(mutateSpyRef.current).toHaveBeenCalledWith({ name: "新しい研究会" });
   });
 
   it("80%（40文字）以上で aria-live='polite' が有効化される", async () => {

--- a/test-helpers/trpc-mutation-mock.ts
+++ b/test-helpers/trpc-mutation-mock.ts
@@ -1,0 +1,47 @@
+import { vi } from "vitest";
+
+export type MutationBehavior = "idle" | "success" | "error" | "pending";
+
+type MakeMutationMockOptions = {
+  errorMessage?: string | null;
+  hasReset?: boolean;
+  successData?: unknown;
+};
+
+export function makeMutationMock<TData = void>(
+  getBehavior: () => MutationBehavior,
+  options?: MakeMutationMockOptions,
+) {
+  const errorMessage = options?.errorMessage ?? null;
+  const hasReset = options?.hasReset ?? true;
+  const successData = options?.successData;
+
+  const mutateSpyRef = { current: vi.fn() };
+  const resetSpy = vi.fn();
+
+  const useMutation = (mutationOptions?: {
+    onSuccess?: (data: TData) => void;
+    onError?: () => void;
+  }) => {
+    const behavior = getBehavior();
+    mutateSpyRef.current = vi.fn(() => {
+      if (behavior === "success") {
+        mutationOptions?.onSuccess?.(successData as TData);
+      } else if (behavior === "error") {
+        mutationOptions?.onError?.();
+      }
+    });
+    return {
+      mutate: mutateSpyRef.current,
+      ...(hasReset ? { reset: resetSpy } : {}),
+      isPending: behavior === "pending",
+      data: null,
+      error:
+        behavior === "error" && errorMessage != null
+          ? { message: errorMessage }
+          : null,
+    };
+  };
+
+  return { useMutation, mutateSpyRef, resetSpy };
+}


### PR DESCRIPTION
## Summary

- `MutationBehavior` 型と `makeMutationMock` ファクトリ関数を `test-helpers/trpc-mutation-mock.ts` に抽出
- 3つのテストファイル（circle-create-dialog, circle-rename-dialog, circle-delete-button）から重複コード（各 ~20行）を削除
- 各テストファイルは共通ヘルパーからインポートし、オプションで挙動を制御

Closes #671

## Test plan

- [x] `npx tsc --noEmit` — 型エラーなし
- [x] `npm run lint` — エラー・警告なし
- [x] `npm run test:run` — 66ファイル 797テスト全 PASS
- [ ] 各テストファイルがローカル定義を持たず `@/test-helpers/trpc-mutation-mock` からインポートしていること

🤖 Generated with [Claude Code](https://claude.com/claude-code)