### PR TITLE
fix(signup): バリデーション順序をフォーム表示順に合わせる

### DIFF
--- a/app/components/signup-form.test.tsx
+++ b/app/components/signup-form.test.tsx
@@ -86,6 +86,25 @@ describe("SignupForm 利用規約チェックボックス", () => {
     );
   });
 
+  it("パスワード不一致 + 利用規約未同意のとき、パスワード不一致エラーが優先表示される", async () => {
+    const user = userEvent.setup();
+    render(<SignupForm />);
+
+    await user.type(screen.getByPlaceholderText("demo1@example.com"), "test@example.com");
+    const passwordInputs = screen.getAllByPlaceholderText("••••••••");
+    await user.type(passwordInputs[0], "password123");
+    await user.type(passwordInputs[1], "different456");
+
+    const submitButton = screen.getByRole("button", {
+      name: "アカウントを作成",
+    });
+    await user.click(submitButton);
+
+    expect(screen.getByRole("alert")).toHaveTextContent(
+      "パスワードが一致しません。",
+    );
+  });
+
   it("利用規約リンクが新しいタブで開くように設定されている", () => {
     render(<SignupForm />);
 

--- a/app/components/signup-form.tsx
+++ b/app/components/signup-form.tsx
@@ -32,13 +32,10 @@ export default function SignupForm({ callbackUrl }: SignupFormProps) {
       return;
     }
 
-    if (!agreedToTerms) {
-      setErrorMessage("利用規約およびプライバシーポリシーに同意してください。");
-      return;
-    }
-
-    if (password !== passwordConfirm) {
-      setErrorMessage("パスワードが一致しません。");
+    if (name.trim().length > MAX_NAME_LENGTH) {
+      setErrorMessage(
+        `表示名は${MAX_NAME_LENGTH}文字以内で入力してください。`,
+      );
       return;
     }
     if (password.length < MIN_PASSWORD_LENGTH) {
@@ -53,10 +50,12 @@ export default function SignupForm({ callbackUrl }: SignupFormProps) {
       );
       return;
     }
-    if (name.trim().length > MAX_NAME_LENGTH) {
-      setErrorMessage(
-        `表示名は${MAX_NAME_LENGTH}文字以内で入力してください。`,
-      );
+    if (password !== passwordConfirm) {
+      setErrorMessage("パスワードが一致しません。");
+      return;
+    }
+    if (!agreedToTerms) {
+      setErrorMessage("利用規約およびプライバシーポリシーに同意してください。");
       return;
     }
 


### PR DESCRIPTION
## Summary

Closes #703

サインアップフォームの `handleSubmit` バリデーション順序をフォームのフィールド表示順に合わせることで、UXを改善する。

- バリデーション順序を表示名 → パスワード長 → パスワード最大長 → パスワード一致 → 利用規約の順に変更
- パスワード不一致 + 利用規約未同意の同時発生時に、パスワードエラーが優先表示されることを検証するテストを追加
- 6つのバリデーションチェックはすべて維持（セキュリティ影響なし）

## Test plan

- [x] `npm run test:run -- app/components/signup-form.test.tsx` — 4 tests passed
- [x] `npx tsc --noEmit` — No errors
- [x] `npm run lint` — No errors
- [ ] 手動確認: `/signup` でパスワード不一致 + 利用規約未チェックのまま送信 → パスワードエラーが先に表示される

## Related issues

- #721 バリデーション順序テストの強化（follow-up）
- #722 エラーメッセージ文字列の定数抽出（follow-up）

🤖 Generated with [Claude Code](https://claude.com/claude-code)