### PR TITLE
fix(url): sanitizeCallbackUrl がフルURL形式の同一オリジンURLを処理できるようにする

### DIFF
--- a/lib/url.test.ts
+++ b/lib/url.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { sanitizeCallbackUrl } from "./url";
 
 describe("sanitizeCallbackUrl", () => {
@@ -54,5 +54,57 @@ describe("sanitizeCallbackUrl", () => {
 
   it("rejects control character bypass: carriage return between slashes", () => {
     expect(sanitizeCallbackUrl("/\r/evil.com")).toBe("/home");
+  });
+
+  describe("full URL handling", () => {
+    const ORIGIN = "http://localhost:3000";
+
+    beforeEach(() => {
+      vi.stubGlobal("window", { location: { origin: ORIGIN } });
+    });
+
+    afterEach(() => {
+      vi.unstubAllGlobals();
+    });
+
+    it("extracts path from same-origin full URL", () => {
+      expect(sanitizeCallbackUrl(`${ORIGIN}/invite/abc`)).toBe("/invite/abc");
+    });
+
+    it("extracts path with query parameters from same-origin full URL", () => {
+      expect(sanitizeCallbackUrl(`${ORIGIN}/invite/abc?foo=bar`)).toBe(
+        "/invite/abc?foo=bar",
+      );
+    });
+
+    it("extracts path with hash from same-origin full URL", () => {
+      expect(sanitizeCallbackUrl(`${ORIGIN}/home#section`)).toBe(
+        "/home#section",
+      );
+    });
+
+    it("rejects full URL from external origin", () => {
+      expect(sanitizeCallbackUrl("https://evil.com/invite/abc")).toBe("/home");
+    });
+
+    it("rejects ftp:// scheme", () => {
+      expect(sanitizeCallbackUrl("ftp://localhost:3000/path")).toBe("/home");
+    });
+
+    it("rejects same-origin URL with protocol-relative path (//evil.com)", () => {
+      expect(sanitizeCallbackUrl(`${ORIGIN}//evil.com/steal`)).toBe("/home");
+    });
+
+    it("rejects full URL with different port", () => {
+      expect(sanitizeCallbackUrl("http://localhost:4000/path")).toBe("/home");
+    });
+  });
+
+  describe("full URL handling on server (no window)", () => {
+    it("falls back to /home for full URL when window is undefined", () => {
+      expect(sanitizeCallbackUrl("http://localhost:3000/invite/abc")).toBe(
+        "/home",
+      );
+    });
   });
 });

--- a/lib/url.ts
+++ b/lib/url.ts
@@ -6,5 +6,18 @@ export function sanitizeCallbackUrl(url: string | undefined): string {
   // Without this, "/\n/evil.com" passes the startsWith checks but resolves to "//evil.com".
   const cleaned = url.replace(/[\t\n\r]/g, "");
   if (cleaned.startsWith("/") && !cleaned.startsWith("//")) return cleaned;
+
+  // Handle full URLs: extract path from same-origin URLs (e.g. NextAuth result.url)
+  try {
+    const parsed = new URL(cleaned);
+    if (typeof window !== "undefined" && parsed.origin === window.location.origin) {
+      const path = parsed.pathname + parsed.search + parsed.hash;
+      // Re-apply validation on extracted path
+      if (path.startsWith("/") && !path.startsWith("//")) return path;
+    }
+  } catch {
+    // Invalid URL — fall through to default
+  }
+
   return DEFAULT_CALLBACK;
 }


### PR DESCRIPTION
## Summary

Closes #686

- `sanitizeCallbackUrl` に同一オリジンのフルURL（例: `http://localhost:3000/invite/abc`）からパスを抽出する処理を追加
- NextAuth `signIn({ redirect: false })` の `result.url` が正しくリダイレクトされるようになる
- オープンリダイレクト攻撃への防御を維持（外部オリジン、プロトコル相対パス `//evil.com` 等はブロック）

## 変更ファイル

| ファイル | 変更内容 |
|---|---|
| `lib/url.ts` | 同一オリジンフルURLからパス抽出ロジックを追加 |
| `lib/url.test.ts` | フルURL処理のテスト7件、SSR環境テスト1件を追加（計21テスト） |

## セキュリティ確認

| 攻撃ベクトル | 防御 |
|---|---|
| 外部オリジン | `parsed.origin === window.location.origin` で拒否 |
| プロトコル相対パス (`//evil.com`) | 抽出パスの再バリデーションで拒否 |
| `javascript:` / `data:` スキーム | `URL.origin` が `null` でオリジン不一致 |
| SSR環境（`window` 未定義） | `/home` にフォールバック |

## Test plan

- [x] `npm run test:run -- lib/url.test.ts` — 21 tests passed
- [x] `npx tsc --noEmit` — no errors
- [x] `npm run lint` — no new warnings
- [ ] 手動確認: `/signin?callbackUrl=http://localhost:3000/invite/abc` でログイン後 `/invite/abc` にリダイレクトされること
- [ ] 手動確認: `/signin?callbackUrl=https://evil.com/path` でログイン後 `/home` にリダイレクトされること

🤖 Generated with [Claude Code](https://claude.com/claude-code)