### PR TITLE
test: NextAuth カスタムページのユニットテストを追加する

### DIFF
--- a/app/auth/error/page.test.tsx
+++ b/app/auth/error/page.test.tsx
@@ -1,0 +1,83 @@
+// @vitest-environment jsdom
+import { cleanup, render, screen } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import AuthErrorPage from "./page";
+
+vi.mock("next/link", () => ({
+  default: ({
+    href,
+    children,
+  }: {
+    href: string;
+    children: React.ReactNode;
+  }) => <a href={href}>{children}</a>,
+}));
+
+afterEach(() => {
+  cleanup();
+  vi.restoreAllMocks();
+});
+
+async function renderPage(searchParams: { error?: string } = {}) {
+  const jsx = await AuthErrorPage({
+    searchParams: Promise.resolve(searchParams),
+  });
+  render(jsx);
+}
+
+describe("AuthErrorPage", () => {
+  it("Configuration エラーで設定問題メッセージを表示する", async () => {
+    await renderPage({ error: "Configuration" });
+    expect(
+      screen.getByText(
+        "サーバーの設定に問題があります。管理者にお問い合わせください。",
+      ),
+    ).toBeInTheDocument();
+  });
+
+  it("AccessDenied エラーでアクセス拒否メッセージを表示する", async () => {
+    await renderPage({ error: "AccessDenied" });
+    expect(
+      screen.getByText("アクセスが拒否されました。"),
+    ).toBeInTheDocument();
+  });
+
+  it("Verification エラーで認証リンク期限切れメッセージを表示する", async () => {
+    await renderPage({ error: "Verification" });
+    expect(
+      screen.getByText(
+        "認証リンクの有効期限が切れたか、既に使用されています。",
+      ),
+    ).toBeInTheDocument();
+  });
+
+  it("OAuthAccountNotLinked エラーで別ログイン方法メッセージを表示する", async () => {
+    await renderPage({ error: "OAuthAccountNotLinked" });
+    expect(
+      screen.getByText(
+        "このメールアドレスは別のログイン方法で登録されています。元のログイン方法でサインインしてください。",
+      ),
+    ).toBeInTheDocument();
+  });
+
+  it("未知のエラータイプでデフォルトメッセージを表示する", async () => {
+    await renderPage({ error: "Unknown" });
+    expect(
+      screen.getByText("認証中にエラーが発生しました。"),
+    ).toBeInTheDocument();
+  });
+
+  it("error パラメータなしでデフォルトメッセージを表示する", async () => {
+    await renderPage();
+    expect(
+      screen.getByText("認証中にエラーが発生しました。"),
+    ).toBeInTheDocument();
+  });
+
+  it("ホームに戻るリンクが href='/' で表示される", async () => {
+    await renderPage();
+    const link = screen.getByRole("link", { name: "ホームに戻る" });
+    expect(link).toHaveAttribute("href", "/");
+  });
+});

--- a/app/signout/page.test.tsx
+++ b/app/signout/page.test.tsx
@@ -1,0 +1,97 @@
+// @vitest-environment jsdom
+import { cleanup, render, screen } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import SignOutPage from "./page";
+
+vi.mock("next/link", () => ({
+  default: ({
+    href,
+    children,
+  }: {
+    href: string;
+    children: React.ReactNode;
+  }) => <a href={href}>{children}</a>,
+}));
+
+const mockGetCsrfToken = vi.fn<() => Promise<string | undefined>>();
+vi.mock("next-auth/react", () => ({
+  getCsrfToken: (...args: unknown[]) => mockGetCsrfToken(...(args as [])),
+}));
+
+afterEach(() => {
+  cleanup();
+  vi.restoreAllMocks();
+});
+
+describe("SignOutPage", () => {
+  describe("getCsrfToken 成功時", () => {
+    it("フォームの action が /api/auth/signout である", async () => {
+      mockGetCsrfToken.mockResolvedValue("test-csrf-token");
+      render(<SignOutPage />);
+      const button = await screen.findByRole("button", { name: "ログアウト" });
+      const form = button.closest("form");
+      expect(form).toBeInTheDocument();
+      expect(form).toHaveAttribute("action", "/api/auth/signout");
+    });
+
+    it("callbackUrl hidden input の value が '/' である", async () => {
+      mockGetCsrfToken.mockResolvedValue("test-csrf-token");
+      render(<SignOutPage />);
+      const button = await screen.findByRole("button", { name: "ログアウト" });
+      const form = button.closest("form");
+      expect(form).toBeInTheDocument();
+      const callbackInput = form!.querySelector('input[name="callbackUrl"]');
+      expect(callbackInput).toBeInTheDocument();
+      expect(callbackInput).toHaveValue("/");
+    });
+
+    it("csrfToken hidden input がフォーム内に存在する", async () => {
+      mockGetCsrfToken.mockResolvedValue("test-csrf-token");
+      render(<SignOutPage />);
+      const button = await screen.findByRole("button", { name: "ログアウト" });
+      const form = button.closest("form");
+      expect(form).toBeInTheDocument();
+      const csrfInput = form!.querySelector('input[name="csrfToken"]');
+      expect(csrfInput).toBeInTheDocument();
+      expect(csrfInput).toHaveValue("test-csrf-token");
+    });
+
+    it("ログアウトボタンが有効である", async () => {
+      mockGetCsrfToken.mockResolvedValue("test-csrf-token");
+      render(<SignOutPage />);
+      const button = await screen.findByRole("button", { name: "ログアウト" });
+      expect(button).toBeEnabled();
+    });
+  });
+
+  describe("getCsrfToken エラー時", () => {
+    it("エラーメッセージを表示する", async () => {
+      mockGetCsrfToken.mockRejectedValue(new Error("fetch failed"));
+      render(<SignOutPage />);
+      expect(
+        await screen.findByText(
+          "トークンの取得に失敗しました。ページを再読み込みしてください。",
+        ),
+      ).toBeInTheDocument();
+    });
+
+    it("ログアウトボタンが disabled である", async () => {
+      mockGetCsrfToken.mockRejectedValue(new Error("fetch failed"));
+      render(<SignOutPage />);
+      await screen.findByText(
+        "トークンの取得に失敗しました。ページを再読み込みしてください。",
+      );
+      expect(
+        screen.getByRole("button", { name: "ログアウト" }),
+      ).toBeDisabled();
+    });
+  });
+
+  it("キャンセルリンクが href='/' で表示される", async () => {
+    mockGetCsrfToken.mockResolvedValue("test-csrf-token");
+    render(<SignOutPage />);
+    const link = screen.getByRole("link", { name: "キャンセル" });
+    expect(link).toHaveAttribute("href", "/");
+  });
+});


### PR DESCRIPTION
## Summary

Closes #681

- NextAuth カスタムページ（error, signout）のユニットテストを追加
- error ページ: 全エラータイプ（Configuration, AccessDenied, Verification, OAuthAccountNotLinked）・デフォルトメッセージ・ホームリンクの検証（7テスト）
- signout ページ: フォーム設定・CSRF トークン・エラーハンドリングの検証（7テスト）
- verify フェーズで検出した問題（非null アサーション、冗長クエリ、afterEach 不一致）を修正済み

## Test plan

- [ ] `npm run test:run -- app/auth/error/page.test.tsx app/signout/page.test.tsx` → 14/14 pass
- [ ] `npx tsc --noEmit` → clean

## Follow-up

- #683: signout ページテストに getCsrfToken が undefined を返す場合のテストケースを追加する

🤖 Generated with [Claude Code](https://claude.com/claude-code)