### PR TITLE
test(trpc): バリデーションエラーの BAD_REQUEST 統合テストを追加する (#694)

### DIFF
--- a/server/presentation/trpc/routers/circle-session.test.ts
+++ b/server/presentation/trpc/routers/circle-session.test.ts
@@ -1,0 +1,134 @@
+import { beforeEach, describe, expect, test, vi } from "vitest";
+import { appRouter } from "@/server/presentation/trpc/router";
+import type { Context } from "@/server/presentation/trpc/context";
+import {
+  circleId,
+  circleSessionId,
+  userId,
+} from "@/server/domain/common/ids";
+import { BadRequestError } from "@/server/domain/common/errors";
+
+const createTestContext = (
+  actorIdValue: ReturnType<typeof userId> | null = userId("user-1"),
+) => {
+  const circleSessionService = {
+    listByCircleId: vi.fn(),
+    getCircleSession: vi.fn(),
+    createCircleSession: vi.fn(),
+    rescheduleCircleSession: vi.fn(),
+    updateCircleSessionDetails: vi.fn(),
+    deleteCircleSession: vi.fn(),
+  };
+
+  const context: Context = {
+    actorId: actorIdValue,
+    circleService: {
+      getCircle: vi.fn(),
+      createCircle: vi.fn(),
+      renameCircle: vi.fn(),
+      deleteCircle: vi.fn(),
+    },
+    circleMembershipService: {
+      listByCircleId: vi.fn(),
+      listByUserId: vi.fn(),
+      addMembership: vi.fn(),
+      changeMembershipRole: vi.fn(),
+      withdrawMembership: vi.fn(),
+      removeMembership: vi.fn(),
+      transferOwnership: vi.fn(),
+    },
+    circleSessionService,
+    circleSessionMembershipService: {
+      countPastSessionsByUserId: vi.fn(),
+      listMemberships: vi.fn(),
+      listByUserId: vi.fn(),
+      addMembership: vi.fn(),
+      changeMembershipRole: vi.fn(),
+      removeMembership: vi.fn(),
+      transferOwnership: vi.fn(),
+      withdrawMembership: vi.fn(),
+    },
+    matchService: {
+      listByCircleSessionId: vi.fn(),
+      getMatch: vi.fn(),
+      recordMatch: vi.fn(),
+      updateMatch: vi.fn(),
+      deleteMatch: vi.fn(),
+    },
+    userService: {
+      getUser: vi.fn(),
+      listUsers: vi.fn(),
+      getMe: vi.fn(),
+      updateProfile: vi.fn(),
+      updateProfileVisibility: vi.fn(),
+      changePassword: vi.fn(),
+    },
+    signupService: {
+      signup: vi.fn(),
+    },
+    circleInviteLinkService: {
+      createInviteLink: vi.fn(),
+      getInviteLinkInfo: vi.fn(),
+      redeemInviteLink: vi.fn(),
+    },
+    accessService: {} as Context["accessService"],
+    userStatisticsService: {} as Context["userStatisticsService"],
+    holidayProvider: {} as Context["holidayProvider"],
+  };
+
+  return { context, mocks: { circleSessionService } };
+};
+
+describe("circle-session tRPC ルーター", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  describe("create", () => {
+    test("空のセッション名 → BAD_REQUEST（Zodバリデーション）", async () => {
+      const { context, mocks } = createTestContext();
+
+      const caller = appRouter.createCaller(context);
+
+      await expect(
+        caller.circleSessions.create({
+          circleId: "circle-1",
+          title: "",
+          startsAt: new Date("2024-06-01T10:00:00Z"),
+          endsAt: new Date("2024-06-01T12:00:00Z"),
+        }),
+      ).rejects.toMatchObject({ code: "BAD_REQUEST" });
+
+      expect(
+        mocks.circleSessionService.createCircleSession,
+      ).not.toHaveBeenCalled();
+    });
+
+    test("BadRequestError（開始日時が終了日時より後）→ BAD_REQUEST", async () => {
+      const { context, mocks } = createTestContext();
+      mocks.circleSessionService.createCircleSession.mockRejectedValueOnce(
+        new BadRequestError(
+          "CircleSession start must be before or equal to end",
+        ),
+      );
+
+      const caller = appRouter.createCaller(context);
+
+      await expect(
+        caller.circleSessions.create({
+          circleId: "circle-1",
+          title: "テストセッション",
+          startsAt: new Date("2024-06-01T14:00:00Z"),
+          endsAt: new Date("2024-06-01T10:00:00Z"),
+        }),
+      ).rejects.toMatchObject({
+        code: "BAD_REQUEST",
+        message: "CircleSession start must be before or equal to end",
+      });
+
+      expect(
+        mocks.circleSessionService.createCircleSession,
+      ).toHaveBeenCalledOnce();
+    });
+  });
+});

--- a/server/presentation/trpc/routers/match.test.ts
+++ b/server/presentation/trpc/routers/match.test.ts
@@ -272,7 +272,12 @@ describe("match tRPC ルーター", () => {
           player1Id: "player-1",
           player2Id: "player-1",
         }),
-      ).rejects.toMatchObject({ code: "BAD_REQUEST" });
+      ).rejects.toMatchObject({
+        code: "BAD_REQUEST",
+        message: expect.stringContaining(
+          "player1Id and player2Id must be different",
+        ),
+      });
     });
 
     test("未認証: actorId null → UNAUTHORIZED", async () => {
@@ -409,14 +414,17 @@ describe("match tRPC ルーター", () => {
     test("BadRequestError（削除済み対局）→ BAD_REQUEST", async () => {
       const { context, mocks } = createTestContext();
       mocks.matchService.deleteMatch.mockRejectedValueOnce(
-        new BadRequestError("Match is already deleted"),
+        new BadRequestError("Match is deleted"),
       );
 
       const caller = appRouter.createCaller(context);
 
       await expect(
         caller.matches.delete({ matchId: "match-1" }),
-      ).rejects.toMatchObject({ code: "BAD_REQUEST" });
+      ).rejects.toMatchObject({
+        code: "BAD_REQUEST",
+        message: "Match is deleted",
+      });
     });
 
     test("未認証: actorId null → UNAUTHORIZED", async () => {


### PR DESCRIPTION
## Summary

- circle-session tRPC ルーターの統合テストを新規追加（空タイトル、開始日時 > 終了日時）
- match tRPC ルーターの既存テストにエラーメッセージのアサーションを追加・修正

Closes #694

## Test plan

- [ ] `npm run test:run -- server/presentation/trpc/routers/circle-session.test.ts` → 2 tests passed
- [ ] `npm run test:run -- server/presentation/trpc/routers/match.test.ts` → 22 tests passed
- [ ] `npm run test:run` → 全テスト通過（回帰なし）

🤖 Generated with [Claude Code](https://claude.com/claude-code)