### PR TITLE
refactor: participant/participating の命名を membership に統一する

### DIFF
--- a/server/application/circle-session/circle-session-membership-service.ts
+++ b/server/application/circle-session/circle-session-membership-service.ts
@@ -7,7 +7,7 @@ import {
 import type { CircleSessionRepository } from "@/server/domain/models/circle-session/circle-session-repository";
 import type { createAccessService } from "@/server/application/authz/access-service";
 import {
-  assertCanAddParticipantWithRole,
+  assertCanAddSessionMemberWithRole,
   assertCanChangeCircleSessionMemberRole,
   assertCanRemoveCircleSessionMember,
   assertCanWithdrawFromSession,
@@ -188,7 +188,7 @@ export const createCircleSessionMembershipService = (
       throw new ConflictError("Membership already exists");
     }
 
-    assertCanAddParticipantWithRole(memberships, params.role);
+    assertCanAddSessionMemberWithRole(memberships, params.role);
 
     await deps.circleSessionRepository.addMembership(
       params.circleSessionId,

--- a/server/application/match/match-service.ts
+++ b/server/application/match/match-service.ts
@@ -36,13 +36,13 @@ export const createMatchService = (deps: MatchServiceDeps) => {
   const uow: UnitOfWork =
     deps.unitOfWork ?? (async (op) => op(deps as unknown as Repositories));
 
-  const ensurePlayersParticipating = async (
+  const ensurePlayersAreSessionMembers = async (
     circleSessionRepository: CircleSessionRepository,
     circleSessionId: CircleSessionId,
     player1Id: UserId,
     player2Id: UserId,
   ) => {
-    const ok = await circleSessionRepository.areUsersParticipating(
+    const ok = await circleSessionRepository.areUsersSessionMembers(
       circleSessionId,
       [player1Id, player2Id],
     );
@@ -75,7 +75,7 @@ export const createMatchService = (deps: MatchServiceDeps) => {
         if (!allowed) {
           throw new ForbiddenError();
         }
-        await ensurePlayersParticipating(
+        await ensurePlayersAreSessionMembers(
           repos.circleSessionRepository,
           params.circleSessionId,
           params.player1Id,
@@ -132,7 +132,7 @@ export const createMatchService = (deps: MatchServiceDeps) => {
               "player1Id and player2Id must both be provided",
             );
           }
-          await ensurePlayersParticipating(
+          await ensurePlayersAreSessionMembers(
             repos.circleSessionRepository,
             match.circleSessionId,
             params.player1Id,

--- a/server/application/test-helpers/mock-repositories.ts
+++ b/server/application/test-helpers/mock-repositories.ts
@@ -32,7 +32,7 @@ export const createMockCircleSessionRepository = () =>
     listMembershipsByUserId: vi.fn(),
     addMembership: vi.fn(),
     updateMembershipRole: vi.fn(),
-    areUsersParticipating: vi.fn(),
+    areUsersSessionMembers: vi.fn(),
     removeMembership: vi.fn(),
   }) satisfies CircleSessionRepository;
 

--- a/server/domain/models/circle-session/circle-session-repository.ts
+++ b/server/domain/models/circle-session/circle-session-repository.ts
@@ -29,7 +29,7 @@ export type CircleSessionRepository = {
     userId: UserId,
     role: CircleSessionRole,
   ): Promise<void>;
-  areUsersParticipating(
+  areUsersSessionMembers(
     circleSessionId: CircleSessionId,
     userIds: readonly UserId[],
   ): Promise<boolean>;

--- a/server/domain/models/match/match-repository.ts
+++ b/server/domain/models/match/match-repository.ts
@@ -12,7 +12,7 @@ export type MatchRepository = {
   listByCircleSessionId(circleSessionId: CircleSessionId): Promise<Match[]>;
   /** Returns non-deleted matches where the player is player1 or player2. */
   listByPlayerId(playerId: UserId): Promise<Match[]>;
-  /** Returns non-deleted matches where both players participated. */
+  /** Returns non-deleted matches where both players are matched. */
   listByBothPlayerIds(playerId: UserId, opponentId: UserId): Promise<Match[]>;
   /** Returns non-deleted matches with circle info via CircleSession. */
   listByPlayerIdWithCircle(playerId: UserId): Promise<MatchWithCircle[]>;

--- a/server/domain/services/authz/ownership.test.ts
+++ b/server/domain/services/authz/ownership.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, test } from "vitest";
 import {
   assertCanAddCircleMemberWithRole,
-  assertCanAddParticipantWithRole,
+  assertCanAddSessionMemberWithRole,
   assertCanChangeCircleMemberRole,
   assertCanChangeCircleSessionMemberRole,
   assertCanRemoveCircleMember,
@@ -213,10 +213,10 @@ describe("Owner の不変条件", () => {
   });
 });
 
-describe("assertCanAddParticipantWithRole", () => {
+describe("assertCanAddSessionMemberWithRole", () => {
   test("Owner がいない状態で Owner 以外を追加しようとするとエラー", () => {
     expect(() =>
-      assertCanAddParticipantWithRole(
+      assertCanAddSessionMemberWithRole(
         [],
         CircleSessionRole.CircleSessionMember,
       ),
@@ -225,7 +225,7 @@ describe("assertCanAddParticipantWithRole", () => {
 
   test("Owner がいる状態で Owner を追加しようとするとエラー", () => {
     expect(() =>
-      assertCanAddParticipantWithRole(
+      assertCanAddSessionMemberWithRole(
         [
           {
             userId: userId("user-1"),
@@ -239,13 +239,13 @@ describe("assertCanAddParticipantWithRole", () => {
 
   test("Owner がいない状態で Owner を追加できる", () => {
     expect(() =>
-      assertCanAddParticipantWithRole([], CircleSessionRole.CircleSessionOwner),
+      assertCanAddSessionMemberWithRole([], CircleSessionRole.CircleSessionOwner),
     ).not.toThrow();
   });
 
   test("Owner がいる状態で Member を追加できる", () => {
     expect(() =>
-      assertCanAddParticipantWithRole(
+      assertCanAddSessionMemberWithRole(
         [
           {
             userId: userId("user-1"),
@@ -259,7 +259,7 @@ describe("assertCanAddParticipantWithRole", () => {
 
   test("Owner がいる状態で Manager を追加できる", () => {
     expect(() =>
-      assertCanAddParticipantWithRole(
+      assertCanAddSessionMemberWithRole(
         [
           {
             userId: userId("user-1"),

--- a/server/domain/services/authz/ownership.ts
+++ b/server/domain/services/authz/ownership.ts
@@ -49,12 +49,12 @@ export const assertSingleCircleSessionOwner = (
   assertSingleOwner(owners.length, "CircleSession");
 };
 
-export const assertCanAddParticipantWithRole = (
-  participants: CircleSessionMember[],
+export const assertCanAddSessionMemberWithRole = (
+  members: CircleSessionMember[],
   newRole: CircleSessionRole,
 ): void => {
-  const hasOwner = participants.some(
-    (p) => p.role === CircleSessionRole.CircleSessionOwner,
+  const hasOwner = members.some(
+    (m) => m.role === CircleSessionRole.CircleSessionOwner,
   );
   if (!hasOwner && newRole !== CircleSessionRole.CircleSessionOwner) {
     throw new Error("CircleSession must have exactly one owner");

--- a/server/infrastructure/repository/circle-session/prisma-circle-session-repository.test.ts
+++ b/server/infrastructure/repository/circle-session/prisma-circle-session-repository.test.ts
@@ -227,11 +227,11 @@ describe("Prisma CircleSession メンバーシップリポジトリ", () => {
     vi.clearAllMocks();
   });
 
-  test("areUsersParticipating は全員参加なら true", async () => {
+  test("areUsersSessionMembers は全員参加なら true", async () => {
     mockedPrisma.circleSessionMembership.count.mockResolvedValueOnce(2);
 
     const result =
-      await prismaCircleSessionRepository.areUsersParticipating(
+      await prismaCircleSessionRepository.areUsersSessionMembers(
         circleSessionId("session-1"),
         [userId("user-1"), userId("user-2")],
       );
@@ -246,11 +246,11 @@ describe("Prisma CircleSession メンバーシップリポジトリ", () => {
     expect(result).toBe(true);
   });
 
-  test("areUsersParticipating は一部不参加なら false", async () => {
+  test("areUsersSessionMembers は一部不参加なら false", async () => {
     mockedPrisma.circleSessionMembership.count.mockResolvedValueOnce(1);
 
     const result =
-      await prismaCircleSessionRepository.areUsersParticipating(
+      await prismaCircleSessionRepository.areUsersSessionMembers(
         circleSessionId("session-1"),
         [userId("user-1"), userId("user-2")],
       );
@@ -258,9 +258,9 @@ describe("Prisma CircleSession メンバーシップリポジトリ", () => {
     expect(result).toBe(false);
   });
 
-  test("areUsersParticipating は空配列で false", async () => {
+  test("areUsersSessionMembers は空配列で false", async () => {
     const result =
-      await prismaCircleSessionRepository.areUsersParticipating(
+      await prismaCircleSessionRepository.areUsersSessionMembers(
         circleSessionId("session-1"),
         [],
       );
@@ -269,11 +269,11 @@ describe("Prisma CircleSession メンバーシップリポジトリ", () => {
     expect(mockedPrisma.circleSessionMembership.count).not.toHaveBeenCalled();
   });
 
-  test("areUsersParticipating は重複したユーザーを排除する", async () => {
+  test("areUsersSessionMembers は重複したユーザーを排除する", async () => {
     mockedPrisma.circleSessionMembership.count.mockResolvedValueOnce(1);
 
     const result =
-      await prismaCircleSessionRepository.areUsersParticipating(
+      await prismaCircleSessionRepository.areUsersSessionMembers(
         circleSessionId("session-1"),
         [userId("user-1"), userId("user-1")],
       );

--- a/server/infrastructure/repository/circle-session/prisma-circle-session-repository.ts
+++ b/server/infrastructure/repository/circle-session/prisma-circle-session-repository.ts
@@ -178,7 +178,7 @@ export const createPrismaCircleSessionRepository = (
     }
   },
 
-  async areUsersParticipating(
+  async areUsersSessionMembers(
     circleSessionId: CircleSessionId,
     userIds: readonly UserId[],
   ): Promise<boolean> {

--- a/server/infrastructure/repository/in-memory/in-memory-circle-session-repository.test.ts
+++ b/server/infrastructure/repository/in-memory/in-memory-circle-session-repository.test.ts
@@ -198,7 +198,7 @@ describe("InMemoryCircleSessionRepository", () => {
       expect(memberships).toHaveLength(0);
     });
 
-    test("areUsersParticipating は全員参加なら true を返す", async () => {
+    test("areUsersSessionMembers は全員参加なら true を返す", async () => {
       const repo = makeRepo();
       await repo.addMembership(
         circleSessionId("s1"),
@@ -211,14 +211,14 @@ describe("InMemoryCircleSessionRepository", () => {
         CircleSessionRole.CircleSessionMember,
       );
 
-      const result = await repo.areUsersParticipating(
+      const result = await repo.areUsersSessionMembers(
         circleSessionId("s1"),
         [userId("u1"), userId("u2")],
       );
       expect(result).toBe(true);
     });
 
-    test("areUsersParticipating は一人でも不参加なら false を返す", async () => {
+    test("areUsersSessionMembers は一人でも不参加なら false を返す", async () => {
       const repo = makeRepo();
       await repo.addMembership(
         circleSessionId("s1"),
@@ -226,23 +226,23 @@ describe("InMemoryCircleSessionRepository", () => {
         CircleSessionRole.CircleSessionMember,
       );
 
-      const result = await repo.areUsersParticipating(
+      const result = await repo.areUsersSessionMembers(
         circleSessionId("s1"),
         [userId("u1"), userId("u2")],
       );
       expect(result).toBe(false);
     });
 
-    test("areUsersParticipating は空配列なら false を返す", async () => {
+    test("areUsersSessionMembers は空配列なら false を返す", async () => {
       const repo = makeRepo();
-      const result = await repo.areUsersParticipating(
+      const result = await repo.areUsersSessionMembers(
         circleSessionId("s1"),
         [],
       );
       expect(result).toBe(false);
     });
 
-    test("areUsersParticipating は論理削除済みメンバーを除外する", async () => {
+    test("areUsersSessionMembers は論理削除済みメンバーを除外する", async () => {
       const repo = makeRepo();
       await repo.addMembership(
         circleSessionId("s1"),
@@ -255,7 +255,7 @@ describe("InMemoryCircleSessionRepository", () => {
         new Date(),
       );
 
-      const result = await repo.areUsersParticipating(
+      const result = await repo.areUsersSessionMembers(
         circleSessionId("s1"),
         [userId("u1")],
       );

--- a/server/infrastructure/repository/in-memory/in-memory-circle-session-repository.ts
+++ b/server/infrastructure/repository/in-memory/in-memory-circle-session-repository.ts
@@ -128,7 +128,7 @@ export const createInMemoryCircleSessionRepository = (
     membershipStore.set(circleSessionId, updated);
   },
 
-  async areUsersParticipating(
+  async areUsersSessionMembers(
     circleSessionId: CircleSessionId,
     userIds: readonly UserId[],
   ): Promise<boolean> {


### PR DESCRIPTION
## Summary

- `assertCanAddParticipantWithRole` → `assertCanAddSessionMemberWithRole`
- `areUsersParticipating` → `areUsersSessionMembers`
- `ensurePlayersParticipating` → `ensurePlayersAreSessionMembers`
- 引数名 `participants` → `members`
- JSDocコメントの `participated` を修正

Closes #769

## Test plan

- [ ] `npm run test:run` で全テスト通過を確認
- [ ] `npx tsc --noEmit` で型エラーなしを確認
- [ ] リネーム漏れがないことを grep で確認（`participant`, `participating` が残っていないこと）

🤖 Generated with [Claude Code](https://claude.com/claude-code)