### PR TITLE
fix(security): セッション作成ページのクエリパラメータにバリデーションを追加する

### DIFF
--- a/app/(authenticated)/circles/[circleId]/sessions/new/page.tsx
+++ b/app/(authenticated)/circles/[circleId]/sessions/new/page.tsx
@@ -32,6 +32,15 @@ export default async function NewCircleSessionPage({
   }
 
   const { startsAt, title, endsAt, location, note } = await searchParams;
+  const dateFormat = /^\d{4}-\d{2}-\d{2}$/;
+  const validStartsAt = dateFormat.test(startsAt ?? "")
+    ? startsAt
+    : undefined;
+  const validEndsAt = dateFormat.test(endsAt ?? "") ? endsAt : undefined;
+  const validTitle = title && title.length <= 100 ? title : undefined;
+  const validLocation =
+    location && location.length <= 200 ? location : undefined;
+  const validNote = note && note.length <= 1000 ? note : undefined;
 
   return (
     <div className="mx-auto flex w-full max-w-2xl flex-col gap-6 py-8">
@@ -40,11 +49,11 @@ export default async function NewCircleSessionPage({
       </h1>
       <CircleSessionCreateForm
         circleId={circleId}
-        defaultStartsAt={startsAt}
-        defaultTitle={title}
-        defaultEndsAt={endsAt}
-        defaultLocation={location}
-        defaultNote={note}
+        defaultStartsAt={validStartsAt}
+        defaultTitle={validTitle}
+        defaultEndsAt={validEndsAt}
+        defaultLocation={validLocation}
+        defaultNote={validNote}
       />
     </div>
   );


### PR DESCRIPTION
## Summary

Closes #79

- `startsAt`, `endsAt` に `YYYY-MM-DD` 形式の正規表現バリデーションを追加
- `title`（100文字）、`location`（200文字）、`note`（1000文字）に長さ制限を追加
- 不正な値は `undefined` として扱い、フォームコンポーネントに渡さない

## Background

`/circles/{circleId}/sessions/new` の searchParams がバリデーションなしにフォームへ渡されていた。実害はない（React JSX エスケープ + HTML5 datetime-local ブラウザバリデーション + tRPC Zod スキーマの多層防御あり）が、defense-in-depth の観点で改善。

## Test plan

- [ ] `npm run lint` / `npx tsc --noEmit` でエラーなし
- [ ] `?startsAt=2026-03-15` → 開始日に値がセットされる
- [ ] `?startsAt=invalid` → 開始日が空
- [ ] `?startsAt=<script>alert(1)</script>` → 開始日が空
- [ ] `?endsAt=2026-03-15` → 終了日に値がセットされる
- [ ] `?endsAt=invalid` → 終了日が空
- [ ] `?title=（101文字超）` → タイトルが空
- [ ] パラメータなし → 全フィールドが空

🤖 Generated with [Claude Code](https://claude.com/claude-code)