### PR TITLE
feat: セッションに参加者を追加するUIを実装する (#761)

### DIFF
--- a/app/(authenticated)/circle-sessions/components/add-session-member-dialog.tsx
+++ b/app/(authenticated)/circle-sessions/components/add-session-member-dialog.tsx
@@ -1,0 +1,197 @@
+"use client";
+
+import { Button } from "@/components/ui/button";
+import { Checkbox } from "@/components/ui/checkbox";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+  DialogTrigger,
+} from "@/components/ui/dialog";
+import { trpc } from "@/lib/trpc/client";
+import type { AddableMemberCandidate } from "@/server/presentation/view-models/circle-session-detail";
+import { UserPlus } from "lucide-react";
+import { useRouter } from "next/navigation";
+import type { FormEvent } from "react";
+import { useState } from "react";
+import { toast } from "sonner";
+
+type AddSessionMemberDialogProps = {
+  circleSessionId: string;
+  candidates: AddableMemberCandidate[];
+};
+
+type RoleValue = "CircleSessionManager" | "CircleSessionMember";
+
+export function AddSessionMemberDialog({
+  circleSessionId,
+  candidates,
+}: AddSessionMemberDialogProps) {
+  const [open, setOpen] = useState(false);
+  const [selectedUserIds, setSelectedUserIds] = useState<Set<string>>(
+    new Set(),
+  );
+  const [selectedRole, setSelectedRole] = useState<RoleValue>(
+    "CircleSessionMember",
+  );
+  const [isPending, setIsPending] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const router = useRouter();
+
+  const addMember = trpc.circleSessions.memberships.add.useMutation();
+
+  const canSubmit = selectedUserIds.size > 0 && !isPending;
+
+  const toggleUser = (userId: string) => {
+    setSelectedUserIds((prev) => {
+      const next = new Set(prev);
+      if (next.has(userId)) {
+        next.delete(userId);
+      } else {
+        next.add(userId);
+      }
+      return next;
+    });
+  };
+
+  const handleSubmit = async (event: FormEvent<HTMLFormElement>) => {
+    event.preventDefault();
+    if (!canSubmit) return;
+
+    setIsPending(true);
+    setError(null);
+
+    try {
+      for (const userId of selectedUserIds) {
+        await addMember.mutateAsync({
+          circleSessionId,
+          userId,
+          role: selectedRole,
+        });
+      }
+      setOpen(false);
+      router.refresh();
+      toast.success(
+        selectedUserIds.size === 1
+          ? "メンバーを追加しました"
+          : `${selectedUserIds.size}人のメンバーを追加しました`,
+      );
+    } catch (e) {
+      setError(e instanceof Error ? e.message : "追加に失敗しました");
+    } finally {
+      setIsPending(false);
+    }
+  };
+
+  const handleOpenChange = (nextOpen: boolean) => {
+    setOpen(nextOpen);
+    if (!nextOpen) {
+      setSelectedUserIds(new Set());
+      setSelectedRole("CircleSessionMember");
+      setError(null);
+      addMember.reset();
+    }
+  };
+
+  return (
+    <Dialog open={open} onOpenChange={handleOpenChange}>
+      <DialogTrigger asChild>
+        <button
+          type="button"
+          className="inline-flex items-center gap-1 rounded-md px-2 py-1 text-xs font-medium text-(--brand-moss) transition hover:bg-(--brand-moss)/10"
+        >
+          <UserPlus className="size-3.5" aria-hidden="true" />
+          追加
+        </button>
+      </DialogTrigger>
+
+      <DialogContent className="max-w-md rounded-2xl border-border/60 bg-white p-6 shadow-xl">
+        <DialogHeader>
+          <DialogTitle className="text-lg font-semibold text-(--brand-ink)">
+            参加メンバーを追加
+          </DialogTitle>
+          <DialogDescription className="sr-only">
+            セッションに参加するメンバーを追加します
+          </DialogDescription>
+        </DialogHeader>
+
+        <form onSubmit={handleSubmit} className="flex flex-col gap-4">
+          <fieldset className="flex flex-col gap-1.5">
+            <legend className="text-xs font-semibold text-(--brand-ink-muted) after:ml-0.5 after:text-red-600 after:content-['*']">
+              メンバー
+            </legend>
+            <div className="max-h-48 overflow-y-auto rounded-lg border border-border/60 bg-white shadow-xs">
+              {candidates.map((candidate) => {
+                const checkboxId = `add-member-${candidate.id}`;
+                return (
+                  <label
+                    key={candidate.id}
+                    htmlFor={checkboxId}
+                    className="flex cursor-pointer items-center gap-2.5 px-3 py-2 text-sm text-(--brand-ink) transition hover:bg-(--brand-moss)/5"
+                  >
+                    <Checkbox
+                      id={checkboxId}
+                      checked={selectedUserIds.has(candidate.id)}
+                      onCheckedChange={() => toggleUser(candidate.id)}
+                    />
+                    {candidate.name}
+                  </label>
+                );
+              })}
+            </div>
+          </fieldset>
+
+          <div className="flex flex-col gap-1.5">
+            <label
+              htmlFor="add-member-role"
+              className="text-xs font-semibold text-(--brand-ink-muted) after:ml-0.5 after:text-red-600 after:content-['*']"
+            >
+              ロール
+            </label>
+            <select
+              id="add-member-role"
+              className="w-full rounded-lg border border-border/60 bg-white px-3 py-2 text-sm text-(--brand-ink) shadow-xs focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring/30"
+              value={selectedRole}
+              onChange={(e) => setSelectedRole(e.target.value as RoleValue)}
+              aria-required="true"
+            >
+              <option value="CircleSessionManager">マネージャー</option>
+              <option value="CircleSessionMember">メンバー</option>
+            </select>
+          </div>
+
+          {error ? (
+            <p role="alert" className="text-xs text-red-600">
+              {error}
+            </p>
+          ) : null}
+
+          <DialogFooter>
+            <Button
+              type="button"
+              variant="outline"
+              className="border-(--brand-ink)/20 bg-white/80 text-(--brand-ink)"
+              onClick={() => handleOpenChange(false)}
+            >
+              キャンセル
+            </Button>
+            <Button
+              type="submit"
+              className="bg-(--brand-moss) text-white hover:bg-(--brand-moss)/90"
+              disabled={!canSubmit}
+            >
+              {isPending
+                ? "追加中..."
+                : selectedUserIds.size > 0
+                  ? `${selectedUserIds.size}人を追加`
+                  : "追加"}
+            </Button>
+          </DialogFooter>
+        </form>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/app/(authenticated)/circle-sessions/components/circle-session-detail-view.test.tsx
+++ b/app/(authenticated)/circle-sessions/components/circle-session-detail-view.test.tsx
@@ -56,6 +56,15 @@ vi.mock("@/lib/trpc/client", () => ({
         }),
       },
       memberships: {
+        add: {
+          useMutation: () => ({
+            mutate: vi.fn(),
+            isPending: false,
+            data: null,
+            error: null,
+            reset: vi.fn(),
+          }),
+        },
         updateRole: {
           useMutation: () => ({
             mutate: vi.fn(),
@@ -124,6 +133,8 @@ function buildDetail(
     canEditCircleSession: false,
     canDeleteCircleSession: false,
     canWithdrawFromCircleSession: false,
+    canAddCircleSessionMember: false,
+    addableMemberCandidates: [],
     memberships: [],
     matches: [],
     ...overrides,

--- a/app/(authenticated)/circle-sessions/components/circle-session-detail-view.tsx
+++ b/app/(authenticated)/circle-sessions/components/circle-session-detail-view.tsx
@@ -16,6 +16,7 @@ import type {
   CircleSessionDetailViewModel,
   CircleSessionRoleKey,
 } from "@/server/presentation/view-models/circle-session-detail";
+import { AddSessionMemberDialog } from "@/app/(authenticated)/circle-sessions/components/add-session-member-dialog";
 import { CircleSessionEditDialog } from "@/app/(authenticated)/circle-sessions/components/circle-session-edit-dialog";
 import { CircleSessionWithdrawButton } from "@/app/(authenticated)/circle-sessions/components/circle-session-withdraw-button";
 import { SessionMemberRoleDropdown } from "@/app/(authenticated)/circle-sessions/components/session-member-role-dropdown";
@@ -473,7 +474,18 @@ export function CircleSessionDetailView({
       </section>
 
       <section className="rounded-2xl border border-border/60 bg-white/90 p-6 shadow-sm">
-        <p className="text-sm font-semibold text-(--brand-ink)">参加メンバー</p>
+        <div className="flex items-center justify-between">
+          <p className="text-sm font-semibold text-(--brand-ink)">
+            参加メンバー
+          </p>
+          {detail.canAddCircleSessionMember &&
+          detail.addableMemberCandidates.length > 0 ? (
+            <AddSessionMemberDialog
+              circleSessionId={detail.circleSessionId}
+              candidates={detail.addableMemberCandidates}
+            />
+          ) : null}
+        </div>
         <div className="mt-4 space-y-3">
           {memberships.length === 0 ? (
             <p className="text-xs text-(--brand-ink-muted)">

--- a/server/presentation/providers/circle-session-detail-provider.ts
+++ b/server/presentation/providers/circle-session-detail-provider.ts
@@ -7,6 +7,7 @@ import { CircleSessionRole } from "@/server/domain/models/circle-session/circle-
 import { appRouter } from "@/server/presentation/trpc/router";
 import { createContext } from "@/server/presentation/trpc/context";
 import type {
+  AddableMemberCandidate,
   CircleSessionMatch,
   CircleSessionMembership,
   CircleSessionRoleKey,
@@ -110,6 +111,7 @@ export async function getCircleSessionDetailViewModel(
     canEditCircleSession,
     canDeleteCircleSession,
     canWithdrawFromCircleSession,
+    canAddCircleSessionMember,
   ] = await Promise.all([
     caller.users.list({ userIds: Array.from(userIds) }),
     viewerId
@@ -124,10 +126,42 @@ export async function getCircleSessionDetailViewModel(
     viewerId
       ? ctx.accessService.canWithdrawFromCircleSession(viewerId, session.id)
       : Promise.resolve(false),
+    viewerId
+      ? ctx.accessService.canAddCircleSessionMember(viewerId, session.id)
+      : Promise.resolve(false),
   ]);
 
   const userNameById = new Map(users.map((user) => [user.id, user.name]));
   const viewerRole = getViewerRole(memberships, viewerId);
+
+  let addableMemberCandidates: AddableMemberCandidate[] = [];
+  if (canAddCircleSessionMember) {
+    const circleMembers = await caller.circles.memberships.list({
+      circleId: session.circleId,
+    });
+    const sessionMemberIds = new Set(memberships.map((m) => m.userId));
+    const candidateUserIds = circleMembers
+      .filter((cm) => !sessionMemberIds.has(cm.userId))
+      .map((cm) => cm.userId);
+
+    if (candidateUserIds.length > 0) {
+      const candidateUserIdsToResolve = candidateUserIds.filter(
+        (id) => !userNameById.has(id),
+      );
+      if (candidateUserIdsToResolve.length > 0) {
+        const extraUsers = await caller.users.list({
+          userIds: candidateUserIdsToResolve,
+        });
+        for (const user of extraUsers) {
+          userNameById.set(user.id, user.name);
+        }
+      }
+      addableMemberCandidates = candidateUserIds.map((id) => ({
+        id,
+        name: userNameById.get(id) ?? id,
+      }));
+    }
+  }
 
   const matchViewModels: CircleSessionMatch[] = matches
     .filter((match) => match.deletedAt == null)
@@ -179,6 +213,8 @@ export async function getCircleSessionDetailViewModel(
     canEditCircleSession,
     canDeleteCircleSession,
     canWithdrawFromCircleSession,
+    canAddCircleSessionMember,
+    addableMemberCandidates,
     memberships: membershipViewModels,
     matches: matchViewModels,
   };

--- a/server/presentation/view-models/circle-session-detail.ts
+++ b/server/presentation/view-models/circle-session-detail.ts
@@ -21,6 +21,11 @@ export type CircleSessionMatch = {
   createdAtInput: string;
 };
 
+export type AddableMemberCandidate = {
+  id: string;
+  name: string;
+};
+
 export type CircleSessionDetailViewModel = {
   circleSessionId: string;
   circleId: string;
@@ -37,6 +42,8 @@ export type CircleSessionDetailViewModel = {
   canEditCircleSession: boolean;
   canDeleteCircleSession: boolean;
   canWithdrawFromCircleSession: boolean;
+  canAddCircleSessionMember: boolean;
+  addableMemberCandidates: AddableMemberCandidate[];
   memberships: CircleSessionMembership[];
   matches: CircleSessionMatch[];
 };


### PR DESCRIPTION
## Summary

- セッション詳細画面の「参加メンバー」セクションに、メンバー追加ダイアログを実装
- 研究会メンバーのうちセッション未参加者を候補として表示し、複数選択・ロール指定で一括追加可能
- 権限チェック（`canAddCircleSessionMember`）と候補リスト構築をProviderで実施し、権限のないユーザーには追加ボタンを非表示

Closes #761

## 変更内容

- `add-session-member-dialog.tsx`: 新規作成。チェックボックスによる複数メンバー選択、ロール選択、バッチ追加を行うダイアログ
- `circle-session-detail-view.tsx`: 参加メンバーセクションに追加ボタンを配置（権限＋候補ありの場合のみ表示）
- `circle-session-detail-provider.ts`: `canAddCircleSessionMember` 権限チェック、候補リスト（研究会メンバー - セッション参加者）の構築を追加
- `circle-session-detail.ts`: ViewModel に `canAddCircleSessionMember`, `AddableMemberCandidate` 型を追加
- `circle-session-detail-view.test.tsx`: テストヘルパーとモックを更新

## Test plan

- [x] `npx tsc --noEmit` OK
- [x] `npm run lint` OK
- [x] `npm run format` OK
- [x] `npm run test:run -- circle-session-detail-view.test.tsx` 15 tests passed

### 手動検証手順
- [ ] オーナー/マネージャーでログインし、セッション詳細の「参加メンバー」に「追加」ボタンが表示される
- [ ] 追加ダイアログで候補リストに既存参加者が含まれていない
- [ ] メンバーを選択・ロール指定して追加が成功し、一覧が更新される
- [ ] 一般メンバーでログインすると追加ボタンが表示されない
- [ ] 追加可能な候補がいない場合、追加ボタンが表示されない

## Known limitations

- 複数メンバー追加時の部分失敗ハンドリングが不十分 → #762
- サーバー側でセッション追加対象が研究会メンバーであることのバリデーション未実装 → #763

🤖 Generated with [Claude Code](https://claude.com/claude-code)