### PR TITLE
refactor: サインアップフォームのエラーメッセージを共有定数に抽出する (#722)

### DIFF
--- a/app/components/signup-form-messages.ts
+++ b/app/components/signup-form-messages.ts
@@ -1,0 +1,13 @@
+export const MIN_PASSWORD_LENGTH = 8;
+export const MAX_PASSWORD_LENGTH = 128;
+export const MAX_NAME_LENGTH = 50;
+
+export const SIGNUP_ERROR_MESSAGES = {
+  nameTooLong: `表示名は${MAX_NAME_LENGTH}文字以内で入力してください。`,
+  passwordTooShort: `パスワードは${MIN_PASSWORD_LENGTH}文字以上で入力してください。`,
+  passwordTooLong: `パスワードは${MAX_PASSWORD_LENGTH}文字以内で入力してください。`,
+  passwordMismatch: "パスワードが一致しません。",
+  termsNotAgreed: "利用規約およびプライバシーポリシーに同意してください。",
+  signupFailed: "登録に失敗しました。",
+  loginAfterSignupFailed: "登録は完了しましたが、ログインに失敗しました。",
+} as const;

--- a/app/components/signup-form.test.tsx
+++ b/app/components/signup-form.test.tsx
@@ -3,6 +3,7 @@ import { cleanup, fireEvent, render, screen, waitFor } from "@testing-library/re
 import userEvent from "@testing-library/user-event";
 import { afterEach, beforeAll, describe, expect, it, vi } from "vitest";
 import SignupForm from "./signup-form";
+import { SIGNUP_ERROR_MESSAGES } from "./signup-form-messages";
 
 beforeAll(() => {
   globalThis.ResizeObserver = class {
@@ -55,7 +56,7 @@ describe("SignupForm 利用規約チェックボックス", () => {
     await user.click(submitButton);
 
     expect(screen.getByRole("alert")).toHaveTextContent(
-      "利用規約およびプライバシーポリシーに同意してください。",
+      SIGNUP_ERROR_MESSAGES.termsNotAgreed,
     );
   });
 
@@ -100,7 +101,7 @@ describe("SignupForm 利用規約チェックボックス", () => {
     await user.click(submitButton);
 
     expect(screen.getByRole("alert")).toHaveTextContent(
-      "表示名は50文字以内で入力してください。",
+      SIGNUP_ERROR_MESSAGES.nameTooLong,
     );
   });
 
@@ -120,7 +121,7 @@ describe("SignupForm 利用規約チェックボックス", () => {
     await user.click(submitButton);
 
     expect(screen.getByRole("alert")).toHaveTextContent(
-      "パスワードは8文字以上で入力してください。",
+      SIGNUP_ERROR_MESSAGES.passwordTooShort,
     );
   });
 
@@ -139,7 +140,7 @@ describe("SignupForm 利用規約チェックボックス", () => {
     await user.click(submitButton);
 
     expect(screen.getByRole("alert")).toHaveTextContent(
-      "パスワードが一致しません。",
+      SIGNUP_ERROR_MESSAGES.passwordMismatch,
     );
   });
 

--- a/app/components/signup-form.tsx
+++ b/app/components/signup-form.tsx
@@ -7,10 +7,12 @@ import { sanitizeCallbackUrl } from "@/lib/url";
 import { Button } from "@/components/ui/button";
 import { Checkbox } from "@/components/ui/checkbox";
 import { Input } from "@/components/ui/input";
-
-const MIN_PASSWORD_LENGTH = 8;
-const MAX_PASSWORD_LENGTH = 128;
-const MAX_NAME_LENGTH = 50;
+import {
+  MAX_NAME_LENGTH,
+  MAX_PASSWORD_LENGTH,
+  MIN_PASSWORD_LENGTH,
+  SIGNUP_ERROR_MESSAGES,
+} from "./signup-form-messages";
 
 type SignupFormProps = {
   callbackUrl?: string;
@@ -33,29 +35,23 @@ export default function SignupForm({ callbackUrl }: SignupFormProps) {
     }
 
     if (name.trim().length > MAX_NAME_LENGTH) {
-      setErrorMessage(
-        `表示名は${MAX_NAME_LENGTH}文字以内で入力してください。`,
-      );
+      setErrorMessage(SIGNUP_ERROR_MESSAGES.nameTooLong);
       return;
     }
     if (password.length < MIN_PASSWORD_LENGTH) {
-      setErrorMessage(
-        `パスワードは${MIN_PASSWORD_LENGTH}文字以上で入力してください。`,
-      );
+      setErrorMessage(SIGNUP_ERROR_MESSAGES.passwordTooShort);
       return;
     }
     if (password.length > MAX_PASSWORD_LENGTH) {
-      setErrorMessage(
-        `パスワードは${MAX_PASSWORD_LENGTH}文字以内で入力してください。`,
-      );
+      setErrorMessage(SIGNUP_ERROR_MESSAGES.passwordTooLong);
       return;
     }
     if (password !== passwordConfirm) {
-      setErrorMessage("パスワードが一致しません。");
+      setErrorMessage(SIGNUP_ERROR_MESSAGES.passwordMismatch);
       return;
     }
     if (!agreedToTerms) {
-      setErrorMessage("利用規約およびプライバシーポリシーに同意してください。");
+      setErrorMessage(SIGNUP_ERROR_MESSAGES.termsNotAgreed);
       return;
     }
 
@@ -78,7 +74,7 @@ export default function SignupForm({ callbackUrl }: SignupFormProps) {
         const payload = (await response.json().catch(() => null)) as {
           message?: string;
         } | null;
-        setErrorMessage(payload?.message ?? "登録に失敗しました。");
+        setErrorMessage(payload?.message ?? SIGNUP_ERROR_MESSAGES.signupFailed);
         return;
       }
 
@@ -90,7 +86,7 @@ export default function SignupForm({ callbackUrl }: SignupFormProps) {
       });
 
       if (!result || result.error) {
-        setErrorMessage("登録は完了しましたが、ログインに失敗しました。");
+        setErrorMessage(SIGNUP_ERROR_MESSAGES.loginAfterSignupFailed);
         return;
       }
 


### PR DESCRIPTION
## Summary

- `signup-form.tsx` と `signup-form.test.tsx` にハードコードされていたエラーメッセージ文字列を `signup-form-messages.ts` に共有定数として抽出
- バリデーション定数（`MIN_PASSWORD_LENGTH`, `MAX_PASSWORD_LENGTH`, `MAX_NAME_LENGTH`）も同ファイルに移動
- ソースとテストの両方から同一定数を参照することで、メッセージ変更時の同期漏れを防止

Closes #722

## Test plan

- [x] `npm run test:run -- app/components/signup-form.test.tsx`: 6 tests passed
- [x] `npx tsc --noEmit`: 型エラーなし
- [ ] `/signup` ページでバリデーションエラーが正しく表示されることを確認

## Notes

- フォローアップ issue: #750（未テストのエラーパスにテストを追加）

🤖 Generated with [Claude Code](https://claude.com/claude-code)