### PR TITLE
fix(validation): 対局の同一プレイヤー選択を DTO 層で拒否する (#141)

### DIFF
--- a/server/presentation/dto/match.test.ts
+++ b/server/presentation/dto/match.test.ts
@@ -1,0 +1,86 @@
+import { describe, expect, test } from "vitest";
+import {
+  matchCreateInputSchema,
+  matchUpdateInputSchema,
+} from "@/server/presentation/dto/match";
+
+describe("matchCreateInputSchema", () => {
+  const validBase = {
+    circleSessionId: "session-1",
+    player1Id: "user-1",
+    player2Id: "user-2",
+    outcome: "P1_WIN" as const,
+  };
+
+  test("異なるプレイヤーIDでパースが成功する", () => {
+    const result = matchCreateInputSchema.safeParse(validBase);
+    expect(result.success).toBe(true);
+  });
+
+  test("同一プレイヤーIDはバリデーションエラーになる", () => {
+    const result = matchCreateInputSchema.safeParse({
+      ...validBase,
+      player1Id: "user-1",
+      player2Id: "user-1",
+    });
+    expect(result.success).toBe(false);
+    if (!result.success) {
+      expect(result.error.issues[0].message).toBe(
+        "player1Id and player2Id must be different",
+      );
+      expect(result.error.issues[0].path).toContain("player2Id");
+    }
+  });
+});
+
+describe("matchUpdateInputSchema", () => {
+  const updateBase = {
+    matchId: "match-1",
+  };
+
+  test("両方のプレイヤーIDが異なる場合はパースが成功する", () => {
+    const result = matchUpdateInputSchema.safeParse({
+      ...updateBase,
+      player1Id: "user-1",
+      player2Id: "user-2",
+    });
+    expect(result.success).toBe(true);
+  });
+
+  test("両方のプレイヤーIDが同一の場合はバリデーションエラーになる", () => {
+    const result = matchUpdateInputSchema.safeParse({
+      ...updateBase,
+      player1Id: "user-1",
+      player2Id: "user-1",
+    });
+    expect(result.success).toBe(false);
+    if (!result.success) {
+      const samePlayerIssue = result.error.issues.find(
+        (i) => i.message === "player1Id and player2Id must be different",
+      );
+      expect(samePlayerIssue).toBeDefined();
+      expect(samePlayerIssue!.path).toContain("player2Id");
+    }
+  });
+
+  test("プレイヤーIDが両方未指定の場合はパースが成功する", () => {
+    const result = matchUpdateInputSchema.safeParse(updateBase);
+    expect(result.success).toBe(true);
+  });
+
+  test("player1Idのみ指定はバリデーションエラーになる", () => {
+    const result = matchUpdateInputSchema.safeParse({
+      ...updateBase,
+      player1Id: "user-1",
+    });
+    expect(result.success).toBe(false);
+  });
+
+  test("player2Idのみ指定はバリデーションエラーになる", () => {
+    const result = matchUpdateInputSchema.safeParse({
+      ...updateBase,
+      player2Id: "user-2",
+    });
+    expect(result.success).toBe(false);
+  });
+});

--- a/server/presentation/dto/match.ts
+++ b/server/presentation/dto/match.ts
@@ -33,12 +33,17 @@ export const matchListInputSchema = z.object({
 
 export type MatchListInput = z.infer<typeof matchListInputSchema>;
 
-export const matchCreateInputSchema = z.object({
-  circleSessionId: circleSessionIdSchema,
-  player1Id: userIdSchema,
-  player2Id: userIdSchema,
-  outcome: matchOutcomeSchema.optional(),
-});
+export const matchCreateInputSchema = z
+  .object({
+    circleSessionId: circleSessionIdSchema,
+    player1Id: userIdSchema,
+    player2Id: userIdSchema,
+    outcome: matchOutcomeSchema.optional(),
+  })
+  .refine((v) => v.player1Id !== v.player2Id, {
+    message: "player1Id and player2Id must be different",
+    path: ["player2Id"],
+  });
 
 export type MatchCreateInput = z.infer<typeof matchCreateInputSchema>;
 
@@ -56,6 +61,13 @@ export const matchUpdateInputSchema = z
     {
       message: "player1Id and player2Id must both be provided",
       path: ["player1Id"],
+    },
+  )
+  .refine(
+    (v) => !v.player1Id || !v.player2Id || v.player1Id !== v.player2Id,
+    {
+      message: "player1Id and player2Id must be different",
+      path: ["player2Id"],
     },
   );
 

--- a/server/presentation/trpc/routers/match.test.ts
+++ b/server/presentation/trpc/routers/match.test.ts
@@ -261,11 +261,8 @@ describe("match tRPC ルーター", () => {
       ).rejects.toMatchObject({ code: "FORBIDDEN" });
     });
 
-    test("BadRequestError（プレイヤー不正）→ BAD_REQUEST", async () => {
-      const { context, mocks } = createTestContext();
-      mocks.matchService.recordMatch.mockRejectedValueOnce(
-        new BadRequestError("Players must be different"),
-      );
+    test("同一プレイヤーID → BAD_REQUEST（Zodバリデーション）", async () => {
+      const { context } = createTestContext();
 
       const caller = appRouter.createCaller(context);
 


### PR DESCRIPTION
## Summary

- `matchCreateInputSchema` / `matchUpdateInputSchema` に Zod `.refine()` を追加し、`player1Id === player2Id` をバリデーション層で拒否する
- DTO 層テスト（`match.test.ts`）を新規追加し、create/update の全入力パターンを網羅
- ルーターテストを Zod バリデーション経由の `BAD_REQUEST` テストに更新

Closes #141

## Verification

```bash
npm run test:run -- server/presentation/dto/match.test.ts server/presentation/trpc/routers/match.test.ts
# 29 tests passed (7 DTO + 22 router)

npx tsc --noEmit
# エラーなし
```

## Known limitation

部分更新で片方の player ID のみ送信し、既存レコードの他方と一致する場合は Zod 層では検出不可。ドメイン層 `assertDifferentIds` がキャッチするが HTTP 500 になる問題は #690 で対応予定。

🤖 Generated with [Claude Code](https://claude.com/claude-code)