### PR TITLE
test: signup-formテストのfetch引数検証をリダイレクト検証に置き換える (#731)

### DIFF
--- a/app/components/signup-form.test.tsx
+++ b/app/components/signup-form.test.tsx
@@ -1,5 +1,5 @@
 // @vitest-environment jsdom
-import { cleanup, fireEvent, render, screen } from "@testing-library/react";
+import { cleanup, fireEvent, render, screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { afterEach, beforeAll, describe, expect, it, vi } from "vitest";
 import SignupForm from "./signup-form";
@@ -59,10 +59,10 @@ describe("SignupForm 利用規約チェックボックス", () => {
     );
   });
 
-  it("チェックボックスにチェック後、送信するとfetchが呼ばれる", async () => {
-    const fetchSpy = vi
-      .spyOn(globalThis, "fetch")
-      .mockResolvedValue(new Response(JSON.stringify({}), { status: 200 }));
+  it("チェックボックスにチェック後、送信するとリダイレクトする", async () => {
+    vi.spyOn(globalThis, "fetch").mockResolvedValue(
+      new Response(JSON.stringify({}), { status: 200 }),
+    );
     signInMock.mockResolvedValue({ error: null, url: "/home" });
 
     const user = userEvent.setup();
@@ -76,14 +76,9 @@ describe("SignupForm 利用規約チェックボックス", () => {
     });
     await user.click(submitButton);
 
-    expect(screen.queryByText("利用規約に同意してください。")).toBeNull();
-    expect(fetchSpy).toHaveBeenCalledWith(
-      "/api/auth/signup",
-      expect.objectContaining({
-        method: "POST",
-        body: expect.stringContaining('"agreedToTerms":true'),
-      }),
-    );
+    await waitFor(() => {
+      expect(pushMock).toHaveBeenCalledWith("/home");
+    });
   });
 
   it("表示名超過 + パスワード短すぎのとき、表示名超過エラーが優先表示される", async () => {


### PR DESCRIPTION
## Summary

- `signup-form.test.tsx` の `fetchSpy.toHaveBeenCalledWith` による実装詳細検証を、`pushMock.toHaveBeenCalledWith("/home")` によるリダイレクト検証に置き換え
- テスト名を「fetchが呼ばれる」→「リダイレクトする」に変更し、振る舞いベースの命名に統一
- 古典学派のテスト設計方針に沿った改善

Closes #731

## Test plan

- [x] `npm run test:run -- app/components/signup-form.test.tsx` → 6 tests passed
- [x] `npm run test:run` → 942 tests passed / 80 files

## Verification

- `fetchSpy.toHaveBeenCalledWith` が完全に除去されている
- 新しいアサーションが `waitFor` で囲まれ、非同期フローを正しく待機
- `pushMock` は外部ライブラリ（`next/navigation`）のモックであり、プロジェクト内部のモックではないためテスト方針に合致

🤖 Generated with [Claude Code](https://claude.com/claude-code)