### PR TITLE
test: 研究会作成ダイアログの文字数カウンター閾値ロジックにテストを追加する (#666)

### DIFF
--- a/app/components/character-counter.test.tsx
+++ b/app/components/character-counter.test.tsx
@@ -1,0 +1,70 @@
+// @vitest-environment jsdom
+import { cleanup, render, screen } from "@testing-library/react";
+import { afterEach, describe, expect, it } from "vitest";
+import { CharacterCounter } from "./character-counter";
+
+afterEach(cleanup);
+
+describe("CharacterCounter", () => {
+  describe("カラー遷移", () => {
+    it("ratio < 0.8 → muted カラー", () => {
+      render(<CharacterCounter count={39} max={50} label="文字数" />);
+      const counter = screen.getByLabelText("文字数");
+      expect(counter).toHaveClass("text-(--brand-ink-muted)");
+    });
+
+    it("ratio = 0.8 → amber カラー", () => {
+      render(<CharacterCounter count={40} max={50} label="文字数" />);
+      const counter = screen.getByLabelText("文字数");
+      expect(counter).toHaveClass("text-amber-600");
+    });
+
+    it("count < max かつ ratio > 0.8 → amber カラー", () => {
+      render(<CharacterCounter count={49} max={50} label="文字数" />);
+      const counter = screen.getByLabelText("文字数");
+      expect(counter).toHaveClass("text-amber-600");
+    });
+
+    it("count = max → destructive カラー", () => {
+      render(<CharacterCounter count={50} max={50} label="文字数" />);
+      const counter = screen.getByLabelText("文字数");
+      expect(counter).toHaveClass("text-destructive");
+    });
+
+    it("count > max → destructive カラー", () => {
+      render(<CharacterCounter count={51} max={50} label="文字数" />);
+      const counter = screen.getByLabelText("文字数");
+      expect(counter).toHaveClass("text-destructive");
+    });
+  });
+
+  describe("aria-live", () => {
+    it("ratio < 0.8 → off", () => {
+      render(<CharacterCounter count={39} max={50} label="文字数" />);
+      expect(screen.getByLabelText("文字数")).toHaveAttribute(
+        "aria-live",
+        "off",
+      );
+    });
+
+    it("ratio >= 0.8 → polite", () => {
+      render(<CharacterCounter count={40} max={50} label="文字数" />);
+      expect(screen.getByLabelText("文字数")).toHaveAttribute(
+        "aria-live",
+        "polite",
+      );
+    });
+  });
+
+  it("表示形式が {count} / {max}", () => {
+    render(<CharacterCounter count={10} max={50} label="文字数" />);
+    expect(screen.getByLabelText("文字数")).toHaveTextContent("10 / 50");
+  });
+
+  it("aria-label が設定される", () => {
+    render(<CharacterCounter count={0} max={50} label="研究会名の文字数" />);
+    expect(
+      screen.getByLabelText("研究会名の文字数"),
+    ).toBeInTheDocument();
+  });
+});

--- a/app/components/circle-create-dialog.test.tsx
+++ b/app/components/circle-create-dialog.test.tsx
@@ -188,4 +188,58 @@ describe("CircleCreateDialog", () => {
 
     expect(counter).toHaveAttribute("aria-live", "polite");
   });
+
+  describe("文字数カウンターのカラー遷移", () => {
+    it("0文字 → muted カラー", async () => {
+      const { dialog } = await openDialog();
+
+      const counter = within(dialog).getByLabelText("研究会名の文字数");
+      expect(counter).toHaveClass("text-(--brand-ink-muted)");
+      expect(counter).toHaveAttribute("aria-live", "off");
+    });
+
+    it("39文字 → muted カラー（amber 閾値の直前）", async () => {
+      const { user, dialog } = await openDialog();
+
+      const input = within(dialog).getByPlaceholderText("研究会名");
+      await user.type(input, "あ".repeat(39));
+
+      const counter = within(dialog).getByLabelText("研究会名の文字数");
+      expect(counter).toHaveClass("text-(--brand-ink-muted)");
+      expect(counter).toHaveAttribute("aria-live", "off");
+    });
+
+    it("40文字 → amber カラー（80% 閾値境界）", async () => {
+      const { user, dialog } = await openDialog();
+
+      const input = within(dialog).getByPlaceholderText("研究会名");
+      await user.type(input, "あ".repeat(40));
+
+      const counter = within(dialog).getByLabelText("研究会名の文字数");
+      expect(counter).toHaveClass("text-amber-600");
+      expect(counter).toHaveAttribute("aria-live", "polite");
+    });
+
+    it("49文字 → amber カラー（destructive 直前）", async () => {
+      const { user, dialog } = await openDialog();
+
+      const input = within(dialog).getByPlaceholderText("研究会名");
+      await user.type(input, "あ".repeat(49));
+
+      const counter = within(dialog).getByLabelText("研究会名の文字数");
+      expect(counter).toHaveClass("text-amber-600");
+      expect(counter).toHaveAttribute("aria-live", "polite");
+    });
+
+    it("50文字 → destructive カラー（上限境界）", async () => {
+      const { user, dialog } = await openDialog();
+
+      const input = within(dialog).getByPlaceholderText("研究会名");
+      await user.type(input, "あ".repeat(50));
+
+      const counter = within(dialog).getByLabelText("研究会名の文字数");
+      expect(counter).toHaveClass("text-destructive");
+      expect(counter).toHaveAttribute("aria-live", "polite");
+    });
+  });
 });


### PR DESCRIPTION
## Summary

Closes #666

- 研究会作成ダイアログの文字数カウンターにおける3段階カラー遷移（muted / amber / destructive）の境界値テスト5件を追加
- `CharacterCounter` 共通コンポーネントの単体テスト9件を新規作成（カラー遷移、aria-live、表示形式、aria-label）

## Test plan

- [ ] `npm run test:run -- app/components/circle-create-dialog.test.tsx` — 全15件パス
- [ ] `npm run test:run -- app/components/character-counter.test.tsx` — 全9件パス
- [ ] `npx tsc --noEmit` — 型エラーなし

## 変更ファイル

| ファイル | 変更内容 |
|---|---|
| `app/components/circle-create-dialog.test.tsx` | 境界値テスト5件追加（0, 39, 40, 49, 50文字） |
| `app/components/character-counter.test.tsx` | 新規: 共通コンポーネントの単体テスト9件 |

🤖 Generated with [Claude Code](https://claude.com/claude-code)