### PR TITLE
test: Auth / User サービス層テストを古典学派スタイルに移行する (#729)

### DIFF
--- a/server/application/auth/signup-service.test.ts
+++ b/server/application/auth/signup-service.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, test, vi } from "vitest";
-import type { UserRepository } from "@/server/domain/models/user/user-repository";
-import { userId } from "@/server/domain/common/ids";
+import { createInMemoryUserRepository } from "@/server/infrastructure/repository/in-memory";
+import type { UserStore } from "@/server/infrastructure/repository/in-memory/in-memory-user-repository";
 import { ConflictError } from "@/server/domain/common/errors";
 import {
   createSignupService,
@@ -15,35 +15,28 @@ const validInput = {
 };
 
 const createDeps = (
-  repoOverrides?: Partial<UserRepository>,
-): SignupServiceDeps => ({
-  userRepository: {
-    emailExists: vi.fn().mockResolvedValue(false),
-    createUser: vi.fn().mockResolvedValue(userId("new-user-id")),
-    findById: vi.fn(),
-    findByIds: vi.fn(),
-    findByEmail: vi.fn(),
-    save: vi.fn(),
-    updateProfile: vi.fn(),
-    findPasswordHashById: vi.fn(),
-    findPasswordChangedAt: vi.fn(),
-    updatePasswordHash: vi.fn(),
-    updateProfileVisibility: vi.fn(),
-    ...repoOverrides,
-  },
-  passwordHasher: {
-    hash: vi.fn().mockReturnValue("hashed-password"),
-    verify: vi.fn(),
-  },
-});
+  userStore: UserStore = new Map(),
+): { deps: SignupServiceDeps; userStore: UserStore } => {
+  const userRepository = createInMemoryUserRepository(userStore);
+  return {
+    deps: {
+      userRepository,
+      passwordHasher: {
+        hash: vi.fn().mockReturnValue("hashed-password"),
+        verify: vi.fn(),
+      },
+    },
+    userStore,
+  };
+};
 
 describe("SignupService", () => {
   test("createUser が ConflictError をスローした場合 email_exists を返す", async () => {
-    const deps = createDeps({
-      createUser: vi
-        .fn()
-        .mockRejectedValue(new ConflictError("User already exists")),
-    });
+    const { deps } = createDeps();
+    // createUser を差し替えてレースコンディション（emailExists通過後のConflictError）を再現
+    deps.userRepository.createUser = async () => {
+      throw new ConflictError("User already exists");
+    };
     const service = createSignupService(deps);
 
     const result = await service.signup(validInput);
@@ -52,71 +45,81 @@ describe("SignupService", () => {
   });
 
   test("agreedToTerms が false の場合 terms_not_agreed を返す", async () => {
-    const deps = createDeps();
+    const { deps, userStore } = createDeps();
     const service = createSignupService(deps);
 
     const result = await service.signup({ ...validInput, agreedToTerms: false });
 
     expect(result).toEqual({ success: false, error: "terms_not_agreed" });
-    expect(deps.userRepository.emailExists).not.toHaveBeenCalled();
+    expect(userStore.size).toBe(0);
   });
 
   test("パスワードが128文字を超える場合 password_too_long を返す", async () => {
-    const deps = createDeps();
+    const { deps, userStore } = createDeps();
     const service = createSignupService(deps);
     const longPassword = "a".repeat(129);
 
-    const result = await service.signup({ ...validInput, password: longPassword });
+    const result = await service.signup({
+      ...validInput,
+      password: longPassword,
+    });
 
     expect(result).toEqual({ success: false, error: "password_too_long" });
-    expect(deps.userRepository.emailExists).not.toHaveBeenCalled();
+    expect(userStore.size).toBe(0);
   });
 
   test("パスワードが128文字の場合は許可される", async () => {
-    const deps = createDeps();
+    const { deps, userStore } = createDeps();
     const service = createSignupService(deps);
     const maxPassword = "a".repeat(128);
 
-    const result = await service.signup({ ...validInput, password: maxPassword });
+    const result = await service.signup({
+      ...validInput,
+      password: maxPassword,
+    });
 
-    expect(result).toEqual({ success: true, userId: userId("new-user-id") });
+    expect(result).toEqual({ success: true, userId: expect.any(String) });
+    expect(userStore.size).toBe(1);
   });
 
   test("名前が50文字を超える場合 name_too_long を返す", async () => {
-    const deps = createDeps();
+    const { deps, userStore } = createDeps();
     const service = createSignupService(deps);
     const longName = "あ".repeat(51);
 
     const result = await service.signup({ ...validInput, name: longName });
 
     expect(result).toEqual({ success: false, error: "name_too_long" });
-    expect(deps.userRepository.emailExists).not.toHaveBeenCalled();
+    expect(userStore.size).toBe(0);
   });
 
   test("名前が50文字の場合は許可される", async () => {
-    const deps = createDeps();
+    const { deps, userStore } = createDeps();
     const service = createSignupService(deps);
     const maxName = "あ".repeat(50);
 
     const result = await service.signup({ ...validInput, name: maxName });
 
-    expect(result).toEqual({ success: true, userId: userId("new-user-id") });
+    expect(result).toEqual({ success: true, userId: expect.any(String) });
+    expect(userStore.size).toBe(1);
   });
 
   test("名前がnullの場合は name_too_long チェックをスキップする", async () => {
-    const deps = createDeps();
+    const { deps, userStore } = createDeps();
     const service = createSignupService(deps);
 
     const result = await service.signup({ ...validInput, name: null });
 
-    expect(result).toEqual({ success: true, userId: userId("new-user-id") });
+    expect(result).toEqual({ success: true, userId: expect.any(String) });
+    expect(userStore.size).toBe(1);
   });
 
   test("createUser が ConflictError 以外をスローした場合はそのまま伝播する", async () => {
+    const { deps } = createDeps();
     const otherError = new Error("Database connection failed");
-    const deps = createDeps({
-      createUser: vi.fn().mockRejectedValue(otherError),
-    });
+    deps.userRepository.createUser = async () => {
+      throw otherError;
+    };
     const service = createSignupService(deps);
 
     await expect(service.signup(validInput)).rejects.toThrow(otherError);

--- a/server/application/authz/access-service.test.ts
+++ b/server/application/authz/access-service.test.ts
@@ -1,8 +1,11 @@
 import { createAccessService } from "@/server/application/authz/access-service";
 import {
-  createMockAuthzRepository,
-  createMockUserRepository,
-} from "@/server/application/test-helpers/mock-repositories";
+  createInMemoryAuthzRepository,
+  createInMemoryUserRepository,
+} from "@/server/infrastructure/repository/in-memory";
+import type { UserStore } from "@/server/infrastructure/repository/in-memory/in-memory-user-repository";
+import type { CircleMembershipStore } from "@/server/infrastructure/repository/in-memory/in-memory-circle-repository";
+import type { CircleSessionMembershipStore } from "@/server/infrastructure/repository/in-memory/in-memory-circle-session-repository";
 import type {
   CircleMembershipStatus,
   CircleSessionMembershipStatus,
@@ -15,31 +18,84 @@ import {
 } from "@/server/domain/services/authz/memberships";
 import type { CircleRole } from "@/server/domain/models/circle/circle-role";
 import type { CircleSessionRole } from "@/server/domain/models/circle-session/circle-session-role";
-import { beforeEach, describe, expect, test, vi } from "vitest";
-import { userId as userIdBrand } from "@/server/domain/common/ids";
+import { beforeEach, describe, expect, test } from "vitest";
 import {
-  createUser,
-  ProfileVisibility,
-} from "@/server/domain/models/user/user";
+  userId as toUserId,
+  circleId as toCircleId,
+  circleSessionId as toCircleSessionId,
+} from "@/server/domain/common/ids";
+import { ProfileVisibility } from "@/server/domain/models/user/user";
 
 const userId = "user-1";
 const targetUserId = "user-2";
 const circleId = "circle-1";
 const circleSessionId = "circle-session-1";
 
-const repository = createMockAuthzRepository();
-const userRepository = createMockUserRepository();
+const userStore: UserStore = new Map();
+const circleMembershipStore: CircleMembershipStore = new Map();
+const circleSessionMembershipStore: CircleSessionMembershipStore = new Map();
+
+const repository = createInMemoryAuthzRepository({
+  userStore,
+  circleMembershipStore,
+  circleSessionMembershipStore,
+});
+
+const userRepository = createInMemoryUserRepository(userStore);
 
 const access = createAccessService({
   authzRepository: repository,
   userRepository,
 });
 
-const mockedIsRegisteredUser = vi.mocked(repository.isRegisteredUser);
-const mockedFindCircleMembership = vi.mocked(repository.findCircleMembership);
-const mockedFindCircleSessionMembership = vi.mocked(
-  repository.findCircleSessionMembership,
-);
+const addUser = (id: string) => {
+  userStore.set(id, {
+    id: toUserId(id),
+    name: "test",
+    email: `${id}@test.com`,
+    image: null,
+    profileVisibility: "PUBLIC",
+    createdAt: new Date(),
+    passwordHash: null,
+    passwordChangedAt: null,
+  });
+};
+
+const addCircleMembership = (
+  memberUserId: string,
+  role: CircleRole,
+  cId: string = circleId,
+) => {
+  const existing = circleMembershipStore.get(cId) ?? [];
+  circleMembershipStore.set(cId, [
+    ...existing,
+    {
+      circleId: toCircleId(cId),
+      userId: toUserId(memberUserId),
+      role,
+      createdAt: new Date(),
+      deletedAt: null,
+    },
+  ]);
+};
+
+const addCircleSessionMembership = (
+  memberUserId: string,
+  role: CircleSessionRole,
+  csId: string = circleSessionId,
+) => {
+  const existing = circleSessionMembershipStore.get(csId) ?? [];
+  circleSessionMembershipStore.set(csId, [
+    ...existing,
+    {
+      circleSessionId: toCircleSessionId(csId),
+      userId: toUserId(memberUserId),
+      role,
+      createdAt: new Date(),
+      deletedAt: null,
+    },
+  ]);
+};
 
 const member = (role: CircleRole): CircleMembershipStatus =>
   circleMembershipStatus(role);
@@ -51,42 +107,47 @@ const noSessionMember = (): CircleSessionMembershipStatus =>
   noCircleSessionMembershipStatus();
 
 const setCircleMembership = (membership: CircleMembershipStatus) => {
-  mockedFindCircleMembership.mockResolvedValue(membership);
+  if (membership.kind === "member") {
+    addCircleMembership(userId, membership.role);
+  }
 };
 
 const setCircleMemberships = (
   actorMembership: CircleMembershipStatus,
   targetMembership: CircleMembershipStatus,
 ) => {
-  mockedFindCircleMembership.mockImplementation(
-    async (requestedUserId: string) =>
-      requestedUserId === userId ? actorMembership : targetMembership,
-  );
+  if (actorMembership.kind === "member") {
+    addCircleMembership(userId, actorMembership.role);
+  }
+  if (targetMembership.kind === "member") {
+    addCircleMembership(targetUserId, targetMembership.role);
+  }
 };
 
 const setCircleSessionMembership = (
   membership: CircleSessionMembershipStatus,
 ) => {
-  mockedFindCircleSessionMembership.mockResolvedValue(membership);
+  if (membership.kind === "member") {
+    addCircleSessionMembership(userId, membership.role);
+  }
 };
 
 const setCircleSessionMemberships = (
   actorMembership: CircleSessionMembershipStatus,
   targetMembership: CircleSessionMembershipStatus,
 ) => {
-  mockedFindCircleSessionMembership.mockImplementation(
-    async (requestedUserId: string) =>
-      requestedUserId === userId ? actorMembership : targetMembership,
-  );
+  if (actorMembership.kind === "member") {
+    addCircleSessionMembership(userId, actorMembership.role);
+  }
+  if (targetMembership.kind === "member") {
+    addCircleSessionMembership(targetUserId, targetMembership.role);
+  }
 };
 
 beforeEach(() => {
-  vi.clearAllMocks();
-  mockedIsRegisteredUser.mockResolvedValue(false);
-  mockedFindCircleMembership.mockResolvedValue(noCircleMembershipStatus());
-  mockedFindCircleSessionMembership.mockResolvedValue(
-    noCircleSessionMembershipStatus(),
-  );
+  userStore.clear();
+  circleMembershipStore.clear();
+  circleSessionMembershipStore.clear();
 });
 
 describe("認可ポリシー", () => {
@@ -96,7 +157,9 @@ describe("認可ポリシー", () => {
         { isRegisteredUser: true, expected: true },
         { isRegisteredUser: false, expected: false },
       ])("登録済み=$isRegisteredUser", async (item) => {
-        mockedIsRegisteredUser.mockResolvedValueOnce(item.isRegisteredUser);
+        if (item.isRegisteredUser) {
+          addUser(userId);
+        }
         await expect(access.canCreateCircle(userId)).resolves.toBe(
           item.expected,
         );
@@ -108,7 +171,9 @@ describe("認可ポリシー", () => {
         { isRegisteredUser: true, expected: true },
         { isRegisteredUser: false, expected: false },
       ])("登録済み=$isRegisteredUser", async (item) => {
-        mockedIsRegisteredUser.mockResolvedValueOnce(item.isRegisteredUser);
+        if (item.isRegisteredUser) {
+          addUser(userId);
+        }
         await expect(access.canListOwnCircles(userId)).resolves.toBe(
           item.expected,
         );
@@ -120,7 +185,9 @@ describe("認可ポリシー", () => {
         { isRegisteredUser: true, expected: true },
         { isRegisteredUser: false, expected: false },
       ])("登録済み=$isRegisteredUser", async (item) => {
-        mockedIsRegisteredUser.mockResolvedValueOnce(item.isRegisteredUser);
+        if (item.isRegisteredUser) {
+          addUser(userId);
+        }
         await expect(access.canViewUser(userId)).resolves.toBe(item.expected);
       });
     });
@@ -546,13 +613,12 @@ describe("認可ポリシー", () => {
         ).resolves.toBe(item.expected);
       });
     });
-
   });
 
   describe("プロフィール公開設定", () => {
     describe("canViewUserProfile（プロフィール統計閲覧）", () => {
-      const actorId = userIdBrand("user-1");
-      const targetId = userIdBrand("user-2");
+      const actorId = toUserId("user-1");
+      const targetId = toUserId("user-2");
 
       test("自分自身のプロフィールは常に閲覧可能", async () => {
         await expect(access.canViewUserProfile(actorId, actorId)).resolves.toBe(
@@ -561,31 +627,38 @@ describe("認可ポリシー", () => {
       });
 
       test("他者のPUBLICプロフィールは閲覧可能", async () => {
-        userRepository.findById.mockResolvedValue(
-          createUser({
-            id: targetId,
-            profileVisibility: ProfileVisibility.PUBLIC,
-          }),
-        );
+        userStore.set(targetId, {
+          id: targetId,
+          name: null,
+          email: null,
+          image: null,
+          profileVisibility: ProfileVisibility.PUBLIC,
+          createdAt: new Date(),
+          passwordHash: null,
+          passwordChangedAt: null,
+        });
         await expect(
           access.canViewUserProfile(actorId, targetId),
         ).resolves.toBe(true);
       });
 
       test("他者のPRIVATEプロフィールは閲覧不可", async () => {
-        userRepository.findById.mockResolvedValue(
-          createUser({
-            id: targetId,
-            profileVisibility: ProfileVisibility.PRIVATE,
-          }),
-        );
+        userStore.set(targetId, {
+          id: targetId,
+          name: null,
+          email: null,
+          image: null,
+          profileVisibility: ProfileVisibility.PRIVATE,
+          createdAt: new Date(),
+          passwordHash: null,
+          passwordChangedAt: null,
+        });
         await expect(
           access.canViewUserProfile(actorId, targetId),
         ).resolves.toBe(false);
       });
 
       test("対象ユーザーが存在しない場合は閲覧不可", async () => {
-        userRepository.findById.mockResolvedValue(null);
         await expect(
           access.canViewUserProfile(actorId, targetId),
         ).resolves.toBe(false);

--- a/server/application/user/user-service.test.ts
+++ b/server/application/user/user-service.test.ts
@@ -1,7 +1,8 @@
 import { beforeEach, describe, expect, test, vi } from "vitest";
 import { createUserService } from "@/server/application/user/user-service";
 import { createAccessServiceStub } from "@/server/application/test-helpers/access-service-stub";
-import { createMockUserRepository } from "@/server/application/test-helpers/mock-repositories";
+import { createInMemoryUserRepository } from "@/server/infrastructure/repository/in-memory";
+import type { UserStore } from "@/server/infrastructure/repository/in-memory/in-memory-user-repository";
 import type { PasswordHasher } from "@/server/domain/common/password-hasher";
 import type { RateLimiter } from "@/server/domain/common/rate-limiter";
 import { userId } from "@/server/domain/common/ids";
@@ -11,7 +12,8 @@ import {
 } from "@/server/domain/models/user/user";
 import { TooManyRequestsError } from "@/server/domain/common/errors";
 
-const userRepository = createMockUserRepository();
+const userStore: UserStore = new Map();
+const userRepository = createInMemoryUserRepository(userStore);
 
 const accessService = createAccessServiceStub();
 
@@ -41,14 +43,22 @@ const testUser = createUser({
   createdAt: new Date("2024-01-01"),
 });
 
+const addTestUser = (passwordHash: string | null = null) => {
+  userStore.set(actorId, {
+    ...testUser,
+    passwordHash,
+    passwordChangedAt: null,
+  });
+};
+
 beforeEach(() => {
+  userStore.clear();
   vi.clearAllMocks();
 });
 
 describe("getMe", () => {
   test("ユーザー情報とhasPasswordを返す", async () => {
-    userRepository.findById.mockResolvedValue(testUser);
-    userRepository.findPasswordHashById.mockResolvedValue("hashed:pass");
+    addTestUser("hashed:pass");
 
     const result = await service.getMe(actorId);
 
@@ -57,8 +67,7 @@ describe("getMe", () => {
   });
 
   test("パスワード未設定の場合 hasPassword=false", async () => {
-    userRepository.findById.mockResolvedValue(testUser);
-    userRepository.findPasswordHashById.mockResolvedValue(null);
+    addTestUser(null);
 
     const result = await service.getMe(actorId);
 
@@ -66,92 +75,88 @@ describe("getMe", () => {
   });
 
   test("ユーザーが存在しない場合 Forbidden エラー", async () => {
-    userRepository.findById.mockResolvedValue(null);
-
     await expect(service.getMe(actorId)).rejects.toThrow("Forbidden");
   });
 });
 
 describe("updateProfile", () => {
   test("プロフィールを更新する", async () => {
-    userRepository.findById.mockResolvedValue(testUser);
-    userRepository.findPasswordHashById.mockResolvedValue("hashed:pass");
-    userRepository.emailExists.mockResolvedValue(false);
+    addTestUser("hashed:pass");
 
     await service.updateProfile(actorId, "NewName", "new@example.com");
 
-    expect(userRepository.updateProfile).toHaveBeenCalledWith(
-      actorId,
-      "NewName",
-      "new@example.com",
-    );
+    const stored = userStore.get(actorId);
+    expect(stored?.name).toBe("NewName");
+    expect(stored?.email).toBe("new@example.com");
   });
 
   test("メールがnullの場合はメール重複チェックをスキップ", async () => {
-    userRepository.findById.mockResolvedValue(testUser);
+    addTestUser();
 
     await service.updateProfile(actorId, "NewName", null);
 
-    expect(userRepository.emailExists).not.toHaveBeenCalled();
-    expect(userRepository.updateProfile).toHaveBeenCalledWith(
-      actorId,
-      "NewName",
-      null,
-    );
+    const stored = userStore.get(actorId);
+    expect(stored?.name).toBe("NewName");
+    expect(stored?.email).toBeNull();
   });
 
   test("メール重複時に BadRequest エラー", async () => {
-    userRepository.findById.mockResolvedValue(testUser);
-    userRepository.findPasswordHashById.mockResolvedValue("hashed:pass");
-    userRepository.emailExists.mockResolvedValue(true);
+    addTestUser("hashed:pass");
+    // 別のユーザーが同じメールを使用中
+    userStore.set("other-user", {
+      id: userId("other-user"),
+      name: "Other",
+      email: "taken@example.com",
+      image: null,
+      profileVisibility: "PUBLIC",
+      createdAt: new Date(),
+      passwordHash: null,
+      passwordChangedAt: null,
+    });
 
     await expect(
       service.updateProfile(actorId, "NewName", "taken@example.com"),
     ).rejects.toThrow("Email already in use");
 
-    expect(userRepository.updateProfile).not.toHaveBeenCalled();
+    // ストアが変更されていないことを検証
+    const stored = userStore.get(actorId);
+    expect(stored?.name).toBe("Taro");
+    expect(stored?.email).toBe("taro@example.com");
   });
 
   test("name=null, email=null の場合はメール重複チェックをスキップして更新する", async () => {
-    userRepository.findById.mockResolvedValue(testUser);
+    addTestUser();
 
     await service.updateProfile(actorId, null, null);
 
-    expect(userRepository.emailExists).not.toHaveBeenCalled();
-    expect(userRepository.updateProfile).toHaveBeenCalledWith(
-      actorId,
-      null,
-      null,
-    );
+    const stored = userStore.get(actorId);
+    expect(stored?.name).toBeNull();
+    expect(stored?.email).toBeNull();
   });
 
   test("OAuthユーザーでもメールがnullなら名前のみ更新できる", async () => {
-    userRepository.findById.mockResolvedValue(testUser);
+    addTestUser(null);
 
     await service.updateProfile(actorId, "NewName", null);
 
-    expect(userRepository.findPasswordHashById).not.toHaveBeenCalled();
-    expect(userRepository.updateProfile).toHaveBeenCalledWith(
-      actorId,
-      "NewName",
-      null,
-    );
+    const stored = userStore.get(actorId);
+    expect(stored?.name).toBe("NewName");
   });
 
   test("OAuthユーザー（パスワード未設定）がメール変更を試みた場合 BadRequest エラー", async () => {
-    userRepository.findById.mockResolvedValue(testUser);
-    userRepository.findPasswordHashById.mockResolvedValue(null);
+    addTestUser(null);
 
     await expect(
       service.updateProfile(actorId, "NewName", "new@example.com"),
     ).rejects.toThrow("OAuth users cannot change email");
 
-    expect(userRepository.updateProfile).not.toHaveBeenCalled();
+    // ストアが変更されていないことを検証
+    const stored = userStore.get(actorId);
+    expect(stored?.name).toBe("Taro");
+    expect(stored?.email).toBe("taro@example.com");
   });
 
   test("ユーザーが存在しない場合 Forbidden エラー", async () => {
-    userRepository.findById.mockResolvedValue(null);
-
     await expect(
       service.updateProfile(actorId, "Name", "email@example.com"),
     ).rejects.toThrow("Forbidden");
@@ -160,81 +165,88 @@ describe("updateProfile", () => {
 
 describe("changePassword", () => {
   test("パスワードを変更する", async () => {
-    userRepository.findPasswordHashById.mockResolvedValue("hashed:oldpass");
+    addTestUser("hashed:oldpass");
 
     await service.changePassword(actorId, "oldpass", "newpass12");
 
-    expect(userRepository.updatePasswordHash).toHaveBeenCalledWith(
-      actorId,
-      "hashed:newpass12",
-      expect.any(Date),
-    );
+    const stored = userStore.get(actorId);
+    expect(stored?.passwordHash).toBe("hashed:newpass12");
+    expect(stored?.passwordChangedAt).toBeInstanceOf(Date);
   });
 
   test("現在のパスワードが不一致の場合 BadRequest エラー", async () => {
-    userRepository.findPasswordHashById.mockResolvedValue("hashed:correct");
+    addTestUser("hashed:correct");
 
     await expect(
       service.changePassword(actorId, "wrong", "newpass12"),
     ).rejects.toThrow("Current password is incorrect");
 
-    expect(userRepository.updatePasswordHash).not.toHaveBeenCalled();
+    // パスワードが変更されていないことを検証
+    const stored = userStore.get(actorId);
+    expect(stored?.passwordHash).toBe("hashed:correct");
   });
 
   test("新パスワードが短い場合 BadRequest エラー", async () => {
-    userRepository.findPasswordHashById.mockResolvedValue("hashed:oldpass");
+    addTestUser("hashed:oldpass");
 
     await expect(
       service.changePassword(actorId, "oldpass", "short"),
     ).rejects.toThrow("Password too short");
 
-    expect(userRepository.updatePasswordHash).not.toHaveBeenCalled();
+    const stored = userStore.get(actorId);
+    expect(stored?.passwordHash).toBe("hashed:oldpass");
   });
 
   test("新パスワードが128文字の場合は許可される", async () => {
-    userRepository.findPasswordHashById.mockResolvedValue("hashed:oldpass");
+    addTestUser("hashed:oldpass");
     const maxPassword = "a".repeat(128);
 
     await service.changePassword(actorId, "oldpass", maxPassword);
 
-    expect(userRepository.updatePasswordHash).toHaveBeenCalled();
+    const stored = userStore.get(actorId);
+    expect(stored?.passwordHash).toBe(`hashed:${maxPassword}`);
   });
 
   test("新パスワードが128文字を超える場合 BadRequest エラー", async () => {
-    userRepository.findPasswordHashById.mockResolvedValue("hashed:oldpass");
+    addTestUser("hashed:oldpass");
     const longPassword = "a".repeat(129);
 
     await expect(
       service.changePassword(actorId, "oldpass", longPassword),
     ).rejects.toThrow("Password too long");
 
-    expect(userRepository.updatePasswordHash).not.toHaveBeenCalled();
+    const stored = userStore.get(actorId);
+    expect(stored?.passwordHash).toBe("hashed:oldpass");
   });
 
   test("OAuthユーザー（パスワード未設定）の場合 BadRequest エラー", async () => {
-    userRepository.findPasswordHashById.mockResolvedValue(null);
+    addTestUser(null);
 
     await expect(
       service.changePassword(actorId, "any", "newpass12"),
     ).rejects.toThrow("Password login is not enabled");
 
-    expect(userRepository.updatePasswordHash).not.toHaveBeenCalled();
+    const stored = userStore.get(actorId);
+    expect(stored?.passwordHash).toBeNull();
   });
 
   test("レート制限超過時に TooManyRequestsError", async () => {
     vi.mocked(changePasswordRateLimiter.check).mockImplementationOnce(() => {
       throw new TooManyRequestsError(50_000);
     });
+    addTestUser("hashed:oldpass");
 
     await expect(
       service.changePassword(actorId, "oldpass", "newpass12"),
     ).rejects.toThrow(TooManyRequestsError);
 
-    expect(userRepository.findPasswordHashById).not.toHaveBeenCalled();
+    // パスワードが変更されていないことを検証
+    const stored = userStore.get(actorId);
+    expect(stored?.passwordHash).toBe("hashed:oldpass");
   });
 
   test("パスワード不一致時に recordFailure が呼ばれる", async () => {
-    userRepository.findPasswordHashById.mockResolvedValue("hashed:correct");
+    addTestUser("hashed:correct");
 
     await expect(
       service.changePassword(actorId, "wrong", "newpass12"),
@@ -246,7 +258,7 @@ describe("changePassword", () => {
   });
 
   test("パスワード変更成功時に reset が呼ばれる", async () => {
-    userRepository.findPasswordHashById.mockResolvedValue("hashed:oldpass");
+    addTestUser("hashed:oldpass");
 
     await service.changePassword(actorId, "oldpass", "newpass12");
 
@@ -256,19 +268,15 @@ describe("changePassword", () => {
 
 describe("updateProfileVisibility", () => {
   test("プロフィール公開設定を更新する", async () => {
-    userRepository.findById.mockResolvedValue(testUser);
+    addTestUser();
 
     await service.updateProfileVisibility(actorId, ProfileVisibility.PRIVATE);
 
-    expect(userRepository.updateProfileVisibility).toHaveBeenCalledWith(
-      actorId,
-      ProfileVisibility.PRIVATE,
-    );
+    const stored = userStore.get(actorId);
+    expect(stored?.profileVisibility).toBe(ProfileVisibility.PRIVATE);
   });
 
   test("ユーザーが存在しない場合 Forbidden エラー", async () => {
-    userRepository.findById.mockResolvedValue(null);
-
     await expect(
       service.updateProfileVisibility(actorId, ProfileVisibility.PRIVATE),
     ).rejects.toThrow("Forbidden");

--- a/server/application/user/user-statistics-service.test.ts
+++ b/server/application/user/user-statistics-service.test.ts
@@ -1,21 +1,31 @@
-import { beforeEach, describe, expect, test, vi } from "vitest";
+import { beforeEach, describe, expect, test } from "vitest";
 import { createUserStatisticsService } from "@/server/application/user/user-statistics-service";
 import {
-  createMockMatchRepository,
-  createMockUserRepository,
-} from "@/server/application/test-helpers/mock-repositories";
+  createInMemoryMatchRepository,
+  createInMemoryUserRepository,
+} from "@/server/infrastructure/repository/in-memory";
+import type { UserStore } from "@/server/infrastructure/repository/in-memory/in-memory-user-repository";
+import type { MatchStore } from "@/server/infrastructure/repository/in-memory/in-memory-match-repository";
+import type { CircleStore } from "@/server/infrastructure/repository/in-memory/in-memory-circle-repository";
+import type { CircleSessionStore } from "@/server/infrastructure/repository/in-memory/in-memory-circle-session-repository";
 import {
   circleId,
   circleSessionId,
   matchId,
   userId,
 } from "@/server/domain/common/ids";
-import type { MatchOutcome, Match } from "@/server/domain/models/match/match";
-import type { MatchWithCircle } from "@/server/domain/models/match/match-read-models";
+import type { MatchOutcome } from "@/server/domain/models/match/match";
 
-const matchRepository = createMockMatchRepository();
+const matchStore: MatchStore = new Map();
+const circleSessionStore: CircleSessionStore = new Map();
+const circleStore: CircleStore = new Map();
+const userStore: UserStore = new Map();
 
-const userRepository = createMockUserRepository();
+const matchRepository = createInMemoryMatchRepository(matchStore, {
+  circleSessionStore,
+  circleStore,
+});
+const userRepository = createInMemoryUserRepository(userStore);
 
 const service = createUserStatisticsService({
   matchRepository,
@@ -30,23 +40,28 @@ const CIRCLE_B = circleId("circle-b");
 
 const OPPONENT_B = userId("opponent-b");
 
-const createTestMatch = (
-  overrides: Partial<{
-    player1Id: ReturnType<typeof userId>;
-    player2Id: ReturnType<typeof userId>;
-    outcome: MatchOutcome;
-  }> = {},
-): Match => ({
-  id: matchId(`match-${Math.random()}`),
-  circleSessionId: circleSessionId("session-1"),
-  createdAt: new Date(),
-  player1Id: overrides.player1Id ?? TARGET_USER,
-  player2Id: overrides.player2Id ?? OPPONENT,
-  outcome: overrides.outcome ?? "UNKNOWN",
-  deletedAt: null,
-});
+let matchCounter = 0;
 
-const createTestMatchWithCircle = (
+const ensureCircle = (cId: ReturnType<typeof circleId>, name: string) => {
+  if (!circleStore.has(cId)) {
+    circleStore.set(cId, { id: cId, name, createdAt: new Date() });
+  }
+  const csId = circleSessionId(`session-for-${cId}`);
+  if (!circleSessionStore.has(csId)) {
+    circleSessionStore.set(csId, {
+      id: csId,
+      circleId: cId,
+      title: "Session",
+      startsAt: new Date(),
+      endsAt: new Date(),
+      location: null,
+      note: "",
+      createdAt: new Date(),
+    });
+  }
+};
+
+const addMatchWithCircle = (
   overrides: Partial<{
     player1Id: ReturnType<typeof userId>;
     player2Id: ReturnType<typeof userId>;
@@ -54,43 +69,82 @@ const createTestMatchWithCircle = (
     circleId: ReturnType<typeof circleId>;
     circleName: string;
   }> = {},
-): MatchWithCircle => ({
-  id: matchId(`match-${Math.random()}`),
-  circleSessionId: circleSessionId("session-1"),
-  createdAt: new Date(),
-  player1Id: overrides.player1Id ?? TARGET_USER,
-  player2Id: overrides.player2Id ?? OPPONENT,
-  outcome: overrides.outcome ?? "UNKNOWN",
-  deletedAt: null,
-  circleId: overrides.circleId ?? CIRCLE_A,
-  circleName: overrides.circleName ?? "研究会A",
-});
+) => {
+  const cId = overrides.circleId ?? CIRCLE_A;
+  const cName = overrides.circleName ?? "研究会A";
+  ensureCircle(cId, cName);
+
+  const csId = circleSessionId(`session-for-${cId}`);
+  const mId = matchId(`match-${matchCounter++}`);
+  matchStore.set(mId, {
+    id: mId,
+    circleSessionId: csId,
+    createdAt: new Date(),
+    player1Id: overrides.player1Id ?? TARGET_USER,
+    player2Id: overrides.player2Id ?? OPPONENT,
+    outcome: overrides.outcome ?? "UNKNOWN",
+    deletedAt: null,
+  });
+};
+
+const addMatch = (
+  overrides: Partial<{
+    player1Id: ReturnType<typeof userId>;
+    player2Id: ReturnType<typeof userId>;
+    outcome: MatchOutcome;
+  }> = {},
+) => {
+  const csId = circleSessionId("session-1");
+  if (!circleSessionStore.has(csId)) {
+    const cId = circleId("default-circle");
+    if (!circleStore.has(cId)) {
+      circleStore.set(cId, { id: cId, name: "Default", createdAt: new Date() });
+    }
+    circleSessionStore.set(csId, {
+      id: csId,
+      circleId: cId,
+      title: "Session",
+      startsAt: new Date(),
+      endsAt: new Date(),
+      location: null,
+      note: "",
+      createdAt: new Date(),
+    });
+  }
+  const mId = matchId(`match-${matchCounter++}`);
+  matchStore.set(mId, {
+    id: mId,
+    circleSessionId: csId,
+    createdAt: new Date(),
+    player1Id: overrides.player1Id ?? TARGET_USER,
+    player2Id: overrides.player2Id ?? OPPONENT,
+    outcome: overrides.outcome ?? "UNKNOWN",
+    deletedAt: null,
+  });
+};
 
 describe("UserStatisticsService", () => {
   beforeEach(() => {
-    vi.clearAllMocks();
+    matchStore.clear();
+    circleSessionStore.clear();
+    circleStore.clear();
+    userStore.clear();
+    matchCounter = 0;
   });
 
   describe("getMatchStatisticsAll - total", () => {
     test("対局なしの場合、全て0を返す", async () => {
-      matchRepository.listByPlayerIdWithCircle.mockResolvedValue([]);
-
       const result = await service.getMatchStatisticsAll(TARGET_USER);
 
       expect(result.total).toEqual({ wins: 0, losses: 0, draws: 0 });
-      expect(matchRepository.listByPlayerIdWithCircle).toHaveBeenCalledWith(
-        TARGET_USER,
-      );
     });
 
     test("player1として勝った場合、winsが1増える", async () => {
-      matchRepository.listByPlayerIdWithCircle.mockResolvedValue([
-        createTestMatchWithCircle({
-          player1Id: TARGET_USER,
-          player2Id: OPPONENT,
-          outcome: "P1_WIN",
-        }),
-      ]);
+      addMatchWithCircle({
+        player1Id: TARGET_USER,
+        player2Id: OPPONENT,
+        outcome: "P1_WIN",
+      });
 
       const result = await service.getMatchStatisticsAll(TARGET_USER);
 
@@ -98,13 +152,11 @@ describe("UserStatisticsService", () => {
     });
 
     test("player1として負けた場合、lossesが1増える", async () => {
-      matchRepository.listByPlayerIdWithCircle.mockResolvedValue([
-        createTestMatchWithCircle({
-          player1Id: TARGET_USER,
-          player2Id: OPPONENT,
-          outcome: "P2_WIN",
-        }),
-      ]);
+      addMatchWithCircle({
+        player1Id: TARGET_USER,
+        player2Id: OPPONENT,
+        outcome: "P2_WIN",
+      });
 
       const result = await service.getMatchStatisticsAll(TARGET_USER);
 
@@ -112,13 +164,11 @@ describe("UserStatisticsService", () => {
     });
 
     test("player2として勝った場合、winsが1増える", async () => {
-      matchRepository.listByPlayerIdWithCircle.mockResolvedValue([
-        createTestMatchWithCircle({
-          player1Id: OPPONENT,
-          player2Id: TARGET_USER,
-          outcome: "P2_WIN",
-        }),
-      ]);
+      addMatchWithCircle({
+        player1Id: OPPONENT,
+        player2Id: TARGET_USER,
+        outcome: "P2_WIN",
+      });
 
       const result = await service.getMatchStatisticsAll(TARGET_USER);
 
@@ -126,13 +176,11 @@ describe("UserStatisticsService", () => {
     });
 
     test("player2として負けた場合、lossesが1増える", async () => {
-      matchRepository.listByPlayerIdWithCircle.mockResolvedValue([
-        createTestMatchWithCircle({
-          player1Id: OPPONENT,
-          player2Id: TARGET_USER,
-          outcome: "P1_WIN",
-        }),
-      ]);
+      addMatchWithCircle({
+        player1Id: OPPONENT,
+        player2Id: TARGET_USER,
+        outcome: "P1_WIN",
+      });
 
       const result = await service.getMatchStatisticsAll(TARGET_USER);
 
@@ -140,9 +188,7 @@ describe("UserStatisticsService", () => {
     });
 
     test("引き分けの場合、drawsが1増える", async () => {
-      matchRepository.listByPlayerIdWithCircle.mockResolvedValue([
-        createTestMatchWithCircle({ outcome: "DRAW" }),
-      ]);
+      addMatchWithCircle({ outcome: "DRAW" });
 
       const result = await service.getMatchStatisticsAll(TARGET_USER);
 
@@ -150,9 +196,7 @@ describe("UserStatisticsService", () => {
     });
 
     test("UNKNOWNの対局は集計から除外される", async () => {
-      matchRepository.listByPlayerIdWithCircle.mockResolvedValue([
-        createTestMatchWithCircle({ outcome: "UNKNOWN" }),
-      ]);
+      addMatchWithCircle({ outcome: "UNKNOWN" });
 
       const result = await service.getMatchStatisticsAll(TARGET_USER);
 
@@ -162,30 +206,26 @@ describe("UserStatisticsService", () => {
 
   describe("getMatchStatisticsAll - byCircle", () => {
     test("対局なしの場合、空配列を返す", async () => {
-      matchRepository.listByPlayerIdWithCircle.mockResolvedValue([]);
-
       const result = await service.getMatchStatisticsAll(TARGET_USER);
 
       expect(result.byCircle).toEqual([]);
     });
 
     test("1つの研究会のみの場合、その研究会の統計を返す", async () => {
-      matchRepository.listByPlayerIdWithCircle.mockResolvedValue([
-        createTestMatchWithCircle({
-          player1Id: TARGET_USER,
-          player2Id: OPPONENT,
-          outcome: "P1_WIN",
-          circleId: CIRCLE_A,
-          circleName: "研究会A",
-        }),
-        createTestMatchWithCircle({
-          player1Id: TARGET_USER,
-          player2Id: OPPONENT,
-          outcome: "P2_WIN",
-          circleId: CIRCLE_A,
-          circleName: "研究会A",
-        }),
-      ]);
+      addMatchWithCircle({
+        player1Id: TARGET_USER,
+        player2Id: OPPONENT,
+        outcome: "P1_WIN",
+        circleId: CIRCLE_A,
+        circleName: "研究会A",
+      });
+      addMatchWithCircle({
+        player1Id: TARGET_USER,
+        player2Id: OPPONENT,
+        outcome: "P2_WIN",
+        circleId: CIRCLE_A,
+        circleName: "研究会A",
+      });
 
       const result = await service.getMatchStatisticsAll(TARGET_USER);
 
@@ -201,48 +241,46 @@ describe("UserStatisticsService", () => {
     });
 
     test("複数の研究会にまたがる対局データで正しく集計される", async () => {
-      matchRepository.listByPlayerIdWithCircle.mockResolvedValue([
-        // 研究会A: 勝ち
-        createTestMatchWithCircle({
-          player1Id: TARGET_USER,
-          player2Id: OPPONENT,
-          outcome: "P1_WIN",
-          circleId: CIRCLE_A,
-          circleName: "研究会A",
-        }),
-        // 研究会A: 引き分け
-        createTestMatchWithCircle({
-          player1Id: TARGET_USER,
-          player2Id: OPPONENT,
-          outcome: "DRAW",
-          circleId: CIRCLE_A,
-          circleName: "研究会A",
-        }),
-        // 研究会B: 負け
-        createTestMatchWithCircle({
-          player1Id: TARGET_USER,
-          player2Id: OPPONENT,
-          outcome: "P2_WIN",
-          circleId: CIRCLE_B,
-          circleName: "研究会B",
-        }),
-        // 研究会B: 勝ち
-        createTestMatchWithCircle({
-          player1Id: OPPONENT,
-          player2Id: TARGET_USER,
-          outcome: "P2_WIN",
-          circleId: CIRCLE_B,
-          circleName: "研究会B",
-        }),
-        // 研究会A: UNKNOWN（除外）
-        createTestMatchWithCircle({
-          player1Id: TARGET_USER,
-          player2Id: OPPONENT,
-          outcome: "UNKNOWN",
-          circleId: CIRCLE_A,
-          circleName: "研究会A",
-        }),
-      ]);
+      // 研究会A: 勝ち
+      addMatchWithCircle({
+        player1Id: TARGET_USER,
+        player2Id: OPPONENT,
+        outcome: "P1_WIN",
+        circleId: CIRCLE_A,
+        circleName: "研究会A",
+      });
+      // 研究会A: 引き分け
+      addMatchWithCircle({
+        player1Id: TARGET_USER,
+        player2Id: OPPONENT,
+        outcome: "DRAW",
+        circleId: CIRCLE_A,
+        circleName: "研究会A",
+      });
+      // 研究会B: 負け
+      addMatchWithCircle({
+        player1Id: TARGET_USER,
+        player2Id: OPPONENT,
+        outcome: "P2_WIN",
+        circleId: CIRCLE_B,
+        circleName: "研究会B",
+      });
+      // 研究会B: 勝ち
+      addMatchWithCircle({
+        player1Id: OPPONENT,
+        player2Id: TARGET_USER,
+        outcome: "P2_WIN",
+        circleId: CIRCLE_B,
+        circleName: "研究会B",
+      });
+      // 研究会A: UNKNOWN（除外）
+      addMatchWithCircle({
+        player1Id: TARGET_USER,
+        player2Id: OPPONENT,
+        outcome: "UNKNOWN",
+        circleId: CIRCLE_A,
+        circleName: "研究会A",
+      });
 
       const result = await service.getMatchStatisticsAll(TARGET_USER);
 
@@ -269,24 +307,22 @@ describe("UserStatisticsService", () => {
     test("byCircleはcircleName昇順でソートされる", async () => {
       const CIRCLE_C = circleId("circle-c");
 
-      matchRepository.listByPlayerIdWithCircle.mockResolvedValue([
-        // データは逆順（C → B → A）で登場
-        createTestMatchWithCircle({
-          outcome: "P1_WIN",
-          circleId: CIRCLE_C,
-          circleName: "研究会C",
-        }),
-        createTestMatchWithCircle({
-          outcome: "P1_WIN",
-          circleId: CIRCLE_B,
-          circleName: "研究会B",
-        }),
-        createTestMatchWithCircle({
-          outcome: "P1_WIN",
-          circleId: CIRCLE_A,
-          circleName: "研究会A",
-        }),
-      ]);
+      // データは逆順（C → B → A）で登場
+      addMatchWithCircle({
+        outcome: "P1_WIN",
+        circleId: CIRCLE_C,
+        circleName: "研究会C",
+      });
+      addMatchWithCircle({
+        outcome: "P1_WIN",
+        circleId: CIRCLE_B,
+        circleName: "研究会B",
+      });
+      addMatchWithCircle({
+        outcome: "P1_WIN",
+        circleId: CIRCLE_A,
+        circleName: "研究会A",
+      });
 
       const result = await service.getMatchStatisticsAll(TARGET_USER);
 
@@ -301,40 +337,38 @@ describe("UserStatisticsService", () => {
 
   describe("getMatchStatisticsAll - 統合テスト", () => {
     test("トータルと研究会別が同時に正しく計算される", async () => {
-      matchRepository.listByPlayerIdWithCircle.mockResolvedValue([
-        // 研究会A: 勝ち
-        createTestMatchWithCircle({
-          player1Id: TARGET_USER,
-          player2Id: OPPONENT,
-          outcome: "P1_WIN",
-          circleId: CIRCLE_A,
-          circleName: "研究会A",
-        }),
-        // 研究会B: 負け
-        createTestMatchWithCircle({
-          player1Id: TARGET_USER,
-          player2Id: OPPONENT,
-          outcome: "P2_WIN",
-          circleId: CIRCLE_B,
-          circleName: "研究会B",
-        }),
-        // 研究会A: 引き分け
-        createTestMatchWithCircle({
-          player1Id: TARGET_USER,
-          player2Id: OPPONENT,
-          outcome: "DRAW",
-          circleId: CIRCLE_A,
-          circleName: "研究会A",
-        }),
-        // UNKNOWN（除外）
-        createTestMatchWithCircle({
-          player1Id: TARGET_USER,
-          player2Id: OPPONENT,
-          outcome: "UNKNOWN",
-          circleId: CIRCLE_A,
-          circleName: "研究会A",
-        }),
-      ]);
+      // 研究会A: 勝ち
+      addMatchWithCircle({
+        player1Id: TARGET_USER,
+        player2Id: OPPONENT,
+        outcome: "P1_WIN",
+        circleId: CIRCLE_A,
+        circleName: "研究会A",
+      });
+      // 研究会B: 負け
+      addMatchWithCircle({
+        player1Id: TARGET_USER,
+        player2Id: OPPONENT,
+        outcome: "P2_WIN",
+        circleId: CIRCLE_B,
+        circleName: "研究会B",
+      });
+      // 研究会A: 引き分け
+      addMatchWithCircle({
+        player1Id: TARGET_USER,
+        player2Id: OPPONENT,
+        outcome: "DRAW",
+        circleId: CIRCLE_A,
+        circleName: "研究会A",
+      });
+      // UNKNOWN（除外）
+      addMatchWithCircle({
+        player1Id: TARGET_USER,
+        player2Id: OPPONENT,
+        outcome: "UNKNOWN",
+        circleId: CIRCLE_A,
+        circleName: "研究会A",
+      });
 
       const result = await service.getMatchStatisticsAll(TARGET_USER);
 
@@ -358,43 +392,47 @@ describe("UserStatisticsService", () => {
           draws: 0,
         },
       ]);
-
-      // DBクエリは1回のみ
-      expect(matchRepository.listByPlayerIdWithCircle).toHaveBeenCalledTimes(1);
     });
   });
 
   describe("getOpponents", () => {
     test("対局なしの場合、空配列を返す", async () => {
-      matchRepository.listDistinctOpponentIds.mockResolvedValue([]);
-
       const result = await service.getOpponents(TARGET_USER);
 
       expect(result).toEqual([]);
-      expect(userRepository.findByIds).not.toHaveBeenCalled();
     });
 
     test("対戦相手を名前付きで返す", async () => {
-      matchRepository.listDistinctOpponentIds.mockResolvedValue([
-        OPPONENT,
-        OPPONENT_B,
-      ]);
-      userRepository.findByIds.mockResolvedValue([
-        {
-          id: OPPONENT,
-          name: "対戦相手A",
-          email: null,
-          image: null,
-          createdAt: new Date(),
-        },
-        {
-          id: OPPONENT_B,
-          name: "対戦相手B",
-          email: null,
-          image: null,
-          createdAt: new Date(),
-        },
-      ]);
+      addMatch({
+        player1Id: TARGET_USER,
+        player2Id: OPPONENT,
+        outcome: "P1_WIN",
+      });
+      addMatch({
+        player1Id: TARGET_USER,
+        player2Id: OPPONENT_B,
+        outcome: "P1_WIN",
+      });
+      userStore.set(OPPONENT, {
+        id: OPPONENT,
+        name: "対戦相手A",
+        email: null,
+        image: null,
+        profileVisibility: "PUBLIC",
+        createdAt: new Date(),
+        passwordHash: null,
+        passwordChangedAt: null,
+      });
+      userStore.set(OPPONENT_B, {
+        id: OPPONENT_B,
+        name: "対戦相手B",
+        email: null,
+        image: null,
+        profileVisibility: "PUBLIC",
+        createdAt: new Date(),
+        passwordHash: null,
+        passwordChangedAt: null,
+      });
 
       const result = await service.getOpponents(TARGET_USER);
 
@@ -405,16 +443,21 @@ describe("UserStatisticsService", () => {
     });
 
     test("名前がnullのユーザーは「名前未設定」として返す", async () => {
-      matchRepository.listDistinctOpponentIds.mockResolvedValue([OPPONENT]);
-      userRepository.findByIds.mockResolvedValue([
-        {
-          id: OPPONENT,
-          name: null,
-          email: null,
-          image: null,
-          createdAt: new Date(),
-        },
-      ]);
+      addMatch({
+        player1Id: TARGET_USER,
+        player2Id: OPPONENT,
+        outcome: "P1_WIN",
+      });
+      userStore.set(OPPONENT, {
+        id: OPPONENT,
+        name: null,
+        email: null,
+        image: null,
+        profileVisibility: "PUBLIC",
+        createdAt: new Date(),
+        passwordHash: null,
+        passwordChangedAt: null,
+      });
 
       const result = await service.getOpponents(TARGET_USER);
 
@@ -424,45 +467,37 @@ describe("UserStatisticsService", () => {
 
   describe("getOpponentRecord", () => {
     test("対局なしの場合、全て0を返す", async () => {
-      matchRepository.listByBothPlayerIds.mockResolvedValue([]);
-
       const result = await service.getOpponentRecord(TARGET_USER, OPPONENT);
 
       expect(result).toEqual({ wins: 0, losses: 0, draws: 0 });
-      expect(matchRepository.listByBothPlayerIds).toHaveBeenCalledWith(
-        TARGET_USER,
-        OPPONENT,
-      );
     });
 
     test("勝敗引き分けを正しく集計する", async () => {
-      matchRepository.listByBothPlayerIds.mockResolvedValue([
-        createTestMatch({
-          player1Id: TARGET_USER,
-          player2Id: OPPONENT,
-          outcome: "P1_WIN",
-        }),
-        createTestMatch({
-          player1Id: TARGET_USER,
-          player2Id: OPPONENT,
-          outcome: "P2_WIN",
-        }),
-        createTestMatch({
-          player1Id: OPPONENT,
-          player2Id: TARGET_USER,
-          outcome: "P1_WIN",
-        }),
-        createTestMatch({
-          player1Id: TARGET_USER,
-          player2Id: OPPONENT,
-          outcome: "DRAW",
-        }),
-        createTestMatch({
-          player1Id: TARGET_USER,
-          player2Id: OPPONENT,
-          outcome: "UNKNOWN",
-        }),
-      ]);
+      addMatch({
+        player1Id: TARGET_USER,
+        player2Id: OPPONENT,
+        outcome: "P1_WIN",
+      });
+      addMatch({
+        player1Id: TARGET_USER,
+        player2Id: OPPONENT,
+        outcome: "P2_WIN",
+      });
+      addMatch({
+        player1Id: OPPONENT,
+        player2Id: TARGET_USER,
+        outcome: "P1_WIN",
+      });
+      addMatch({
+        player1Id: TARGET_USER,
+        player2Id: OPPONENT,
+        outcome: "DRAW",
+      });
+      addMatch({
+        player1Id: TARGET_USER,
+        player2Id: OPPONENT,
+        outcome: "UNKNOWN",
+      });
 
       const result = await service.getOpponentRecord(TARGET_USER, OPPONENT);
 


### PR DESCRIPTION
## Summary

- Auth / User ドメインのサービス層テスト4ファイルをモックリポジトリからインメモリリポジトリに移行
- `toHaveBeenCalledWith` による呼び出し検証を、保存後のデータ取得による状態検証に変更
- 外部サービス（PasswordHasher, RateLimiter）のモックは維持

## Changes

| ファイル | テスト数 | 主な変更 |
|---------|---------|---------|
| `signup-service.test.ts` | 8 | InMemoryUserRepository 使用、成功ケースに状態検証追加 |
| `access-service.test.ts` | 79 | 3つのインメモリストアで状態管理、ヘルパー関数でデータセットアップ |
| `user-service.test.ts` | 21 | InMemoryUserRepository 使用、`userStore.get()` で状態検証 |
| `user-statistics-service.test.ts` | 17 | InMemoryMatchRepository 使用、ヘルパー関数でデータセットアップ |

## Test plan

- [x] 対象4ファイル 125テスト全パス
- [x] フルテストスイート 945テスト全パス（リグレッションなし）
- [x] `npx tsc --noEmit` パス
- [ ] リポジトリに対する `toHaveBeenCalled` がゼロであることを確認
- [ ] `session.test.ts` は変更なし（外部サービス依存のため対象外）

Closes #729

🤖 Generated with [Claude Code](https://claude.com/claude-code)