### PR TITLE
feat: セッション参加者のロールを変更するUIを追加する

### DIFF
--- a/app/(authenticated)/circle-sessions/components/circle-session-detail-view.test.tsx
+++ b/app/(authenticated)/circle-sessions/components/circle-session-detail-view.test.tsx
@@ -55,6 +55,16 @@ vi.mock("@/lib/trpc/client", () => ({
           reset: vi.fn(),
         }),
       },
+      memberships: {
+        updateRole: {
+          useMutation: () => ({
+            mutate: vi.fn(),
+            isPending: false,
+            data: null,
+            error: null,
+          }),
+        },
+      },
     },
     matches: {
       create: {
@@ -242,8 +252,8 @@ describe("CircleSessionDetailView 複製ボタン", () => {
 });
 
 const twoMemberships = [
-  { id: "p1", name: "藤井太郎" },
-  { id: "p2", name: "羽生次郎" },
+  { id: "p1", name: "藤井太郎", role: "member" as const, canChangeRole: false },
+  { id: "p2", name: "羽生次郎", role: "member" as const, canChangeRole: false },
 ];
 
 const oneMatch = [

--- a/app/(authenticated)/circle-sessions/components/circle-session-detail-view.tsx
+++ b/app/(authenticated)/circle-sessions/components/circle-session-detail-view.tsx
@@ -18,6 +18,7 @@ import type {
 } from "@/server/presentation/view-models/circle-session-detail";
 import { CircleSessionEditDialog } from "@/app/(authenticated)/circle-sessions/components/circle-session-edit-dialog";
 import { CircleSessionWithdrawButton } from "@/app/(authenticated)/circle-sessions/components/circle-session-withdraw-button";
+import { SessionMemberRoleDropdown } from "@/app/(authenticated)/circle-sessions/components/session-member-role-dropdown";
 import { Copy, Trash2 } from "lucide-react";
 import { useRouter } from "next/navigation";
 import { type FormEvent, useRef, useState } from "react";
@@ -468,6 +469,49 @@ export function CircleSessionDetailView({
               ) : null}
             </div>
           </div>
+        </div>
+      </section>
+
+      <section className="rounded-2xl border border-border/60 bg-white/90 p-6 shadow-sm">
+        <p className="text-sm font-semibold text-(--brand-ink)">参加メンバー</p>
+        <div className="mt-4 space-y-3">
+          {memberships.length === 0 ? (
+            <p className="text-xs text-(--brand-ink-muted)">
+              まだ参加メンバーがいません
+            </p>
+          ) : (
+            memberships.map((membership) => {
+              const memberRoleLabel = membership.role
+                ? (roleLabels[membership.role] ?? "メンバー")
+                : null;
+              return (
+                <div key={membership.id} className="flex items-center gap-1">
+                  <div className="flex flex-1 items-center justify-between gap-4 rounded-xl border border-border/60 bg-white/70 p-4">
+                    <p className="text-sm font-semibold text-(--brand-ink)">
+                      {membership.name}
+                    </p>
+                    {membership.role && memberRoleLabel ? (
+                      <span
+                        className={`rounded-full px-2.5 py-1 text-xs ${
+                          roleClasses[membership.role] ??
+                          "bg-(--brand-ink)/10 text-(--brand-ink)"
+                        }`}
+                      >
+                        {memberRoleLabel}
+                      </span>
+                    ) : null}
+                  </div>
+                  {membership.canChangeRole && membership.role ? (
+                    <SessionMemberRoleDropdown
+                      circleSessionId={detail.circleSessionId}
+                      userId={membership.id}
+                      currentRole={membership.role}
+                    />
+                  ) : null}
+                </div>
+              );
+            })
+          )}
         </div>
       </section>
 

--- a/app/(authenticated)/circle-sessions/components/session-member-role-dropdown.tsx
+++ b/app/(authenticated)/circle-sessions/components/session-member-role-dropdown.tsx
@@ -1,0 +1,91 @@
+"use client";
+
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuTrigger,
+} from "@/components/ui/dropdown-menu";
+import { trpc } from "@/lib/trpc/client";
+import type { CircleSessionRole } from "@/server/domain/models/circle-session/circle-session-role";
+import type { CircleSessionRoleKey } from "@/server/presentation/view-models/circle-session-detail";
+import { Check, Pencil } from "lucide-react";
+import { useRouter } from "next/navigation";
+import { toast } from "sonner";
+
+type SessionMemberRoleDropdownProps = {
+  circleSessionId: string;
+  userId: string;
+  currentRole: CircleSessionRoleKey;
+};
+
+const assignableRoles: ReadonlyArray<{
+  key: CircleSessionRoleKey;
+  label: string;
+  apiValue: CircleSessionRole;
+}> = [
+  {
+    key: "manager",
+    label: "マネージャー",
+    apiValue: "CircleSessionManager",
+  },
+  { key: "member", label: "メンバー", apiValue: "CircleSessionMember" },
+];
+
+export function SessionMemberRoleDropdown({
+  circleSessionId,
+  userId,
+  currentRole,
+}: SessionMemberRoleDropdownProps) {
+  const router = useRouter();
+
+  const updateRole = trpc.circleSessions.memberships.updateRole.useMutation({
+    onSuccess: () => {
+      router.refresh();
+    },
+    onError: () => {
+      toast.error("ロールの変更に失敗しました");
+    },
+  });
+
+  const handleRoleChange = (apiValue: CircleSessionRole) => {
+    updateRole.mutate({ circleSessionId, userId, role: apiValue });
+  };
+
+  return (
+    <DropdownMenu>
+      <DropdownMenuTrigger asChild>
+        <button
+          type="button"
+          className="inline-flex size-7 items-center justify-center rounded-md text-(--brand-ink-muted) transition hover:bg-(--brand-ink)/10 hover:text-(--brand-ink)"
+          disabled={updateRole.isPending}
+          aria-label="ロールを変更"
+        >
+          {updateRole.isPending ? (
+            <span className="text-[10px]">…</span>
+          ) : (
+            <Pencil className="size-3.5" aria-hidden="true" />
+          )}
+        </button>
+      </DropdownMenuTrigger>
+      <DropdownMenuContent align="end">
+        {assignableRoles.map((role) => (
+          <DropdownMenuItem
+            key={role.key}
+            disabled={currentRole === role.key}
+            onClick={() => handleRoleChange(role.apiValue)}
+          >
+            <span className="flex items-center gap-2">
+              {currentRole === role.key ? (
+                <Check className="size-3.5" aria-hidden="true" />
+              ) : (
+                <span className="size-3.5" />
+              )}
+              {role.label}
+            </span>
+          </DropdownMenuItem>
+        ))}
+      </DropdownMenuContent>
+    </DropdownMenu>
+  );
+}

--- a/server/presentation/providers/circle-session-detail-provider.ts
+++ b/server/presentation/providers/circle-session-detail-provider.ts
@@ -34,12 +34,15 @@ const getViewerRole = (
 };
 
 const mapMemberships = (
-  memberships: Array<{ userId: string }>,
+  memberships: Array<{ userId: string; role: CircleSessionRole }>,
   nameById: Map<string, string | null>,
+  canChangeRoleById: Map<string, boolean>,
 ): CircleSessionMembership[] =>
   memberships.map((membership) => ({
     id: membership.userId,
     name: nameById.get(membership.userId) ?? membership.userId,
+    role: roleKeyByDto[membership.role] ?? null,
+    canChangeRole: canChangeRoleById.get(membership.userId) ?? false,
   }));
 
 const mergeMembershipIds = (
@@ -56,6 +59,8 @@ const mergeMembershipIds = (
       extras.push({
         id: match.player1Id,
         name: nameById.get(match.player1Id) ?? match.player1Id,
+        role: null,
+        canChangeRole: false,
       });
     }
     if (!ids.has(match.player2Id)) {
@@ -63,6 +68,8 @@ const mergeMembershipIds = (
       extras.push({
         id: match.player2Id,
         name: nameById.get(match.player2Id) ?? match.player2Id,
+        role: null,
+        canChangeRole: false,
       });
     }
   }
@@ -132,8 +139,26 @@ export async function getCircleSessionDetailViewModel(
       createdAtInput: formatDateForInput(match.createdAt),
     }));
 
+  const canChangeRoleById = new Map<string, boolean>();
+  if (viewerId) {
+    const canChangeResults = await Promise.all(
+      memberships.map(async (membership) => {
+        const can =
+          await ctx.accessService.canChangeCircleSessionMemberRole(
+            viewerId,
+            membership.userId,
+            session.id,
+          );
+        return [membership.userId, can] as const;
+      }),
+    );
+    for (const [userId, can] of canChangeResults) {
+      canChangeRoleById.set(userId, can);
+    }
+  }
+
   const membershipViewModels = mergeMembershipIds(
-    mapMemberships(memberships, userNameById),
+    mapMemberships(memberships, userNameById, canChangeRoleById),
     matchViewModels,
     userNameById,
   );

--- a/server/presentation/view-models/circle-session-detail.ts
+++ b/server/presentation/view-models/circle-session-detail.ts
@@ -9,6 +9,8 @@ export type CircleSessionMatchOutcome =
 export type CircleSessionMembership = {
   id: string;
   name: string;
+  role: CircleSessionRoleKey | null;
+  canChangeRole: boolean;
 };
 
 export type CircleSessionMatch = {


### PR DESCRIPTION
## Summary

Closes #755

- セッション詳細画面に参加メンバー一覧セクションを追加し、ロールバッジとロール変更ドロップダウンを表示
- プロバイダーで `canChangeCircleSessionMemberRole` 認可チェックを実行し、ビューモデルに `role` / `canChangeRole` を追加
- Issue #754 の研究会メンバー版ドロップダウンと同一パターンで `SessionMemberRoleDropdown` を実装

## Verification

### 自動検証（全パス）

- TypeScript 型チェック (`npx tsc --noEmit`)
- テスト（対象ファイル: 15件）
- ESLint

### 手動検証手順

1. セッションオーナーでログインし、セッション詳細画面を開く
2. 参加メンバー一覧にロールバッジとドロップダウンが表示されることを確認
3. メンバーのロールを Manager に変更し、即座にUIが更新されることを確認
4. マネージャーでログインし、Owner のロール変更ドロップダウンが表示されないことを確認
5. メンバーでログインし、ロール変更ドロップダウンが表示されないことを確認

## Security

多層防御を確認済み:

| レイヤー | 制御 |
|---------|------|
| UI | `canChangeRole` フラグでドロップダウン表示を制御 |
| tRPC | `z.nativeEnum(CircleSessionRole)` で入力バリデーション |
| サーバー認可 | `accessService.canChangeCircleSessionMemberRole()` |
| ドメインポリシー | `canChangeSessionMemberRole()` でオーナーのみ変更可 |

## Follow-up Issues

- #758 プロバイダーの認可チェックを並列化する
- #759 ロール変更ドロップダウンにエラーフィードバックを追加する

🤖 Generated with [Claude Code](https://claude.com/claude-code)