### PR TITLE
feat: セッション詳細情報の編集ダイアログを実装する

### DIFF
--- a/app/(authenticated)/circle-sessions/components/circle-session-detail-view.test.tsx
+++ b/app/(authenticated)/circle-sessions/components/circle-session-detail-view.test.tsx
@@ -46,6 +46,15 @@ vi.mock("@/lib/trpc/client", () => ({
           error: null,
         }),
       },
+      update: {
+        useMutation: () => ({
+          mutate: vi.fn(),
+          isPending: false,
+          data: null,
+          error: null,
+          reset: vi.fn(),
+        }),
+      },
     },
     matches: {
       create: {
@@ -102,6 +111,7 @@ function buildDetail(
     endsAtInput: "2025-04-01T18:00",
     viewerRole: "owner",
     canCreateCircleSession: false,
+    canEditCircleSession: false,
     canDeleteCircleSession: false,
     canWithdrawFromCircleSession: false,
     memberships: [],
@@ -403,6 +413,32 @@ describe("CircleSessionDetailView mutation エラーパス", () => {
       expect(toastModule.toast.success).toHaveBeenCalledOnce();
       expect(refreshMock).toHaveBeenCalled();
     });
+  });
+});
+
+describe("CircleSessionDetailView 編集ボタン", () => {
+  it("canEditCircleSession: true の場合、編集ボタンが表示される", () => {
+    render(
+      <CircleSessionDetailView
+        detail={buildDetail({ canEditCircleSession: true })}
+      />,
+    );
+
+    expect(
+      screen.getByRole("button", { name: "セッションを編集" }),
+    ).toBeInTheDocument();
+  });
+
+  it("canEditCircleSession: false の場合、編集ボタンが表示されない", () => {
+    render(
+      <CircleSessionDetailView
+        detail={buildDetail({ canEditCircleSession: false })}
+      />,
+    );
+
+    expect(
+      screen.queryByRole("button", { name: "セッションを編集" }),
+    ).not.toBeInTheDocument();
   });
 });
 

--- a/app/(authenticated)/circle-sessions/components/circle-session-detail-view.tsx
+++ b/app/(authenticated)/circle-sessions/components/circle-session-detail-view.tsx
@@ -16,8 +16,9 @@ import type {
   CircleSessionDetailViewModel,
   CircleSessionRoleKey,
 } from "@/server/presentation/view-models/circle-session-detail";
+import { CircleSessionEditDialog } from "@/app/(authenticated)/circle-sessions/components/circle-session-edit-dialog";
 import { CircleSessionWithdrawButton } from "@/app/(authenticated)/circle-sessions/components/circle-session-withdraw-button";
-import { Copy, Pencil, Trash2 } from "lucide-react";
+import { Copy, Trash2 } from "lucide-react";
 import { useRouter } from "next/navigation";
 import { type FormEvent, useRef, useState } from "react";
 import { toast } from "sonner";
