### PR TITLE
fix(security): signIn() callbackUrl を事前サニタイズする

### DIFF
--- a/app/components/credentials-login-form.tsx
+++ b/app/components/credentials-login-form.tsx
@@ -33,7 +33,7 @@ export default function CredentialsLoginForm({
         email,
         password,
         redirect: false,
-        callbackUrl: callbackUrl ?? "/home",
+        callbackUrl: sanitizeCallbackUrl(callbackUrl),
       });
       if (!result || result.error) {
         try {

--- a/app/components/login-button.tsx
+++ b/app/components/login-button.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { Button } from "@/components/ui/button";
+import { sanitizeCallbackUrl } from "@/lib/url";
 import { signIn } from "next-auth/react";
 
 type LoginButtonProps = {
@@ -17,7 +18,7 @@ export default function LoginButton({
   return (
     <Button
       className={className}
-      onClick={() => signIn("google", { callbackUrl: callbackUrl ?? "/home" })}
+      onClick={() => signIn("google", { callbackUrl: sanitizeCallbackUrl(callbackUrl) })}
     >
       {label ?? "Googleでログイン"}
     </Button>

--- a/app/components/signup-form.tsx
+++ b/app/components/signup-form.tsx
@@ -65,7 +65,7 @@ export default function SignupForm({ callbackUrl }: SignupFormProps) {
         email,
         password,
         redirect: false,
-        callbackUrl: callbackUrl ?? "/home",
+        callbackUrl: sanitizeCallbackUrl(callbackUrl),
       });
 
       if (!result || result.error) {


### PR DESCRIPTION
## Summary

- `credentials-login-form.tsx`, `signup-form.tsx`, `login-button.tsx` の3コンポーネントで `signIn()` に渡す `callbackUrl` を `sanitizeCallbackUrl()` でラップ
- Open Redirect に対する defense-in-depth（多層防御）を強化
- `callbackUrl ?? "/home"` → `sanitizeCallbackUrl(callbackUrl)` への置換（`sanitizeCallbackUrl(undefined)` は `"/home"` を返すため既存動作と同等）

Closes #242

## Verification

### 自動検証

| Check | Result |
|---|---|
| `npx tsc --noEmit` | Pass |
| `npm run lint` | Pass |
| `npm run test:run -- lib/url.test.ts` | Pass (13 tests) |

### 手動検証手順

1. `npm run dev` で開発サーバーを起動
2. `/auth/login?callbackUrl=/circles` → ログイン後 `/circles` にリダイレクト
3. `/auth/login` → ログイン後 `/home` にリダイレクト
4. `/auth/login?callbackUrl=https://evil.com` → ログイン後 `/home` にリダイレクト（外部URLブロック）
5. Google OAuth: `/auth/login` で「Google でログイン」→ 正常にリダイレクト
6. `/auth/signup` で新規登録 → `/home` にリダイレクト

## Follow-up Issues

- #687 — sanitizeCallbackUrl のハードニング: パストラバーサルとバックスラッシュの拒否
- #688 — 本番環境での NEXTAUTH_URL 未設定チェックの追加

🤖 Generated with [Claude Code](https://claude.ai/claude-code)