### PR TITLE
feat(auth): サインアップ時の利用規約同意をサーバーサイドで検証する

### DIFF
--- a/app/api/auth/signup/route.ts
+++ b/app/api/auth/signup/route.ts
@@ -15,6 +15,7 @@ type SignupPayload = {
   email?: string;
   password?: string;
   name?: string;
+  agreedToTerms?: boolean;
 };
 
 export async function POST(request: Request) {
@@ -31,15 +32,24 @@ export async function POST(request: Request) {
   const name =
     typeof body.name === "string" && body.name.trim() ? body.name.trim() : null;
 
-  const result = await signupService.signup({ email, password, name });
+  const agreedToTerms = body.agreedToTerms === true;
+
+  const result = await signupService.signup({
+    email,
+    password,
+    name,
+    agreedToTerms,
+  });
 
   if (!result.success) {
     const errorMessages = {
+      terms_not_agreed: "利用規約に同意してください。",
       invalid_email: "メールアドレスを入力してください。",
       password_too_short: "パスワードは8文字以上で入力してください。",
       email_exists: "このメールアドレスは既に登録されています。",
     };
     const statusCodes = {
+      terms_not_agreed: 400,
       invalid_email: 400,
       password_too_short: 400,
       email_exists: 409,

--- a/app/components/signup-form.test.tsx
+++ b/app/components/signup-form.test.tsx
@@ -79,7 +79,10 @@ describe("SignupForm 利用規約チェックボックス", () => {
     expect(screen.queryByText("利用規約に同意してください。")).toBeNull();
     expect(fetchSpy).toHaveBeenCalledWith(
       "/api/auth/signup",
-      expect.objectContaining({ method: "POST" }),
+      expect.objectContaining({
+        method: "POST",
+        body: expect.stringContaining('"agreedToTerms":true'),
+      }),
     );
   });
 

--- a/app/components/signup-form.tsx
+++ b/app/components/signup-form.tsx
@@ -57,6 +57,7 @@ export default function SignupForm({ callbackUrl }: SignupFormProps) {
           name: name.trim() ? name.trim() : undefined,
           email,
           password,
+          agreedToTerms,
         }),
       });
 

--- a/server/application/auth/signup-service.test.ts
+++ b/server/application/auth/signup-service.test.ts
@@ -11,6 +11,7 @@ const validInput = {
   email: "test@example.com",
   password: "password123",
   name: "Test User",
+  agreedToTerms: true,
 };
 
 const createDeps = (
@@ -48,6 +49,16 @@ describe("SignupService", () => {
     const result = await service.signup(validInput);
 
     expect(result).toEqual({ success: false, error: "email_exists" });
+  });
+
+  test("agreedToTerms が false の場合 terms_not_agreed を返す", async () => {
+    const deps = createDeps();
+    const service = createSignupService(deps);
+
+    const result = await service.signup({ ...validInput, agreedToTerms: false });
+
+    expect(result).toEqual({ success: false, error: "terms_not_agreed" });
+    expect(deps.userRepository.emailExists).not.toHaveBeenCalled();
   });
 
   test("createUser が ConflictError 以外をスローした場合はそのまま伝播する", async () => {

--- a/server/application/auth/signup-service.ts
+++ b/server/application/auth/signup-service.ts
@@ -14,17 +14,26 @@ export type SignupInput = {
   email: string;
   password: string;
   name: string | null;
+  agreedToTerms: boolean;
 };
 
 export type SignupResult =
   | { success: true; userId: UserId }
   | {
       success: false;
-      error: "invalid_email" | "password_too_short" | "email_exists";
+      error:
+        | "terms_not_agreed"
+        | "invalid_email"
+        | "password_too_short"
+        | "email_exists";
     };
 
 export const createSignupService = (deps: SignupServiceDeps) => ({
   async signup(input: SignupInput): Promise<SignupResult> {
+    if (input.agreedToTerms !== true) {
+      return { success: false, error: "terms_not_agreed" };
+    }
+
     const email = input.email.trim();
     const password = input.password;
     const name = input.name?.trim() || null;


### PR DESCRIPTION
## Summary

Closes #702

- サインアップAPIに `agreedToTerms` フィールドを追加し、サーバーサイドで利用規約同意を検証
- `agreedToTerms !== true` の場合、DBアクセス前に `400 Bad Request` を返却
- クライアント側から `agreedToTerms: true` をリクエストボディに含めるよう修正

## Changes

| File | Change |
|---|---|
| `server/application/auth/signup-service.ts` | `SignupInput` に `agreedToTerms` 追加、バリデーション順序の先頭で検証 |
| `app/api/auth/signup/route.ts` | `body.agreedToTerms === true` で厳密チェック、エラーレスポンス追加 |
| `app/components/signup-form.tsx` | リクエストボディに `agreedToTerms` を含める |
| `server/application/auth/signup-service.test.ts` | terms未同意テスト追加（短絡動作の検証含む） |
| `app/components/signup-form.test.tsx` | リクエストボディに `agreedToTerms` が含まれることを検証 |

## Security Notes

- `=== true` による厳密な型チェック（文字列 `"true"` や数値 `1` を拒否）
- バリデーション順序: terms → email → password → DB問合せ（未同意時はDB不問合せ）
- 同意のDB永続化（`termsAcceptedAt`）は設計判断としてスコープ外（#702 本文に記載）

## Related Issues

- Created from safety review of #698
- Follow-up: #705 (パスワード最大長制限), #706 (名前最大長制限)

## Test plan

- [x] `npm run test:run -- server/application/auth/signup-service.test.ts` — 3/3 通過
- [x] `npm run test:run -- app/components/signup-form.test.tsx` — 3/3 通過
- [x] `npx tsc --noEmit` — エラーなし
- [x] `npm run lint` — エラーなし
- [ ] 手動: `/signup` でチェックなし送信 → クライアントエラー表示
- [ ] 手動: `curl` で `agreedToTerms` なし/false/"true"/true の4パターンを検証
- [ ] 手動: チェックありで正常サインアップ

🤖 Generated with [Claude Code](https://claude.com/claude-code)