### PR TITLE
fix(security): セッション参加者追加時に研究会メンバーシップを検証する

### DIFF
--- a/server/application/circle-session/circle-session-membership-service.test.ts
+++ b/server/application/circle-session/circle-session-membership-service.test.ts
@@ -5,7 +5,7 @@ import {
   createInMemoryCircleRepository,
   createInMemoryCircleSessionRepository,
 } from "@/server/infrastructure/repository/in-memory";
-import { ConflictError } from "@/server/domain/common/errors";
+import { ConflictError, ForbiddenError } from "@/server/domain/common/errors";
 import { circleId, circleSessionId, userId } from "@/server/domain/common/ids";
 import { createCircleSession } from "@/server/domain/models/circle-session/circle-session";
 
@@ -106,6 +106,16 @@ describe("CircleSession セッションメンバーシップサービス", () =>
   });
 
   test("addMembership は論理削除済みユーザーをセッションに再参加できる", async () => {
+    await circleRepository.addMembership(
+      circleId("circle-1"),
+      userId("user-owner"),
+      "CircleOwner",
+    );
+    await circleRepository.addMembership(
+      circleId("circle-1"),
+      userId("user-rejoining"),
+      "CircleMember",
+    );
     await circleSessionRepository.addMembership(
       circleSessionId("session-1"),
       userId("user-owner"),
@@ -138,6 +148,11 @@ describe("CircleSession セッションメンバーシップサービス", () =>
   });
 
   test("addMembership は既存メンバーの重複追加で ConflictError", async () => {
+    await circleRepository.addMembership(
+      circleId("circle-1"),
+      userId("user-1"),
+      "CircleMember",
+    );
     await circleSessionRepository.addMembership(
       circleSessionId("session-1"),
       userId("user-1"),
@@ -160,6 +175,12 @@ describe("CircleSession セッションメンバーシップサービス", () =>
   });
 
   test("addMembership は Owner がいない状態で Member を拒否する", async () => {
+    await circleRepository.addMembership(
+      circleId("circle-1"),
+      userId("user-1"),
+      "CircleMember",
+    );
+
     await expect(
       service.addMembership({
         actorId: "user-actor",
@@ -226,7 +247,34 @@ describe("CircleSession セッションメンバーシップサービス", () =>
     expect(result[0]?.title).toBe("第2回 研究会");
   });
 
+  test("addMembership は研究会メンバーでないユーザーの追加を拒否する", async () => {
+    await circleSessionRepository.addMembership(
+      circleSessionId("session-1"),
+      userId("user-1"),
+      "CircleSessionOwner",
+    );
+
+    await expect(
+      service.addMembership({
+        actorId: "user-actor",
+        circleSessionId: circleSessionId("session-1"),
+        userId: userId("non-circle-member"),
+        role: "CircleSessionMember",
+      }),
+    ).rejects.toThrow("User is not an active member of the circle");
+
+    const memberships = await circleSessionRepository.listMemberships(
+      circleSessionId("session-1"),
+    );
+    expect(memberships).toHaveLength(1);
+  });
+
   test("addMembership は Owner がいる場合に Member を追加できる", async () => {
+    await circleRepository.addMembership(
+      circleId("circle-1"),
+      userId("user-2"),
+      "CircleMember",
+    );
     await circleSessionRepository.addMembership(
       circleSessionId("session-1"),
       userId("user-1"),

--- a/server/application/circle-session/circle-session-membership-service.ts
+++ b/server/application/circle-session/circle-session-membership-service.ts
@@ -170,6 +170,15 @@ export const createCircleSessionMembershipService = (
     if (!allowed) {
       throw new ForbiddenError();
     }
+
+    const circleMembers =
+      await deps.circleRepository.listMembershipsByCircleId(session.circleId);
+    if (!circleMembers.some((m) => m.userId === params.userId)) {
+      throw new ForbiddenError(
+        "User is not an active member of the circle",
+      );
+    }
+
     const memberships =
       await deps.circleSessionRepository.listMemberships(
         params.circleSessionId,


### PR DESCRIPTION
## Summary

Closes #763

- `CircleSessionMembershipService.addMembership()` に研究会メンバーシップ検証を追加
- 研究会のアクティブメンバーでないユーザーのセッション追加を `ForbiddenError` で拒否
- 既存テストにメンバーシップセットアップを追加し、新規テストケースを追加（全21テスト PASS）

## Test plan

- [ ] `npx vitest run server/application/circle-session/circle-session-membership-service.test.ts` で全21テスト PASS を確認
- [ ] `npx tsc --noEmit` で型チェック PASS を確認
- [ ] 研究会メンバーのセッション追加が正常に動作することを確認
- [ ] API直接呼び出しで研究会外ユーザー追加が拒否されることを確認

## Related Issues

- #765 `CircleRepository` に `findMembershipByCircleAndUser` メソッド追加（follow-up）
- #766 `ForbiddenError` と `ValidationError` の使い分け整理（follow-up）

🤖 Generated with [Claude Code](https://claude.com/claude-code)