### PR TITLE
fix(security): 本番環境での NEXTAUTH_URL 未設定チェックを追加する (#688)

### DIFF
--- a/instrumentation.test.ts
+++ b/instrumentation.test.ts
@@ -1,0 +1,77 @@
+import { afterEach, beforeEach, describe, expect, test, vi } from "vitest";
+
+describe("instrumentation register()", () => {
+  let originalEnv: NodeJS.ProcessEnv;
+
+  beforeEach(() => {
+    originalEnv = { ...process.env };
+    vi.resetModules();
+  });
+
+  afterEach(() => {
+    process.env = originalEnv;
+  });
+
+  test("本番環境で NEXTAUTH_URL が未設定の場合エラーをスローする", async () => {
+    process.env = { ...originalEnv, NODE_ENV: "production" };
+    delete process.env.NEXTAUTH_URL;
+
+    const { register } = await import("./instrumentation");
+    expect(() => register()).toThrow(
+      "NEXTAUTH_URL environment variable is required in production",
+    );
+  });
+
+  test("本番環境で NEXTAUTH_URL が設定済みの場合エラーにならない", async () => {
+    process.env = {
+      ...originalEnv,
+      NODE_ENV: "production",
+      NEXTAUTH_URL: "https://example.com",
+    };
+
+    const { register } = await import("./instrumentation");
+    expect(() => register()).not.toThrow();
+  });
+
+  test("本番環境で NEXTAUTH_URL が空文字の場合エラーをスローする", async () => {
+    process.env = {
+      ...originalEnv,
+      NODE_ENV: "production",
+      NEXTAUTH_URL: "",
+    };
+
+    const { register } = await import("./instrumentation");
+    expect(() => register()).toThrow(
+      "NEXTAUTH_URL environment variable is required in production",
+    );
+  });
+
+  test("本番環境で NEXTAUTH_URL が空白のみの場合エラーをスローする", async () => {
+    process.env = {
+      ...originalEnv,
+      NODE_ENV: "production",
+      NEXTAUTH_URL: "   ",
+    };
+
+    const { register } = await import("./instrumentation");
+    expect(() => register()).toThrow(
+      "NEXTAUTH_URL environment variable is required in production",
+    );
+  });
+
+  test("開発環境で NEXTAUTH_URL が未設定でもエラーにならない", async () => {
+    process.env = { ...originalEnv, NODE_ENV: "development" };
+    delete process.env.NEXTAUTH_URL;
+
+    const { register } = await import("./instrumentation");
+    expect(() => register()).not.toThrow();
+  });
+
+  test("テスト環境で NEXTAUTH_URL が未設定でもエラーにならない", async () => {
+    process.env = { ...originalEnv, NODE_ENV: "test" };
+    delete process.env.NEXTAUTH_URL;
+
+    const { register } = await import("./instrumentation");
+    expect(() => register()).not.toThrow();
+  });
+});

--- a/instrumentation.ts
+++ b/instrumentation.ts
@@ -1,0 +1,10 @@
+export function register() {
+  if (
+    process.env.NODE_ENV === "production" &&
+    !process.env.NEXTAUTH_URL?.trim()
+  ) {
+    throw new Error(
+      "NEXTAUTH_URL environment variable is required in production",
+    );
+  }
+}


### PR DESCRIPTION
## Summary

- Next.js Instrumentation API (`instrumentation.ts`) を使い、本番環境で `NEXTAUTH_URL` が未設定・空文字・空白のみの場合にサーバー起動時エラーをスローする
- 開発・テスト環境ではチェックをスキップし、開発体験に影響しない
- テスト6件（未設定/設定済み/空文字/空白のみ/開発環境/テスト環境）を追加

Closes #688

## Test plan

- [ ] `npm run test:run -- instrumentation.test.ts` で6件すべてパス
- [ ] `npx tsc --noEmit` で型エラーなし
- [ ] `instrumentation.ts` がプロジェクトルートに配置されていることを確認
- [ ] 既存ファイルへの変更がないことを確認（新規2ファイルのみ）

🤖 Generated with [Claude Code](https://claude.com/claude-code)