### PR TITLE
feat: 研究会参加者のロールを変更するUIを追加する

### DIFF
--- a/app/(authenticated)/circles/components/circle-overview-view.test.tsx
+++ b/app/(authenticated)/circles/components/circle-overview-view.test.tsx
@@ -49,6 +49,15 @@ vi.mock(
   }),
 );
 
+vi.mock(
+  "@/app/(authenticated)/circles/components/member-role-dropdown",
+  () => ({
+    MemberRoleDropdown: ({ userId }: { userId: string }) => (
+      <button data-testid={`role-edit-${userId}`}>ロールを変更</button>
+    ),
+  }),
+);
+
 afterEach(() => {
   cleanup();
 });
@@ -179,5 +188,45 @@ describe("CircleOverviewView ロールベース表示制御", () => {
     expect(
       screen.queryByTestId("circle-delete-button"),
     ).not.toBeInTheDocument();
+  });
+
+  it("canChangeRole が true のメンバーにはロールバッジと編集ボタンが表示される", () => {
+    render(
+      <CircleOverviewView
+        overview={buildOverview({
+          members: [
+            {
+              userId: "user-1",
+              name: "テストユーザー",
+              role: "manager",
+              canChangeRole: true,
+            },
+          ],
+        })}
+      />,
+    );
+
+    expect(screen.getByText("マネージャー")).toBeInTheDocument();
+    expect(screen.getByTestId("role-edit-user-1")).toBeInTheDocument();
+  });
+
+  it("canChangeRole が false のメンバーにはロールバッジのみ表示される", () => {
+    render(
+      <CircleOverviewView
+        overview={buildOverview({
+          members: [
+            {
+              userId: "user-2",
+              name: "オーナーユーザー",
+              role: "owner",
+              canChangeRole: false,
+            },
+          ],
+        })}
+      />,
+    );
+
+    expect(screen.getByText("オーナー")).toBeInTheDocument();
+    expect(screen.queryByTestId("role-edit-user-2")).not.toBeInTheDocument();
   });
 });

--- a/app/(authenticated)/circles/components/circle-overview-view.tsx
+++ b/app/(authenticated)/circles/components/circle-overview-view.tsx
@@ -2,6 +2,7 @@ import { CircleDeleteButton } from "@/app/(authenticated)/circles/components/cir
 import { CircleOverviewCalendar } from "@/app/(authenticated)/circles/components/circle-overview-calendar";
 import { CircleRenameDialog } from "@/app/(authenticated)/circles/components/circle-rename-dialog";
 import { CircleWithdrawButton } from "@/app/(authenticated)/circles/components/circle-withdraw-button";
+import { MemberRoleDropdown } from "@/app/(authenticated)/circles/components/member-role-dropdown";
 import type {
   CircleOverviewMember,
   CircleOverviewViewModel,
@@ -178,25 +179,36 @@ export function CircleOverviewView({
                     : null;
                   const memberRoleLabel = roleLabels[member.role] ?? "メンバー";
                   return (
-                    <LinkCard
+                    <div
                       key={member.userId}
-                      href={memberHref}
-                      className="flex items-center justify-between gap-4 rounded-xl border border-border/60 bg-white/70 p-4 transition hover:border-border hover:bg-white hover:shadow-sm"
+                      className="flex items-center gap-1"
                     >
-                      <div>
-                        <p className="text-sm font-semibold text-(--brand-ink)">
-                          {member.name}
-                        </p>
-                      </div>
-                      <span
-                        className={`rounded-full px-2.5 py-1 text-xs ${
-                          roleClasses[member.role] ??
-                          "bg-(--brand-ink)/10 text-(--brand-ink)"
-                        }`}
+                      <LinkCard
+                        href={memberHref}
+                        className="flex flex-1 items-center justify-between gap-4 rounded-xl border border-border/60 bg-white/70 p-4 transition hover:border-border hover:bg-white hover:shadow-sm"
                       >
-                        {memberRoleLabel}
-                      </span>
-                    </LinkCard>
+                        <div>
+                          <p className="text-sm font-semibold text-(--brand-ink)">
+                            {member.name}
+                          </p>
+                        </div>
+                        <span
+                          className={`rounded-full px-2.5 py-1 text-xs ${
+                            roleClasses[member.role] ??
+                            "bg-(--brand-ink)/10 text-(--brand-ink)"
+                          }`}
+                        >
+                          {memberRoleLabel}
+                        </span>
+                      </LinkCard>
+                      {member.canChangeRole ? (
+                        <MemberRoleDropdown
+                          circleId={overview.circleId}
+                          userId={member.userId}
+                          currentRole={member.role}
+                        />
+                      ) : null}
+                    </div>
                   );
                 })
               )}

