### PR TITLE
feat: NextAuth の signOut・error に custom pages を設定して CSP 保護を確保する

### DIFF
--- a/app/auth/error/page.tsx
+++ b/app/auth/error/page.tsx
@@ -1,0 +1,41 @@
+import Link from "next/link";
+import { Button } from "@/components/ui/button";
+
+const errorMessages: Record<string, string> = {
+  Configuration: "サーバーの設定に問題があります。管理者にお問い合わせください。",
+  AccessDenied: "アクセスが拒否されました。",
+  Verification: "認証リンクの有効期限が切れたか、既に使用されています。",
+  OAuthAccountNotLinked:
+    "このメールアドレスは別のログイン方法で登録されています。元のログイン方法でサインインしてください。",
+  Default: "認証中にエラーが発生しました。",
+};
+
+export default async function AuthErrorPage(props: {
+  searchParams: Promise<{ error?: string }>;
+}) {
+  const searchParams = await props.searchParams;
+  const errorType = searchParams.error ?? "Default";
+  const message = Object.hasOwn(errorMessages, errorType)
+    ? errorMessages[errorType]
+    : errorMessages.Default;
+
+  return (
+    <main className="flex min-h-svh flex-col items-center justify-center px-6">
+      <div className="max-w-md space-y-6 text-center">
+        <h1 className="text-4xl font-bold text-(--brand-moss)">エラー</h1>
+        <h2 className="text-2xl font-(--font-display) text-(--brand-ink)">
+          認証エラー
+        </h2>
+        <p className="text-sm leading-relaxed text-(--brand-ink-muted)">
+          {message}
+        </p>
+        <Button
+          asChild
+          className="bg-(--brand-moss) hover:bg-(--brand-moss)/90"
+        >
+          <Link href="/">ホームに戻る</Link>
+        </Button>
+      </div>
+    </main>
+  );
+}

--- a/app/signout/page.tsx
+++ b/app/signout/page.tsx
@@ -1,0 +1,55 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import Link from "next/link";
+import { getCsrfToken } from "next-auth/react";
+import { Button } from "@/components/ui/button";
+
+export default function SignOutPage() {
+  const [csrfToken, setCsrfToken] = useState<string>();
+  const [tokenError, setTokenError] = useState(false);
+
+  useEffect(() => {
+    getCsrfToken()
+      .then((token) => setCsrfToken(token ?? undefined))
+      .catch(() => setTokenError(true));
+  }, []);
+
+  return (
+    <main className="flex min-h-svh flex-col items-center justify-center px-6">
+      <div className="max-w-md space-y-6 text-center">
+        <h1 className="text-4xl font-bold text-(--brand-moss)">ログアウト</h1>
+        <h2 className="text-2xl font-(--font-display) text-(--brand-ink)">
+          ログアウトしますか？
+        </h2>
+        {tokenError && (
+          <p className="text-sm text-red-600">
+            トークンの取得に失敗しました。ページを再読み込みしてください。
+          </p>
+        )}
+        <form method="post" action="/api/auth/signout">
+          {csrfToken && (
+            <input type="hidden" name="csrfToken" value={csrfToken} />
+          )}
+          <input type="hidden" name="callbackUrl" value="/" />
+          <div className="flex flex-col items-center gap-3">
+            <Button
+              type="submit"
+              className="w-full bg-(--brand-moss) hover:bg-(--brand-moss)/90"
+              disabled={!csrfToken}
+            >
+              ログアウト
+            </Button>
+            <Button
+              asChild
+              variant="outline"
+              className="w-full border-(--brand-moss) text-(--brand-moss)"
+            >
+              <Link href="/">キャンセル</Link>
+            </Button>
+          </div>
+        </form>
+      </div>
+    </main>
+  );
+}

--- a/server/infrastructure/auth/nextauth-handler.ts
+++ b/server/infrastructure/auth/nextauth-handler.ts
@@ -101,6 +101,15 @@ export const createAuthOptions = (deps: AuthDeps): AuthOptions => ({
       },
     }),
   ],
+  // These paths must match the corresponding App Router page files:
+  //   app/(public)/page.tsx    -> "/"
+  //   app/signout/page.tsx     -> "/signout"
+  //   app/auth/error/page.tsx  -> "/auth/error"
+  pages: {
+    signIn: "/",
+    signOut: "/signout",
+    error: "/auth/error",
+  },
   session: { strategy: "jwt" },
   debug: isDebug,
   callbacks: {


### PR DESCRIPTION
## Summary

Closes #678

- NextAuth の `pages.signOut` と `pages.error` にカスタムページを設定し、組み込み HTML ページの代わりに Next.js ページへリダイレクトさせる
- これにより middleware の CSP ヘッダーが適用され、defense-in-depth が改善される
- `/signout`: CSRF トークン付きログアウト確認 UI（エラーハンドリング付き）
- `/auth/error`: エラータイプ別メッセージ表示（許可リスト方式、`Object.hasOwn` によるプロトタイプ汚染防御）

## 変更ファイル

| ファイル | 内容 |
|---------|------|
| `server/infrastructure/auth/nextauth-handler.ts` | `pages` に `signOut`, `error` を追加 + パス対応コメント |
| `app/signout/page.tsx` | 新規: ログアウト確認ページ（Client Component） |
| `app/auth/error/page.tsx` | 新規: 認証エラーページ（Server Component） |

## 検証手順

1. **signOut ページ**: 認証済み状態で `/signout` にアクセス → ログアウト確認 UI 表示 → 「ログアウト」で `/` にリダイレクト
2. **error ページ**: `/auth/error?error=AccessDenied` にアクセス → 「アクセスが拒否されました。」表示
3. **CSP 確認**: 両ページのレスポンスに `Content-Security-Policy` ヘッダーが含まれることを確認
4. **既存フロー**: 通常のサインイン・サインアウトフローが正常動作すること

## 残課題（別 issue で対応）

- #680 auth 関連カスタムページの URL パスを `/auth/` 配下に統一する
- #681 auth カスタムページのユニットテストを追加する

🤖 Generated with [Claude Code](https://claude.com/claude-code)