### PR TITLE
test: tRPCルーターテストの toHaveBeenCalledWith 削減 (#730)

### DIFF
--- a/server/presentation/trpc/routers/circle-invite-link.test.ts
+++ b/server/presentation/trpc/routers/circle-invite-link.test.ts
@@ -102,13 +102,6 @@ describe("circleInviteLink tRPC ルーター", () => {
 
     expect(result.token).toBe(TEST_TOKEN_UUID);
     expect(result.circleId).toBe("circle-1");
-    expect(mocks.circleInviteLinkService.createInviteLink).toHaveBeenCalledWith(
-      {
-        actorId: userId("user-1"),
-        circleId: circleId("circle-1"),
-        expiryDays: undefined,
-      },
-    );
   });
 
   test("circles.inviteLinks.getInfo はリンク情報を返す", async () => {
@@ -143,12 +136,6 @@ describe("circleInviteLink tRPC ルーター", () => {
 
     expect(result.circleId).toBe("circle-1");
     expect(result.alreadyMember).toBe(false);
-    expect(mocks.circleInviteLinkService.redeemInviteLink).toHaveBeenCalledWith(
-      {
-        actorId: userId("user-1"),
-        token: TEST_TOKEN_UUID,
-      },
-    );
   });
 
   test("circles.inviteLinks.redeem は既存メンバーの場合 alreadyMember=true", async () => {

--- a/server/presentation/trpc/routers/match.test.ts
+++ b/server/presentation/trpc/routers/match.test.ts
@@ -105,10 +105,6 @@ describe("match tRPC ルーター", () => {
       expect(result[0].id).toBe("match-1");
       expect(result[0].player1Id).toBe("player-1");
       expect(result[0].outcome).toBe("P1_WIN");
-      expect(mocks.matchService.listByCircleSessionId).toHaveBeenCalledWith({
-        actorId: userId("user-1"),
-        circleSessionId: circleSessionId("session-1"),
-      });
     });
 
     test("空配列を返す（対局なし）", async () => {
@@ -159,10 +155,6 @@ describe("match tRPC ルーター", () => {
       expect(result.circleSessionId).toBe("session-1");
       expect(result.player1Id).toBe("player-1");
       expect(result.player2Id).toBe("player-2");
-      expect(mocks.matchService.getMatch).toHaveBeenCalledWith({
-        actorId: userId("user-1"),
-        id: matchId("match-1"),
-      });
     });
 
     test("存在しない対局 → NOT_FOUND", async () => {
@@ -213,15 +205,6 @@ describe("match tRPC ルーター", () => {
 
       expect(result.id).toBe("match-1");
       expect(result.outcome).toBe("P1_WIN");
-      expect(mocks.matchService.recordMatch).toHaveBeenCalledWith(
-        expect.objectContaining({
-          actorId: userId("user-1"),
-          circleSessionId: circleSessionId("session-1"),
-          player1Id: userId("player-1"),
-          player2Id: userId("player-2"),
-          outcome: "P1_WIN",
-        }),
-      );
     });
 
     test("対局を作成できる（outcome なし）", async () => {
@@ -237,11 +220,6 @@ describe("match tRPC ルーター", () => {
       });
 
       expect(result.outcome).toBe("UNKNOWN");
-      expect(mocks.matchService.recordMatch).toHaveBeenCalledWith(
-        expect.objectContaining({
-          outcome: undefined,
-        }),
-      );
     });
 
     test("ForbiddenError → FORBIDDEN", async () => {
@@ -313,13 +291,6 @@ describe("match tRPC ルーター", () => {
 
       expect(result.player1Id).toBe("player-3");
       expect(result.player2Id).toBe("player-4");
-      expect(mocks.matchService.updateMatch).toHaveBeenCalledWith({
-        actorId: userId("user-1"),
-        id: matchId("match-1"),
-        player1Id: userId("player-3"),
-        player2Id: userId("player-4"),
-        outcome: undefined,
-      });
     });
 
     test("対局を更新できる（outcome のみ変更）", async () => {
@@ -334,13 +305,6 @@ describe("match tRPC ルーター", () => {
       });
 
       expect(result.outcome).toBe("DRAW");
-      expect(mocks.matchService.updateMatch).toHaveBeenCalledWith({
-        actorId: userId("user-1"),
-        id: matchId("match-1"),
-        player1Id: undefined,
-        player2Id: undefined,
-        outcome: "DRAW",
-      });
     });
 
     test("ForbiddenError → FORBIDDEN", async () => {
@@ -392,10 +356,6 @@ describe("match tRPC ルーター", () => {
       const result = await caller.matches.delete({ matchId: "match-1" });
 
       expect(result.deletedAt).toEqual(new Date("2024-06-02T00:00:00Z"));
-      expect(mocks.matchService.deleteMatch).toHaveBeenCalledWith({
-        actorId: userId("user-1"),
-        id: matchId("match-1"),
-      });
     });
 
     test("ForbiddenError → FORBIDDEN", async () => {

--- a/server/presentation/trpc/routers/user-circle-membership.test.ts
+++ b/server/presentation/trpc/routers/user-circle-membership.test.ts
@@ -105,12 +105,6 @@ describe("userCircleMembership tRPC ルーター", () => {
       expect(result[0].role).toBe("CircleMember");
       expect(result[1].circleId).toBe("circle-2");
       expect(result[1].role).toBe("CircleOwner");
-      expect(
-        mocks.circleMembershipService.listByUserId,
-      ).toHaveBeenCalledWith({
-        actorId: userId("user-1"),
-        userId: userId("user-1"),
-      });
     });
 
     test("空配列を返す（参加なし）", async () => {

--- a/server/presentation/trpc/routers/user-circle-session-membership.test.ts
+++ b/server/presentation/trpc/routers/user-circle-session-membership.test.ts
@@ -109,13 +109,6 @@ describe("userCircleSessionMembership tRPC ルーター", () => {
       expect(result[0].circleName).toBe("京大将棋研究会");
       expect(result[0].title).toBe("第1回例会");
       expect(result[0].location).toBe("部室");
-      expect(
-        mocks.circleSessionMembershipService.listByUserId,
-      ).toHaveBeenCalledWith({
-        actorId: userId("user-1"),
-        userId: userId("user-1"),
-        limit: 5,
-      });
     });
 
     test("ユーザーのセッション参加一覧を取得できる（limit 省略）", async () => {
@@ -128,13 +121,6 @@ describe("userCircleSessionMembership tRPC ルーター", () => {
       const result = await caller.users.circleSessions.memberships.list({});
 
       expect(result).toHaveLength(1);
-      expect(
-        mocks.circleSessionMembershipService.listByUserId,
-      ).toHaveBeenCalledWith({
-        actorId: userId("user-1"),
-        userId: userId("user-1"),
-        limit: undefined,
-      });
     });
 
     test("空配列を返す（参加なし）", async () => {

--- a/server/presentation/trpc/routers/user.test.ts
+++ b/server/presentation/trpc/routers/user.test.ts
@@ -107,7 +107,6 @@ describe("user tRPC ルーター", () => {
       expect(result.email).toBe("taro@example.com");
       expect(result.hasPassword).toBe(true);
       expect(result.profileVisibility).toBe("PUBLIC");
-      expect(mocks.userService.getMe).toHaveBeenCalledWith(userId("user-1"));
     });
 
     test("ForbiddenError → FORBIDDEN", async () => {
@@ -123,23 +122,6 @@ describe("user tRPC ルーター", () => {
   });
 
   describe("updateProfile", () => {
-    test("正常入力で userService.updateProfile が正しい引数で呼ばれる", async () => {
-      const { context, mocks } = createTestContext();
-      mocks.userService.updateProfile.mockResolvedValueOnce(undefined);
-
-      const caller = appRouter.createCaller(context);
-      await caller.users.updateProfile({
-        name: "NewName",
-        email: "new@example.com",
-      });
-
-      expect(mocks.userService.updateProfile).toHaveBeenCalledWith(
-        userId("user-1"),
-        "NewName",
-        "new@example.com",
-      );
-    });
-
     test("BadRequestError → BAD_REQUEST", async () => {
       const { context, mocks } = createTestContext();
       mocks.userService.updateProfile.mockRejectedValueOnce(
@@ -158,23 +140,6 @@ describe("user tRPC ルーター", () => {
   });
 
   describe("changePassword", () => {
-    test("正常入力で userService.changePassword が正しい引数で呼ばれる", async () => {
-      const { context, mocks } = createTestContext();
-      mocks.userService.changePassword.mockResolvedValueOnce(undefined);
-
-      const caller = appRouter.createCaller(context);
-      await caller.users.changePassword({
-        currentPassword: "oldpass12",
-        newPassword: "newpass12",
-      });
-
-      expect(mocks.userService.changePassword).toHaveBeenCalledWith(
-        userId("user-1"),
-        "oldpass12",
-        "newpass12",
-      );
-    });
-
     test("BadRequestError → BAD_REQUEST", async () => {
       const { context, mocks } = createTestContext();
       mocks.userService.changePassword.mockRejectedValueOnce(
@@ -209,23 +174,6 @@ describe("user tRPC ルーター", () => {
   });
 
   describe("updateProfileVisibility", () => {
-    test("正常入力で userService.updateProfileVisibility が正しい引数で呼ばれる", async () => {
-      const { context, mocks } = createTestContext();
-      mocks.userService.updateProfileVisibility.mockResolvedValueOnce(
-        undefined,
-      );
-
-      const caller = appRouter.createCaller(context);
-      await caller.users.updateProfileVisibility({
-        visibility: "PRIVATE",
-      });
-
-      expect(mocks.userService.updateProfileVisibility).toHaveBeenCalledWith(
-        userId("user-1"),
-        "PRIVATE",
-      );
-    });
-
     test("ForbiddenError → FORBIDDEN", async () => {
       const { context, mocks } = createTestContext();
       mocks.userService.updateProfileVisibility.mockRejectedValueOnce(


### PR DESCRIPTION
## Summary

- tRPCルーターテスト5ファイルから、サービス層への引数検証（`toHaveBeenCalledWith`）を16箇所削除
- ルーター層の責務（入力バリデーション、DTOマッピング、エラーコード変換）のテストは維持
- `not.toHaveBeenCalled()` による否定的アサーション（バリデーション失敗時のサービス未呼び出し検証）も維持

## Changes

| ファイル | 変更内容 |
|---|---|
| `match.test.ts` | `toHaveBeenCalledWith` 7箇所削除（23テスト維持） |
| `user.test.ts` | `toHaveBeenCalledWith` 3箇所＋正常系テスト3件削除（10→7テスト） |
| `circle-invite-link.test.ts` | `toHaveBeenCalledWith` 3箇所削除（6テスト維持） |
| `user-circle-session-membership.test.ts` | `toHaveBeenCalledWith` 2箇所削除（7テスト維持） |
| `user-circle-membership.test.ts` | `toHaveBeenCalledWith` 1箇所削除（4テスト維持） |

## Test plan

- [x] `vitest run` 48テスト全パス
- [x] ESLint エラーなし
- [ ] `toHaveBeenCalledWith` が対象ファイルから除去されていることを確認
- [ ] 残存テストに意味のあるアサーションがあることを確認

Closes #730

🤖 Generated with [Claude Code](https://claude.com/claude-code)