--- a/app/(authenticated)/circles/components/member-role-dropdown.test.tsx
+++ b/app/(authenticated)/circles/components/member-role-dropdown.test.tsx
@@ -1,0 +1,164 @@
+// @vitest-environment jsdom
+import { cleanup, render, screen, within } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  type MutationBehavior,
+  makeMutationMock,
+} from "@/test-helpers/trpc-mutation-mock";
+import { MemberRoleDropdown } from "./member-role-dropdown";
+
+const refreshMock = vi.fn();
+
+let updateRoleBehavior: MutationBehavior = "idle";
+
+const useMutationHolder = vi.hoisted(() => {
+  const noop = (): unknown => ({});
+  return { current: noop as (...args: unknown[]) => unknown };
+});
+
+const { useMutation, mutateSpyRef } = makeMutationMock(
+  () => updateRoleBehavior,
+  { hasReset: false },
+);
+useMutationHolder.current =
+  useMutation as unknown as typeof useMutationHolder.current;
+
+vi.mock("@/lib/trpc/client", () => ({
+  trpc: {
+    circles: {
+      memberships: {
+        updateRole: {
+          useMutation: (...args: unknown[]) =>
+            useMutationHolder.current(...args),
+        },
+      },
+    },
+  },
+}));
+
+vi.mock("next/navigation", () => ({
+  useRouter: () => ({
+    push: vi.fn(),
+    replace: vi.fn(),
+    prefetch: vi.fn(),
+    refresh: refreshMock,
+  }),
+}));
+
+vi.mock("sonner", () => ({
+  toast: {
+    error: vi.fn(),
+  },
+}));
+
+afterEach(() => {
+  cleanup();
+  refreshMock.mockClear();
+  updateRoleBehavior = "idle";
+});
+
+const defaultProps = {
+  circleId: "circle-1",
+  userId: "user-1",
+  currentRole: "manager" as const,
+};
+
+describe("MemberRoleDropdown", () => {
+  let toastModule: {
+    toast: { error: ReturnType<typeof vi.fn> };
+  };
+
+  beforeEach(async () => {
+    toastModule = (await import("sonner")) as unknown as typeof toastModule;
+    toastModule.toast.error.mockClear();
+  });
+
+  it("編集アイコンボタンが表示される", () => {
+    render(<MemberRoleDropdown {...defaultProps} />);
+
+    expect(
+      screen.getByRole("button", { name: "ロールを変更" }),
+    ).toBeInTheDocument();
+  });
+
+  it("編集ボタンをクリックするとマネージャーとメンバーの選択肢が表示される", async () => {
+    const user = userEvent.setup();
+    render(<MemberRoleDropdown {...defaultProps} />);
+
+    await user.click(screen.getByRole("button", { name: "ロールを変更" }));
+
+    const menu = screen.getByRole("menu");
+    const items = within(menu).getAllByRole("menuitem");
+    expect(items).toHaveLength(2);
+    expect(items[0]).toHaveTextContent("マネージャー");
+    expect(items[1]).toHaveTextContent("メンバー");
+  });
+
+  it("現在のロールと同じメニュー項目は disabled", async () => {
+    const user = userEvent.setup();
+    render(<MemberRoleDropdown {...defaultProps} currentRole="manager" />);
+
+    await user.click(screen.getByRole("button", { name: "ロールを変更" }));
+
+    const menu = screen.getByRole("menu");
+    const items = within(menu).getAllByRole("menuitem");
+    expect(items[0]).toHaveAttribute("data-disabled");
+  });
+
+  it("異なるロールを選択すると updateRole が呼ばれる", async () => {
+    updateRoleBehavior = "success";
+    const user = userEvent.setup();
+    render(<MemberRoleDropdown {...defaultProps} currentRole="manager" />);
+
+    await user.click(screen.getByRole("button", { name: "ロールを変更" }));
+
+    const menu = screen.getByRole("menu");
+    const items = within(menu).getAllByRole("menuitem");
+    await user.click(items[1]);
+
+    expect(mutateSpyRef.current).toHaveBeenCalledWith({
+      circleId: "circle-1",
+      userId: "user-1",
+      role: "CircleMember",
+    });
+  });
+
+  it("ロール変更成功時に router.refresh() が呼ばれる", async () => {
+    updateRoleBehavior = "success";
+    const user = userEvent.setup();
+    render(<MemberRoleDropdown {...defaultProps} currentRole="manager" />);
+
+    await user.click(screen.getByRole("button", { name: "ロールを変更" }));
+
+    const menu = screen.getByRole("menu");
+    const items = within(menu).getAllByRole("menuitem");
+    await user.click(items[1]);
+
+    expect(refreshMock).toHaveBeenCalled();
+  });
+
+  it("ロール変更失敗時に toast.error が呼ばれる", async () => {
+    updateRoleBehavior = "error";
+    const user = userEvent.setup();
+    render(<MemberRoleDropdown {...defaultProps} currentRole="manager" />);
+
+    await user.click(screen.getByRole("button", { name: "ロールを変更" }));
+
+    const menu = screen.getByRole("menu");
+    const items = within(menu).getAllByRole("menuitem");
+    await user.click(items[1]);
+
+    expect(toastModule.toast.error).toHaveBeenCalledWith(
+      "ロールの変更に失敗しました",
+    );
+  });
+
+  it("isPending 中は編集ボタンが disabled になる", () => {
+    updateRoleBehavior = "pending";
+    render(<MemberRoleDropdown {...defaultProps} />);
+
+    const trigger = screen.getByRole("button", { name: "ロールを変更" });
+    expect(trigger).toBeDisabled();
+  });
+});

