### PR TITLE
fix: OAuth name 切り詰めで Unicode サロゲートペア分割を防止する (#663)

### DIFF
--- a/server/infrastructure/auth/nextauth-handler.test.ts
+++ b/server/infrastructure/auth/nextauth-handler.test.ts
@@ -208,6 +208,23 @@ describe("Google プロバイダの profile コールバック", () => {
     expect(result.name!.length).toBe(USER_NAME_MAX_LENGTH);
   });
 
+  test("サロゲートペアを含む50文字超の name を切り詰めてもサロゲートペアが分割されない", () => {
+    const profile = extractGoogleProfile();
+    // 49文字のASCII + 2文字の絵文字（各サロゲートペア）= 51コードポイント
+    const nameWithEmoji = "a".repeat(49) + "🍣🍺";
+
+    const result = profile({
+      sub: "google-sp",
+      name: nameWithEmoji,
+      email: "user@example.com",
+      picture: "https://example.com/photo.jpg",
+    });
+
+    expect(result.name).toBe("a".repeat(49) + "🍣");
+    expect(result.name!.length).toBe(USER_NAME_MAX_LENGTH + 1); // サロゲートペアは length 2
+    expect([...result.name!].length).toBe(USER_NAME_MAX_LENGTH); // コードポイント数は50
+  });
+
   test("必須フィールド（id, email, name, image）をすべて返す", () => {
     const profile = extractGoogleProfile();
 

--- a/server/infrastructure/auth/nextauth-handler.ts
+++ b/server/infrastructure/auth/nextauth-handler.ts
@@ -91,7 +91,10 @@ export const createAuthOptions = (deps: AuthDeps): AuthOptions => ({
       profile(profile) {
         return {
           id: profile.sub,
-          name: profile.name?.slice(0, USER_NAME_MAX_LENGTH) ?? null,
+          name:
+            profile.name != null
+              ? [...profile.name].slice(0, USER_NAME_MAX_LENGTH).join("")
+              : null,
           email: profile.email,
           image: profile.picture,
         };


### PR DESCRIPTION
## Summary

- Google OAuth の `profile()` コールバックで `String.prototype.slice()` を使った name 切り詰めを、スプレッド構文（`[...str]`）によるコードポイント単位の切り詰めに変更
- サロゲートペア境界でのテストケースを追加（全25テスト pass）

Closes #663

## Changes

- `server/infrastructure/auth/nextauth-handler.ts`: `slice()` → `[...str].slice().join("")` に変更（1行）
- `server/infrastructure/auth/nextauth-handler.test.ts`: サロゲートペア保全テストを追加

## Test plan

- [x] 既存テスト24件が pass すること
- [x] 新規テスト（サロゲートペアを含む51コードポイントの name が50コードポイントに切り詰められ、サロゲートペアが分割されないこと）が pass すること
- [x] `npm run test:run -- server/infrastructure/auth/nextauth-handler.test.ts` で全25テスト pass 確認済み

## Follow-up

- #676: `USER_NAME_MAX_LENGTH` の長さカウントを Zod バリデーション側もコードポイント単位に統一する

🤖 Generated with [Claude Code](https://claude.com/claude-code)