@@ -132,8 +133,6 @@ export function CircleSessionDetailView({
     ? (roleClasses[detail.viewerRole] ??
       "bg-(--brand-ink)/10 text-(--brand-ink)")
     : "bg-(--brand-ink)/10 text-(--brand-ink)";
-  const showMemoEdit =
-    detail.viewerRole === "owner" || detail.viewerRole === "manager";
   const memoText = detail.memoText?.trim() ? detail.memoText : "未設定";
 
   const triggerCellIdRef = useRef<string | null>(null);
@@ -385,23 +384,22 @@ export function CircleSessionDetailView({
               {detail.dateTimeLabel}
               {detail.locationLabel ? ` / ${detail.locationLabel}` : ""}
             </p>
-            <div className="mt-3 flex flex-wrap items-center gap-2 text-xs text-(--brand-ink-muted)">
-              <p>連絡メモ: {memoText}</p>
-              {showMemoEdit ? (
-                <Button
-                  type="button"
-                  variant="ghost"
-                  size="icon-sm"
-                  className="text-(--brand-ink-muted) hover:text-(--brand-ink)"
-                  aria-label="メモを編集"
-                >
-                  <Pencil aria-hidden="true" />
-                </Button>
-              ) : null}
-            </div>
+            <p className="mt-3 text-xs text-(--brand-ink-muted)">
+              連絡メモ: {memoText}
+            </p>
           </div>
           <div className="flex w-full flex-col gap-4 sm:w-auto sm:min-w-60 sm:max-w-[320px]">
             <div className="flex flex-col gap-3">
+              {detail.canEditCircleSession ? (
+                <CircleSessionEditDialog
+                  circleSessionId={detail.circleSessionId}
+                  title={detail.title}
+                  startsAtInput={detail.startsAtInput}
+                  endsAtInput={detail.endsAtInput}
+                  locationLabel={detail.locationLabel}
+                  memoText={detail.memoText}
+                />
+              ) : null}
               {canDuplicate ? (
                 <Button
                   variant="outline"

--- a/app/(authenticated)/circle-sessions/components/circle-session-edit-dialog.test.tsx
+++ b/app/(authenticated)/circle-sessions/components/circle-session-edit-dialog.test.tsx
@@ -1,0 +1,207 @@
+// @vitest-environment jsdom
+import { cleanup, render, screen, within } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { CircleSessionEditDialog } from "./circle-session-edit-dialog";
+
+const refreshMock = vi.fn();
+
+type MutationBehavior = "idle" | "success" | "error";
+let updateBehavior: MutationBehavior = "idle";
+const mutateMock = vi.fn();
+const resetMock = vi.fn();
+
+vi.mock("@/lib/trpc/client", () => ({
+  trpc: {
+    circleSessions: {
+      update: {
+        useMutation: (options?: {
+          onSuccess?: () => void;
+          onError?: () => void;
+        }) => {
+          mutateMock.mockImplementation(
+            (_data: unknown, inline?: { onSuccess?: () => void }) => {
+              const behavior = updateBehavior;
+              if (behavior === "success") {
+                options?.onSuccess?.();
+                inline?.onSuccess?.();
+              } else if (behavior === "error") {
+                options?.onError?.();
+              }
+            },
+          );
+          return {
+            mutate: mutateMock,
+            isPending: false,
+            data: null,
+            error:
+              updateBehavior === "error"
+                ? { message: "更新に失敗しました" }
+                : null,
+            reset: resetMock,
+          };
+        },
+      },
+    },
+  },
+}));
+
+vi.mock("next/navigation", () => ({
+  useRouter: () => ({
+    push: vi.fn(),
+    replace: vi.fn(),
+    prefetch: vi.fn(),
+    refresh: refreshMock,
+  }),
+}));
+
+afterEach(() => {
+  cleanup();
+  refreshMock.mockClear();
+  mutateMock.mockClear();
+  resetMock.mockClear();
+  updateBehavior = "idle";
+});
+
+const defaultProps: {
+  circleSessionId: string;
+  title: string;
+  startsAtInput: string;
+  endsAtInput: string;
+  locationLabel: string | null;
+  memoText: string | null;
+} = {
+  circleSessionId: "session-1",
+  title: "第1回例会",
+  startsAtInput: "2025-04-01T10:00",
+  endsAtInput: "2025-04-01T18:00",
+  locationLabel: "将棋会館",
+  memoText: "持ち物: 将棋盤",
+};
+
+async function openEditDialog(
+  overrides: Partial<typeof defaultProps> = {},
+) {
+  const user = userEvent.setup();
+  render(<CircleSessionEditDialog {...defaultProps} {...overrides} />);
+  await user.click(
+    screen.getByRole("button", { name: "セッションを編集" }),
+  );
+  return user;
+}
+
+describe("CircleSessionEditDialog", () => {
+  describe("レンダリング", () => {
+    it("トリガーボタンが表示される", () => {
+      render(<CircleSessionEditDialog {...defaultProps} />);
+      expect(
+        screen.getByRole("button", { name: "セッションを編集" }),
+      ).toBeInTheDocument();
+    });
+
+    it("ダイアログを開くと各フィールドに初期値がセットされる", async () => {
+      await openEditDialog();
+
+      const dialog = await screen.findByRole("dialog");
+      expect(within(dialog).getByLabelText("タイトル")).toHaveValue(
+        "第1回例会",
+      );
+      expect(within(dialog).getByLabelText("開始日時")).toHaveValue(
+        "2025-04-01T10:00",
+      );
+      expect(within(dialog).getByLabelText("終了日時")).toHaveValue(
+        "2025-04-01T18:00",
+      );
+      expect(within(dialog).getByLabelText("場所（任意）")).toHaveValue(
+        "将棋会館",
+      );
+      expect(within(dialog).getByLabelText("備考（任意）")).toHaveValue(
+        "持ち物: 将棋盤",
+      );
+    });
+
+    it("locationLabel が null の場合、場所フィールドが空文字になる", async () => {
+      await openEditDialog({ locationLabel: null });
+
+      const dialog = await screen.findByRole("dialog");
+      expect(within(dialog).getByLabelText("場所（任意）")).toHaveValue("");
+    });
+
+    it("memoText が null の場合、備考フィールドが空文字になる", async () => {
+      await openEditDialog({ memoText: null });
+
+      const dialog = await screen.findByRole("dialog");
+      expect(within(dialog).getByLabelText("備考（任意）")).toHaveValue("");
+    });
+  });
+
+  describe("送信", () => {
+    it("保存ボタンをクリックすると mutation が呼ばれる", async () => {
+      updateBehavior = "success";
+      const user = await openEditDialog();
+
+      const dialog = await screen.findByRole("dialog");
+      const submitButton = within(dialog).getByRole("button", {
+        name: "保存",
+      });
+      await user.click(submitButton);
+
+      expect(mutateMock).toHaveBeenCalledOnce();
+    });
+
+    it("成功時にダイアログが閉じ、router.refresh が呼ばれる", async () => {
+      updateBehavior = "success";
+      const user = await openEditDialog();
+
+      const dialog = await screen.findByRole("dialog");
+      const submitButton = within(dialog).getByRole("button", {
+        name: "保存",
+      });
+      await user.click(submitButton);
+
+      expect(screen.queryByRole("dialog")).not.toBeInTheDocument();
+      expect(refreshMock).toHaveBeenCalled();
+    });
+
+    it("タイトルが空白のみの場合、保存ボタンが無効になる", async () => {
+      const user = await openEditDialog();
+
+      const dialog = await screen.findByRole("dialog");
+      const titleInput = within(dialog).getByLabelText("タイトル");
+      await user.clear(titleInput);
+      await user.type(titleInput, "   ");
+
+      const submitButton = within(dialog).getByRole("button", {
+        name: "保存",
+      });
+      expect(submitButton).toBeDisabled();
+    });
+  });
+
+  describe("キャンセル", () => {
+    it("キャンセルをクリックするとダイアログが閉じ、値がリセットされる", async () => {
+      const user = await openEditDialog();
+
+      const dialog = await screen.findByRole("dialog");
+      const titleInput = within(dialog).getByLabelText("タイトル");
+      await user.clear(titleInput);
+      await user.type(titleInput, "変更後のタイトル");
+
+      const cancelButton = within(dialog).getByRole("button", {
+        name: "キャンセル",
+      });
+      await user.click(cancelButton);
+
+      expect(screen.queryByRole("dialog")).not.toBeInTheDocument();
+
+      await user.click(
+        screen.getByRole("button", { name: "セッションを編集" }),
+      );
+
+      const reopenedDialog = await screen.findByRole("dialog");
+      expect(within(reopenedDialog).getByLabelText("タイトル")).toHaveValue(
+        "第1回例会",
+      );
+    });
+  });
+});

--- a/app/(authenticated)/circle-sessions/components/circle-session-edit-dialog.tsx
+++ b/app/(authenticated)/circle-sessions/components/circle-session-edit-dialog.tsx
@@ -1,0 +1,220 @@
+"use client";
+
+import { Button } from "@/components/ui/button";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+  DialogTrigger,
+} from "@/components/ui/dialog";
+import { Input } from "@/components/ui/input";
+import { Textarea } from "@/components/ui/textarea";
+import { trpc } from "@/lib/trpc/client";
+import {
+  CIRCLE_SESSION_NOTE_MAX_LENGTH,
+  CIRCLE_SESSION_TITLE_MAX_LENGTH,
+} from "@/server/domain/models/circle-session/circle-session";
+import { Pencil } from "lucide-react";
+import { useRouter } from "next/navigation";
+import type { FormEvent } from "react";
+import { useState } from "react";
+
+type CircleSessionEditDialogProps = {
+  circleSessionId: string;
+  title: string;
+  startsAtInput: string;
+  endsAtInput: string;
+  locationLabel: string | null;
+  memoText: string | null;
+};
+
+export function CircleSessionEditDialog({
+  circleSessionId,
+  title: initialTitle,
+  startsAtInput,
+  endsAtInput,
+  locationLabel,
+  memoText,
+}: CircleSessionEditDialogProps) {
+  const [open, setOpen] = useState(false);
+  const [title, setTitle] = useState(initialTitle);
+  const [startsAt, setStartsAt] = useState(startsAtInput);
+  const [endsAt, setEndsAt] = useState(endsAtInput);
+  const [location, setLocation] = useState(locationLabel ?? "");
+  const [note, setNote] = useState(memoText ?? "");
+  const router = useRouter();
+
+  const updateSession = trpc.circleSessions.update.useMutation({
+    onSuccess: () => {
+      setOpen(false);
+      router.refresh();
+    },
+  });
+
+  const trimmedTitle = title.trim();
+  const canSubmit = trimmedTitle.length > 0 && !updateSession.isPending;
+
+  const handleSubmit = (event: FormEvent<HTMLFormElement>) => {
+    event.preventDefault();
+    if (!canSubmit) return;
+    updateSession.mutate({
+      circleSessionId,
+      title: trimmedTitle,
+      startsAt: new Date(startsAt),
+      endsAt: new Date(endsAt),
+      location: location.trim() || null,
+      note: note.trim(),
+    });
+  };
+
+  const handleOpenChange = (nextOpen: boolean) => {
+    setOpen(nextOpen);
+    if (!nextOpen) {
+      setTitle(initialTitle);
+      setStartsAt(startsAtInput);
+      setEndsAt(endsAtInput);
+      setLocation(locationLabel ?? "");
+      setNote(memoText ?? "");
+      updateSession.reset();
+    }
+  };
+
+  return (
+    <Dialog open={open} onOpenChange={handleOpenChange}>
+      <DialogTrigger asChild>
+        <Button
+          variant="outline"
+          className="w-full border-(--brand-ink)/20 bg-white/80 text-(--brand-ink) hover:bg-white"
+        >
+          <Pencil className="size-4" aria-hidden="true" />
+          セッションを編集
+        </Button>
+      </DialogTrigger>
+
+      <DialogContent className="max-w-md rounded-2xl border-border/60 bg-white p-6 shadow-xl">
+        <DialogHeader>
+          <DialogTitle className="text-lg font-semibold text-(--brand-ink)">
+            セッションを編集
+          </DialogTitle>
+          <DialogDescription className="sr-only">
+            セッションの詳細情報を編集します
+          </DialogDescription>
+        </DialogHeader>
+
+        <form onSubmit={handleSubmit} className="flex flex-col gap-4">
+          <div className="flex flex-col gap-1.5">
+            <label
+              htmlFor="edit-title"
+              className="text-xs font-semibold text-(--brand-ink-muted) after:ml-0.5 after:text-red-600 after:content-['*']"
+            >
+              タイトル
+            </label>
+            <Input
+              id="edit-title"
+              value={title}
+              onChange={(e) => setTitle(e.target.value)}
+              maxLength={CIRCLE_SESSION_TITLE_MAX_LENGTH}
+              aria-required="true"
+              className="bg-white"
+            />
+          </div>
+
+          <div className="grid gap-4 sm:grid-cols-2">
+            <div className="flex flex-col gap-1.5">
+              <label
+                htmlFor="edit-startsAt"
+                className="text-xs font-semibold text-(--brand-ink-muted) after:ml-0.5 after:text-red-600 after:content-['*']"
+              >
+                開始日時
+              </label>
+              <Input
+                id="edit-startsAt"
+                type="datetime-local"
+                value={startsAt}
+                onChange={(e) => setStartsAt(e.target.value)}
+                aria-required="true"
+                className="bg-white"
+              />
+            </div>
+            <div className="flex flex-col gap-1.5">
+              <label
+                htmlFor="edit-endsAt"
+                className="text-xs font-semibold text-(--brand-ink-muted) after:ml-0.5 after:text-red-600 after:content-['*']"
+              >
+                終了日時
+              </label>
+              <Input
+                id="edit-endsAt"
+                type="datetime-local"
+                value={endsAt}
+                onChange={(e) => setEndsAt(e.target.value)}
+                aria-required="true"
+                className="bg-white"
+              />
+            </div>
+          </div>
+
+          <div className="flex flex-col gap-1.5">
+            <label
+              htmlFor="edit-location"
+              className="text-xs font-semibold text-(--brand-ink-muted)"
+            >
+              場所（任意）
+            </label>
+            <Input
+              id="edit-location"
+              value={location}
+              onChange={(e) => setLocation(e.target.value)}
+              placeholder="例: 将棋会館 3F"
+              className="bg-white"
+            />
+          </div>
+
+          <div className="flex flex-col gap-1.5">
+            <label
+              htmlFor="edit-note"
+              className="text-xs font-semibold text-(--brand-ink-muted)"
+            >
+              備考（任意）
+            </label>
+            <Textarea
+              id="edit-note"
+              value={note}
+              onChange={(e) => setNote(e.target.value)}
+              maxLength={CIRCLE_SESSION_NOTE_MAX_LENGTH}
+              rows={3}
+              className="bg-white"
+            />
+          </div>
+
+          {updateSession.error ? (
+            <p role="alert" className="text-xs text-red-600">
+              {updateSession.error.message}
+            </p>
+          ) : null}
+
+          <DialogFooter>
+            <Button
+              type="button"
+              variant="outline"
+              className="border-(--brand-ink)/20 bg-white/80 text-(--brand-ink)"
+              onClick={() => handleOpenChange(false)}
+            >
+              キャンセル
+            </Button>
+            <Button
+              type="submit"
+              className="bg-(--brand-moss) text-white hover:bg-(--brand-moss)/90"
+              disabled={!canSubmit}
+            >
+              {updateSession.isPending ? "保存中..." : "保存"}
+            </Button>
+          </DialogFooter>
+        </form>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/server/presentation/providers/circle-session-detail-provider.ts
+++ b/server/presentation/providers/circle-session-detail-provider.ts
@@ -100,12 +100,16 @@ export async function getCircleSessionDetailViewModel(
   const [
     users,
     canCreateCircleSession,
+    canEditCircleSession,
     canDeleteCircleSession,
     canWithdrawFromCircleSession,
   ] = await Promise.all([
     caller.users.list({ userIds: Array.from(userIds) }),
     viewerId
       ? ctx.accessService.canCreateCircleSession(viewerId, session.circleId)
+      : Promise.resolve(false),
+    viewerId
+      ? ctx.accessService.canEditCircleSession(viewerId, session.id)
       : Promise.resolve(false),
     viewerId
       ? ctx.accessService.canDeleteCircleSession(viewerId, session.id)
@@ -147,6 +151,7 @@ export async function getCircleSessionDetailViewModel(
     endsAtInput: formatDateTimeForInput(session.endsAt),
     viewerRole,
     canCreateCircleSession,
+    canEditCircleSession,
     canDeleteCircleSession,
     canWithdrawFromCircleSession,
     memberships: membershipViewModels,

--- a/server/presentation/view-models/circle-session-detail.ts
+++ b/server/presentation/view-models/circle-session-detail.ts
@@ -32,6 +32,7 @@ export type CircleSessionDetailViewModel = {
   endsAtInput: string;
   viewerRole: CircleSessionRoleKey | null;
   canCreateCircleSession: boolean;
+  canEditCircleSession: boolean;
   canDeleteCircleSession: boolean;
   canWithdrawFromCircleSession: boolean;
   memberships: CircleSessionMembership[];


### PR DESCRIPTION
## Summary

- セッション詳細画面に編集ダイアログ (`CircleSessionEditDialog`) を新規追加
- タイトル・開始/終了日時・場所・備考を一括編集できるフォームを実装
- `canEditCircleSession` フラグにより、オーナー・マネージャーのみ編集ボタンを表示
- 旧メモ編集ボタン（Pencil アイコン）を削除し、統合的な編集UIに置換

Closes #752

## 変更ファイル

| ファイル | 変更内容 |
|---|---|
| `circle-session-edit-dialog.tsx` | 新規: 編集ダイアログコンポーネント |
| `circle-session-edit-dialog.test.tsx` | 新規: 編集ダイアログのテスト |
| `circle-session-detail-view.tsx` | 編集ダイアログの統合、旧メモ編集ボタン削除 |
| `circle-session-detail-view.test.tsx` | 編集ボタン表示制御のテスト追加 |
| `circle-session-detail.ts` | `canEditCircleSession` を ViewModel に追加 |
| `circle-session-detail-provider.ts` | `canEditCircleSession` の認可チェックを追加 |

## Test plan

- [ ] `npm run test:run` で全テストがパスすること
- [ ] `npx tsc --noEmit` で型エラーがないこと
- [ ] オーナー/マネージャーでログインし「セッションを編集」ボタンが表示されること
- [ ] ダイアログで各フィールドを編集・保存できること
- [ ] 一般メンバーでは編集ボタンが表示されないこと
- [ ] キャンセル時にフォームがリセットされること

🤖 Generated with [Claude Code](https://claude.com/claude-code)