--- a/app/(authenticated)/circles/components/member-role-dropdown.tsx
+++ b/app/(authenticated)/circles/components/member-role-dropdown.tsx
@@ -1,0 +1,87 @@
+"use client";
+
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuTrigger,
+} from "@/components/ui/dropdown-menu";
+import { trpc } from "@/lib/trpc/client";
+import type { CircleRole } from "@/server/domain/models/circle/circle-role";
+import type { CircleRoleKey } from "@/server/presentation/view-models/circle-overview";
+import { Check, Pencil } from "lucide-react";
+import { useRouter } from "next/navigation";
+import { toast } from "sonner";
+
+type MemberRoleDropdownProps = {
+  circleId: string;
+  userId: string;
+  currentRole: CircleRoleKey;
+};
+
+const assignableRoles: ReadonlyArray<{
+  key: CircleRoleKey;
+  label: string;
+  apiValue: CircleRole;
+}> = [
+  { key: "manager", label: "マネージャー", apiValue: "CircleManager" },
+  { key: "member", label: "メンバー", apiValue: "CircleMember" },
+];
+
+export function MemberRoleDropdown({
+  circleId,
+  userId,
+  currentRole,
+}: MemberRoleDropdownProps) {
+  const router = useRouter();
+
+  const updateRole = trpc.circles.memberships.updateRole.useMutation({
+    onSuccess: () => {
+      router.refresh();
+    },
+    onError: () => {
+      toast.error("ロールの変更に失敗しました");
+    },
+  });
+
+  const handleRoleChange = (apiValue: CircleRole) => {
+    updateRole.mutate({ circleId, userId, role: apiValue });
+  };
+
+  return (
+    <DropdownMenu>
+      <DropdownMenuTrigger asChild>
+        <button
+          type="button"
+          className="inline-flex size-7 items-center justify-center rounded-md text-(--brand-ink-muted) transition hover:bg-(--brand-ink)/10 hover:text-(--brand-ink)"
+          disabled={updateRole.isPending}
+          aria-label="ロールを変更"
+        >
+          {updateRole.isPending ? (
+            <span className="text-[10px]">…</span>
+          ) : (
+            <Pencil className="size-3.5" aria-hidden="true" />
+          )}
+        </button>
+      </DropdownMenuTrigger>
+      <DropdownMenuContent align="end">
+        {assignableRoles.map((role) => (
+          <DropdownMenuItem
+            key={role.key}
+            disabled={currentRole === role.key}
+            onClick={() => handleRoleChange(role.apiValue)}
+          >
+            <span className="flex items-center gap-2">
+              {currentRole === role.key ? (
+                <Check className="size-3.5" aria-hidden="true" />
+              ) : (
+                <span className="size-3.5" />
+              )}
+              {role.label}
+            </span>
+          </DropdownMenuItem>
+        ))}
+      </DropdownMenuContent>
+    </DropdownMenu>
+  );
+}

