### PR TITLE
fix(help): 権限マトリックステーブルのアクセシビリティを改善する (#713)

### DIFF
--- a/app/(authenticated)/help/page.tsx
+++ b/app/(authenticated)/help/page.tsx
@@ -10,6 +10,7 @@ type PermissionRow = {
 type PermissionTableConfig = {
   title: string;
   ariaLabel: string;
+  noteId: string;
   rows: PermissionRow[];
 };
 
@@ -31,6 +32,7 @@ const permissionTables: PermissionTableConfig[] = [
   {
     title: "研究会ロール",
     ariaLabel: "研究会ロール権限一覧",
+    noteId: "circle-role-note",
     rows: [
       { operation: "研究会の編集", owner: "○", manager: "○", member: "—" },
       { operation: "研究会の削除", owner: "○", manager: "—", member: "—" },
@@ -42,6 +44,7 @@ const permissionTables: PermissionTableConfig[] = [
   {
     title: "セッションロール",
     ariaLabel: "セッションロール権限一覧",
+    noteId: "session-role-note",
     rows: [
       {
         operation: "セッションの編集",
@@ -60,6 +63,41 @@ const permissionTables: PermissionTableConfig[] = [
     ],
   },
 ];
+
+function renderPermissionCell(value: string, noteId?: string) {
+  switch (value) {
+    case "○ ※":
+      return {
+        content: (
+          <>
+            <span aria-hidden="true">○ ※</span>
+            <span className="sr-only">許可（条件付き）</span>
+          </>
+        ),
+        describedBy: noteId,
+      };
+    case "○":
+      return {
+        content: (
+          <>
+            <span aria-hidden="true">○</span>
+            <span className="sr-only">許可</span>
+          </>
+        ),
+      };
+    case "—":
+      return {
+        content: (
+          <>
+            <span aria-hidden="true">—</span>
+            <span className="sr-only">不可</span>
+          </>
+        ),
+      };
+    default:
+      return { content: value };
+  }
+}
 
 const contactFormUrl = process.env.NEXT_PUBLIC_CONTACT_FORM_URL;
 
@@ -102,6 +140,7 @@ export default function HelpPage() {
             aria-label={table.ariaLabel}
           >
             <table className="w-full text-sm text-(--brand-ink-muted)">
+              <caption className="sr-only">{table.ariaLabel}</caption>
               <thead>
                 <tr className="border-b border-border/60 text-left">
                   <th
@@ -139,15 +178,27 @@ export default function HelpPage() {
                     >
                       {row.operation}
                     </th>
-                    <td className="py-3 text-center">{row.owner}</td>
-                    <td className="py-3 text-center">{row.manager}</td>
-                    <td className="py-3 text-center">{row.member}</td>
+                    {(["owner", "manager", "member"] as const).map((role) => {
+                      const cell = renderPermissionCell(
+                        row[role],
+                        table.noteId,
+                      );
+                      return (
+                        <td
+                          key={role}
+                          className="py-3 text-center"
+                          aria-describedby={cell.describedBy}
+                        >
+                          {cell.content}
+                        </td>
+                      );
+                    })}
                   </tr>
                 ))}
               </tbody>
             </table>
           </div>
-          <p className="mt-2 text-xs text-(--brand-ink-muted)">
+          <p id={table.noteId} className="mt-2 text-xs text-(--brand-ink-muted)">
             ※ マネージャーは自分より上位のロールの変更不可
           </p>
         </section>


### PR DESCRIPTION
## Summary

Closes #713

権限マトリックステーブル（研究会ロール・セッションロール）のアクセシビリティを WCAG 2.1 Level A に準拠するよう改善。

- **SC 1.1.1（非テキストコンテンツ）**: `○`/`—` 記号を `aria-hidden="true"` で隠蔽し、`sr-only` で「許可」「不可」「許可（条件付き）」の代替テキストを追加
- **SC 1.3.1（情報及び関係性）**: `<caption>` でテーブルにラベルを付与、`aria-describedby` で `※` 注釈をセルに関連付け
- `renderPermissionCell` ヘルパーを抽出し、セル描画ロジックを統一

## Test plan

- [ ] ヘルプページの権限テーブルが視覚的に変更なく表示されることを確認
- [ ] スクリーンリーダーで `○` が「許可」、`—` が「不可」と読み上げられることを確認
- [ ] テーブルランドマーク移動時に `<caption>` のラベルが読み上げられることを確認
- [ ] `※` セルにフォーカスした際に注釈テキストが読み上げられることを確認

## Follow-up issues

- #718: `aria-label` と `<caption>` の重複解消
- #719: `renderPermissionCell` の `value` にユニオン型導入

🤖 Generated with [Claude Code](https://claude.com/claude-code)