### PR TITLE
refactor: 文字数カウンターを共通コンポーネントとして抽出する (#668)

### DIFF
--- a/app/(authenticated)/circles/components/circle-rename-dialog.tsx
+++ b/app/(authenticated)/circles/components/circle-rename-dialog.tsx
@@ -12,6 +12,7 @@ import {
 } from "@/components/ui/dialog";
 import { Input } from "@/components/ui/input";
 import { trpc } from "@/lib/trpc/client";
+import { CharacterCounter } from "@/app/components/character-counter";
 import { CIRCLE_NAME_MAX_LENGTH } from "@/server/domain/models/circle/circle";
 import { Pencil } from "lucide-react";
 import { useRouter } from "next/navigation";
@@ -94,21 +95,11 @@ export function CircleRenameDialog({
             aria-required="true"
             className="mt-2 bg-white"
           />
-          <p
-            className={`mt-1 text-right text-xs ${
-              name.length >= CIRCLE_NAME_MAX_LENGTH
-                ? "text-destructive"
-                : name.length >= CIRCLE_NAME_MAX_LENGTH * 0.8
-                  ? "text-amber-600"
-                  : "text-(--brand-ink-muted)"
-            }`}
-            aria-live={
-              name.length >= CIRCLE_NAME_MAX_LENGTH * 0.8 ? "polite" : "off"
-            }
-            aria-label="研究会名の文字数"
-          >
-            {name.length} / {CIRCLE_NAME_MAX_LENGTH}
-          </p>
+          <CharacterCounter
+            count={name.length}
+            max={CIRCLE_NAME_MAX_LENGTH}
+            label="研究会名の文字数"
+          />
           {renameCircle.error ? (
             <p role="alert" className="mt-2 text-xs text-red-600">
               {renameCircle.error.message}

--- a/app/components/character-counter.tsx
+++ b/app/components/character-counter.tsx
@@ -1,0 +1,25 @@
+type CharacterCounterProps = {
+  count: number;
+  max: number;
+  label: string;
+};
+
+export function CharacterCounter({ count, max, label }: CharacterCounterProps) {
+  const ratio = count / max;
+
+  return (
+    <p
+      className={`mt-1 text-right text-xs ${
+        count >= max
+          ? "text-destructive"
+          : ratio >= 0.8
+            ? "text-amber-600"
+            : "text-(--brand-ink-muted)"
+      }`}
+      aria-live={ratio >= 0.8 ? "polite" : "off"}
+      aria-label={label}
+    >
+      {count} / {max}
+    </p>
+  );
+}

--- a/app/components/circle-create-dialog.tsx
+++ b/app/components/circle-create-dialog.tsx
@@ -14,6 +14,7 @@ import { Input } from "@/components/ui/input";
 import { trpc } from "@/lib/trpc/client";
 import { CIRCLE_NAME_MAX_LENGTH } from "@/server/domain/models/circle/circle";
 import { CirclePlus } from "lucide-react";
+import { CharacterCounter } from "./character-counter";
 import { useRouter } from "next/navigation";
 import type { FormEvent } from "react";
 import { useState } from "react";
@@ -93,21 +94,11 @@ export function CircleCreateDialog() {
             aria-required="true"
             className="mt-2 bg-white"
           />
-          <p
-            className={`mt-1 text-right text-xs ${
-              name.length >= CIRCLE_NAME_MAX_LENGTH
-                ? "text-destructive"
-                : name.length >= CIRCLE_NAME_MAX_LENGTH * 0.8
-                  ? "text-amber-600"
-                  : "text-(--brand-ink-muted)"
-            }`}
-            aria-live={
-              name.length >= CIRCLE_NAME_MAX_LENGTH * 0.8 ? "polite" : "off"
-            }
-            aria-label="研究会名の文字数"
-          >
-            {name.length} / {CIRCLE_NAME_MAX_LENGTH}
-          </p>
+          <CharacterCounter
+            count={name.length}
+            max={CIRCLE_NAME_MAX_LENGTH}
+            label="研究会名の文字数"
+          />
           {createCircle.error ? (
             <p role="alert" className="mt-2 text-xs text-red-600">
               {createCircle.error.message}


### PR DESCRIPTION
## Summary

- `circle-create-dialog` と `circle-rename-dialog` で重複していた文字数カウンター UI を `CharacterCounter` コンポーネントに抽出
- 3段階カラー（通常→警告→エラー）、`aria-live`、`aria-label` のロジックを共通化
- 既存の動作・テスト（22テスト）に変更なし

Closes #668

## Test plan

- [ ] `npm run test:run` — 関連テスト 22件 ALL PASSED
- [ ] `npx tsc --noEmit` — 型エラーなし
- [ ] `npx eslint` — 変更3ファイル違反なし
- [ ] 研究会作成ダイアログで文字数カウンターの表示・色変化を確認
- [ ] 研究会名変更ダイアログで文字数カウンターの表示・色変化を確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)