--- a/server/presentation/providers/circle-overview-provider.ts
+++ b/server/presentation/providers/circle-overview-provider.ts
@@ -71,6 +71,22 @@ export async function getCircleOverviewViewModel(
   ]);
   const userNameById = new Map(users.map((user) => [user.id, user.name]));
 
+  const canChangeRoleByUserId = new Map<string, boolean>();
+  if (viewerId) {
+    const results = await Promise.all(
+      memberships.map((m) =>
+        ctx.accessService.canChangeCircleMemberRole(
+          viewerId,
+          m.userId,
+          circleId,
+        ),
+      ),
+    );
+    memberships.forEach((m, i) => {
+      canChangeRoleByUserId.set(m.userId, results[i]);
+    });
+  }
+
   const viewerRole = getViewerRole(memberships, viewerId);
 
   const allSessions = sessions
@@ -105,6 +121,7 @@ export async function getCircleOverviewViewModel(
       userId: membership.userId,
       name: userNameById.get(membership.userId) ?? membership.userId,
       role: roleKeyByDto[membership.role] ?? "member",
+      canChangeRole: canChangeRoleByUserId.get(membership.userId) ?? false,
     })),
     holidayDates: ctx.holidayProvider.getHolidayDateStringsForRange(),
     canDeleteCircle,

--- a/server/presentation/view-models/circle-overview.ts
+++ b/server/presentation/view-models/circle-overview.ts
@@ -11,6 +11,7 @@ export type CircleOverviewMember = {
   userId: string;
   name: string;
   role: CircleRoleKey;
+  canChangeRole: boolean;
 };
 
 export type CircleOverviewViewModel = {


### PR DESCRIPTION
## Summary

Closes #754

- 研究会概要ページのメンバー一覧に、ロール変更用のドロップダウンメニューを追加
- ViewModel に `canChangeRole` フラグを追加し、Provider で `AccessService` を使い認可判定を算出
- 権限のあるユーザーのみ編集アイコンが表示され、マネージャー/メンバー間のロール変更が可能

## Changes

| ファイル | 変更内容 |
|---------|---------|
| `server/presentation/view-models/circle-overview.ts` | `CircleOverviewMember` に `canChangeRole` 追加 |
| `server/presentation/providers/circle-overview-provider.ts` | `accessService.canChangeCircleMemberRole()` で認可判定を算出 |
| `app/.../member-role-dropdown.tsx` | DropdownMenu ベースのロール変更コンポーネント（新規） |
| `app/.../circle-overview-view.tsx` | `canChangeRole` に応じた条件分岐表示 |

## Security

認可は3層で保護:
1. **UI層**: `canChangeRole` フラグで表示制御
2. **サービス層**: `accessService.canChangeCircleMemberRole()` で認可チェック
3. **ドメイン層**: `assertCanChangeCircleMemberRole()` で Owner への変更を拒否

## Test plan

- [x] `npx tsc --noEmit` パス
- [x] `npm run lint` パス
- [x] テスト 18/18 passed（view 11 + dropdown 7）
- [ ] Owner でログイン → Manager/Member のロール変更ボタンが表示される
- [ ] Manager でログイン → Member のみロール変更ボタンが表示される
- [ ] Member でログイン → ロール変更ボタンが表示されない

## Follow-up

- #756: updateRole エンドポイントの Zod スキーマで CircleOwner を入力段階で拒否する

🤖 Generated with [Claude Code](https://claude.com/claude-code)