### PR TITLE
refactor: PasswordHasher ポート定義を domain 層に移動する (#743)

### DIFF
--- a/app/api/auth/signup/route.ts
+++ b/app/api/auth/signup/route.ts
@@ -8,7 +8,7 @@ import {
 
 const signupService = createSignupService({
   userRepository: prismaUserRepository,
-  passwordUtils: { hash: hashPassword, verify: verifyPassword },
+  passwordHasher: { hash: hashPassword, verify: verifyPassword },
 });
 
 type SignupPayload = {

--- a/server/application/auth/signup-service.test.ts
+++ b/server/application/auth/signup-service.test.ts
@@ -31,7 +31,7 @@ const createDeps = (
     updateProfileVisibility: vi.fn(),
     ...repoOverrides,
   },
-  passwordUtils: {
+  passwordHasher: {
     hash: vi.fn().mockReturnValue("hashed-password"),
     verify: vi.fn(),
   },

--- a/server/application/auth/signup-service.ts
+++ b/server/application/auth/signup-service.ts
@@ -1,6 +1,6 @@
 import type { UserId } from "@/server/domain/common/ids";
 import type { UserRepository } from "@/server/domain/models/user/user-repository";
-import type { PasswordUtils } from "@/server/application/user/user-service";
+import type { PasswordHasher } from "@/server/domain/common/password-hasher";
 import { ConflictError } from "@/server/domain/common/errors";
 import {
   USER_NAME_MAX_LENGTH,
@@ -11,7 +11,7 @@ const MIN_PASSWORD_LENGTH = 8;
 
 export type SignupServiceDeps = {
   userRepository: UserRepository;
-  passwordUtils: PasswordUtils;
+  passwordHasher: PasswordHasher;
 };
 
 export type SignupInput = {
@@ -65,7 +65,7 @@ export const createSignupService = (deps: SignupServiceDeps) => ({
       return { success: false, error: "email_exists" };
     }
 
-    const passwordHash = deps.passwordUtils.hash(password);
+    const passwordHash = deps.passwordHasher.hash(password);
 
     try {
       const userId = await deps.userRepository.createUser({

--- a/server/application/user/user-service.test.ts
+++ b/server/application/user/user-service.test.ts
@@ -2,7 +2,7 @@ import { beforeEach, describe, expect, test, vi } from "vitest";
 import { createUserService } from "@/server/application/user/user-service";
 import { createAccessServiceStub } from "@/server/application/test-helpers/access-service-stub";
 import { createMockUserRepository } from "@/server/application/test-helpers/mock-repositories";
-import type { PasswordUtils } from "@/server/application/user/user-service";
+import type { PasswordHasher } from "@/server/domain/common/password-hasher";
 import type { RateLimiter } from "@/server/domain/common/rate-limiter";
 import { userId } from "@/server/domain/common/ids";
 import {
@@ -15,7 +15,7 @@ const userRepository = createMockUserRepository();
 
 const accessService = createAccessServiceStub();
 
-const passwordUtils: PasswordUtils = {
+const passwordHasher: PasswordHasher = {
   hash: vi.fn((p: string) => `hashed:${p}`),
   verify: vi.fn((p: string, h: string) => h === `hashed:${p}`),
 };
@@ -29,7 +29,7 @@ const changePasswordRateLimiter: RateLimiter = {
 const service = createUserService({
   userRepository,
   accessService,
-  passwordUtils,
+  passwordHasher,
   changePasswordRateLimiter,
 });
 

--- a/server/application/user/user-service.ts
+++ b/server/application/user/user-service.ts
@@ -2,6 +2,7 @@ import type { User, ProfileVisibility } from "@/server/domain/models/user/user";
 import type { UserId } from "@/server/domain/common/ids";
 import type { UserRepository } from "@/server/domain/models/user/user-repository";
 import type { createAccessService } from "@/server/application/authz/access-service";
+import type { PasswordHasher } from "@/server/domain/common/password-hasher";
 import type { RateLimiter } from "@/server/domain/common/rate-limiter";
 import { BadRequestError, ForbiddenError } from "@/server/domain/common/errors";
 import { USER_PASSWORD_MAX_LENGTH } from "@/server/domain/models/user/user";
@@ -10,15 +11,10 @@ const MIN_PASSWORD_LENGTH = 8;
 
 type AccessService = ReturnType<typeof createAccessService>;
 
-export type PasswordUtils = {
-  hash(password: string): string;
-  verify(password: string, hashedValue: string): boolean;
-};
-
 export type UserServiceDeps = {
   userRepository: UserRepository;
   accessService: AccessService;
-  passwordUtils: PasswordUtils;
+  passwordHasher: PasswordHasher;
   changePasswordRateLimiter: RateLimiter;
 };
 
@@ -88,7 +84,7 @@ export const createUserService = (deps: UserServiceDeps) => ({
       throw new BadRequestError("Password login is not enabled");
     }
 
-    const valid = deps.passwordUtils.verify(currentPassword, passwordHash);
+    const valid = deps.passwordHasher.verify(currentPassword, passwordHash);
     if (!valid) {
       await deps.changePasswordRateLimiter.recordFailure(actorId);
       throw new BadRequestError("Current password is incorrect");
@@ -103,7 +99,7 @@ export const createUserService = (deps: UserServiceDeps) => ({
     }
 
     await deps.changePasswordRateLimiter.reset(actorId);
-    const newHash = deps.passwordUtils.hash(newPassword);
+    const newHash = deps.passwordHasher.hash(newPassword);
     const passwordChangedAt = new Date();
     await deps.userRepository.updatePasswordHash(
       actorId,

--- a/server/domain/common/password-hasher.ts
+++ b/server/domain/common/password-hasher.ts
@@ -1,0 +1,12 @@
+/**
+ * パスワードハッシャーのポート定義
+ *
+ * アプリケーション層がパスワードのハッシュ化・検証機能に依存するためのインターフェース。
+ * 具体的な実装（bcrypt など）はインフラ層で提供される。
+ */
+export type PasswordHasher = {
+  /** 平文パスワードをハッシュ化する */
+  hash(password: string): string;
+  /** 平文パスワードがハッシュ値と一致するか検証する */
+  verify(password: string, hashedValue: string): boolean;
+};

--- a/server/infrastructure/service-container.test.ts
+++ b/server/infrastructure/service-container.test.ts
@@ -25,7 +25,7 @@ describe("Service container", () => {
       userRepository,
       authzRepository,
       circleInviteLinkRepository,
-      passwordUtils: { hash: vi.fn(), verify: vi.fn() },
+      passwordHasher: { hash: vi.fn(), verify: vi.fn() },
       changePasswordRateLimiter: {
         check: vi.fn(),
         recordFailure: vi.fn(),

--- a/server/infrastructure/service-container.ts
+++ b/server/infrastructure/service-container.ts
@@ -16,7 +16,7 @@ import type { UnitOfWork } from "@/server/domain/common/unit-of-work";
 import type { AuthzRepository } from "@/server/domain/services/authz/authz-repository";
 import type { UserRepository } from "@/server/domain/models/user/user-repository";
 import type { CircleInviteLinkRepository } from "@/server/domain/models/circle-invite-link/circle-invite-link-repository";
-import type { PasswordUtils } from "@/server/application/user/user-service";
+import type { PasswordHasher } from "@/server/domain/common/password-hasher";
 import type { HolidayProvider } from "@/server/domain/common/holiday-provider";
 
 export type ServiceContainer = {
@@ -44,7 +44,7 @@ export type ServiceContainerDeps = {
   userRepository: UserRepository;
   authzRepository: AuthzRepository;
   circleInviteLinkRepository: CircleInviteLinkRepository;
-  passwordUtils: PasswordUtils;
+  passwordHasher: PasswordHasher;
   changePasswordRateLimiter: RateLimiter;
   holidayProvider: HolidayProvider;
   unitOfWork?: UnitOfWork;
@@ -89,12 +89,12 @@ export const createServiceContainer = (
     userService: createUserService({
       userRepository: deps.userRepository,
       accessService,
-      passwordUtils: deps.passwordUtils,
+      passwordHasher: deps.passwordHasher,
       changePasswordRateLimiter: deps.changePasswordRateLimiter,
     }),
     signupService: createSignupService({
       userRepository: deps.userRepository,
-      passwordUtils: deps.passwordUtils,
+      passwordHasher: deps.passwordHasher,
     }),
     circleInviteLinkService: createCircleInviteLinkService({
       circleInviteLinkRepository: deps.circleInviteLinkRepository,

--- a/server/presentation/trpc/context.ts
+++ b/server/presentation/trpc/context.ts
@@ -33,7 +33,7 @@ const buildServiceContainer = (): ServiceContainer =>
     userRepository: prismaUserRepository,
     authzRepository: prismaAuthzRepository,
     circleInviteLinkRepository: prismaCircleInviteLinkRepository,
-    passwordUtils: { hash: hashPassword, verify: verifyPassword },
+    passwordHasher: { hash: hashPassword, verify: verifyPassword },
     changePasswordRateLimiter,
     holidayProvider: japaneseHolidayProvider,
     unitOfWork: prismaUnitOfWork,


### PR DESCRIPTION
## Summary

- `PasswordUtils` 型定義を `server/application/user/user-service.ts` から `server/domain/common/password-hasher.ts` に移動
- 型名を `PasswordUtils` → `PasswordHasher`、変数名を `passwordUtils` → `passwordHasher` にリネーム
- HolidayProvider (#736)・RateLimiter (#735) と同一パターンに統一し、infrastructure → application の依存方向違反を解消

Closes #743

## 変更ファイル

| ファイル | 変更内容 |
|---------|---------|
| `server/domain/common/password-hasher.ts` | 新規: ポート定義（JSDoc 付き） |
| `server/application/user/user-service.ts` | `PasswordUtils` 型定義を削除、インポート先を domain に変更 |
| `server/application/auth/signup-service.ts` | インポート先・変数名を変更 |
| `server/infrastructure/service-container.ts` | インポート先・変数名を変更 |
| `server/presentation/trpc/context.ts` | 変数名を変更 |
| `app/api/auth/signup/route.ts` | 変数名を変更 |
| テストファイル 3件 | 型名・変数名を変更 |

## Test plan

- [x] `npx tsc --noEmit` パス
- [x] `npm run test:run` 全テスト通過（30 tests）
- [x] `grep -r "PasswordUtils\|passwordUtils"` → 0 hits（旧名称の完全除去を確認）
- [x] 依存方向: 全インポートが domain ← application ← infrastructure の内側方向

🤖 Generated with [Claude Code](https://claude.com/claude-code)