### PR TITLE
fix(domain): validation 関数の throw を BadRequestError に統一する (#690)

### DIFF
--- a/server/domain/common/validation.test.ts
+++ b/server/domain/common/validation.test.ts
@@ -1,14 +1,17 @@
 import { describe, expect, test } from "vitest";
 import {
   assertDifferentIds,
+  assertMaxLength,
   assertNonEmpty,
   assertPositiveInteger,
   assertStartBeforeEnd,
   assertValidDate,
 } from "@/server/domain/common/validation";
+import { BadRequestError } from "@/server/domain/common/errors";
 
 describe("バリデーション", () => {
   test("assertNonEmpty は空文字（空白のみ）でエラー", () => {
+    expect(() => assertNonEmpty(" ", "name")).toThrow(BadRequestError);
     expect(() => assertNonEmpty(" ", "name")).toThrow("name is required");
   });
 
@@ -20,11 +23,29 @@ describe("バリデーション", () => {
     expect(assertNonEmpty("  ok  ", "name")).toBe("ok");
   });
 
+  test("assertMaxLength は最大長を超えるとエラー", () => {
+    expect(() => assertMaxLength("abcdef", 5, "title")).toThrow(
+      BadRequestError,
+    );
+    expect(() => assertMaxLength("abcdef", 5, "title")).toThrow(
+      "title must be at most 5 characters",
+    );
+  });
+
+  test("assertMaxLength は最大長ちょうどなら成功する", () => {
+    expect(assertMaxLength("abcde", 5, "title")).toBe("abcde");
+  });
+
+  test("assertMaxLength は最大長未満なら成功する", () => {
+    expect(assertMaxLength("abc", 5, "title")).toBe("abc");
+  });
+
   test("assertPositiveInteger は正の整数で値を返す", () => {
     expect(assertPositiveInteger(3, "count")).toBe(3);
   });
 
   test("assertPositiveInteger は0でエラー", () => {
+    expect(() => assertPositiveInteger(0, "count")).toThrow(BadRequestError);
     expect(() => assertPositiveInteger(0, "count")).toThrow(
       "count must be a positive integer",
     );
@@ -49,6 +70,9 @@ describe("バリデーション", () => {
 
   test("assertValidDate は不正な日付でエラー", () => {
     expect(() => assertValidDate(new Date("invalid"), "createdAt")).toThrow(
+      BadRequestError,
+    );
+    expect(() => assertValidDate(new Date("invalid"), "createdAt")).toThrow(
       "createdAt must be a valid date",
     );
   });
@@ -56,6 +80,9 @@ describe("バリデーション", () => {
   test("assertStartBeforeEnd は開始が後ならエラー", () => {
     const startsAt = new Date("2024-01-02T00:00:00Z");
     const endsAt = new Date("2024-01-01T00:00:00Z");
+    expect(() => assertStartBeforeEnd(startsAt, endsAt, "session")).toThrow(
+      BadRequestError,
+    );
     expect(() => assertStartBeforeEnd(startsAt, endsAt, "session")).toThrow(
       "session start must be before or equal to end",
     );
@@ -75,6 +102,9 @@ describe("バリデーション", () => {
   });
 
   test("assertDifferentIds は同一でエラー", () => {
+    expect(() => assertDifferentIds("id", "id", "target")).toThrow(
+      BadRequestError,
+    );
     expect(() => assertDifferentIds("id", "id", "target")).toThrow(
       "target must be different",
     );

--- a/server/domain/common/validation.ts
+++ b/server/domain/common/validation.ts
@@ -1,7 +1,15 @@
+/**
+ * SECURITY: これらのバリデーション関数は BadRequestError を throw し、
+ * そのメッセージはクライアントへそのまま返される。
+ * field / label 引数には開発者が定義した文字列リテラルのみを渡すこと。
+ * ユーザー入力を渡してはならない。
+ */
+import { BadRequestError } from "./errors";
+
 export const assertNonEmpty = (value: string, field: string): string => {
   const trimmed = value.trim();
   if (!trimmed) {
-    throw new Error(`${field} is required`);
+    throw new BadRequestError(`${field} is required`);
   }
   return trimmed;
 };
@@ -12,21 +20,21 @@ export const assertMaxLength = (
   field: string,
 ): string => {
   if (value.length > maxLength) {
-    throw new Error(`${field} must be at most ${maxLength} characters`);
+    throw new BadRequestError(`${field} must be at most ${maxLength} characters`);
   }
   return value;
 };
 
 export const assertPositiveInteger = (value: number, field: string): number => {
   if (!Number.isInteger(value) || value <= 0) {
-    throw new Error(`${field} must be a positive integer`);
+    throw new BadRequestError(`${field} must be a positive integer`);
   }
   return value;
 };
 
 export const assertValidDate = (value: Date, field: string): Date => {
   if (Number.isNaN(value.getTime())) {
-    throw new Error(`${field} must be a valid date`);
+    throw new BadRequestError(`${field} must be a valid date`);
   }
   return value;
 };
@@ -37,7 +45,7 @@ export const assertStartBeforeEnd = (
   field: string,
 ): void => {
   if (startsAt.getTime() > endsAt.getTime()) {
-    throw new Error(`${field} start must be before or equal to end`);
+    throw new BadRequestError(`${field} start must be before or equal to end`);
   }
 };
 
@@ -47,6 +55,6 @@ export const assertDifferentIds = (
   field: string,
 ): void => {
   if (left === right) {
-    throw new Error(`${field} must be different`);
+    throw new BadRequestError(`${field} must be different`);
   }
 };


### PR DESCRIPTION
## Summary

- `validation.ts` の全6関数（`assertNonEmpty`, `assertMaxLength`, `assertPositiveInteger`, `assertValidDate`, `assertStartBeforeEnd`, `assertDifferentIds`）が plain `Error` を throw していたため、tRPC エラーハンドラで `DomainError` として認識されず HTTP 500 を返していた
- `BadRequestError` に変更し、適切に HTTP 400 を返すようにした
- テストに `BadRequestError` 型アサーションを追加し、リグレッションを防止
- `assertMaxLength` のテストケースを補完（エラー・境界値・正常系）

Closes #690

## Test plan

- [x] `npx vitest run server/domain/common/validation.test.ts` — 17 tests passed
- [x] `npx tsc --noEmit` — no errors
- [ ] 開発サーバーでセッション名を空にして送信 → HTTP 400 が返ることを確認
- [ ] 対局記録で先手と後手に同じプレイヤーを指定 → HTTP 400 が返ることを確認

## Remaining

- tRPC エンドポイントレベルの統合テスト → #694 で対応

🤖 Generated with [Claude Code](https://claude.com/claude-code)