### PR TITLE
fix(ui): セッション参加者の複数追加時に部分失敗を適切にハンドリングする

### DIFF
--- a/app/(authenticated)/circle-sessions/components/add-session-member-dialog.tsx
+++ b/app/(authenticated)/circle-sessions/components/add-session-member-dialog.tsx
@@ -64,25 +64,45 @@ export function AddSessionMemberDialog({
     setIsPending(true);
     setError(null);
 
+    const succeededUserIds: string[] = [];
+    const failedUserIds: string[] = [];
+
     try {
       for (const userId of selectedUserIds) {
-        await addMember.mutateAsync({
-          circleSessionId,
-          userId,
-          role: selectedRole,
-        });
+        try {
+          await addMember.mutateAsync({
+            circleSessionId,
+            userId,
+            role: selectedRole,
+          });
+          succeededUserIds.push(userId);
+        } catch {
+          failedUserIds.push(userId);
+        }
       }
+    } finally {
+      setIsPending(false);
+    }
+
+    if (failedUserIds.length === 0) {
+      // 全件成功
       setOpen(false);
       router.refresh();
       toast.success(
-        selectedUserIds.size === 1
+        succeededUserIds.length === 1
           ? "メンバーを追加しました"
-          : `${selectedUserIds.size}人のメンバーを追加しました`,
+          : `${succeededUserIds.length}人のメンバーを追加しました`,
       );
-    } catch (e) {
-      setError(e instanceof Error ? e.message : "追加に失敗しました");
-    } finally {
-      setIsPending(false);
+    } else if (succeededUserIds.length > 0) {
+      // 部分成功
+      router.refresh();
+      setSelectedUserIds(new Set(failedUserIds));
+      setError(
+        `${succeededUserIds.length}人の追加に成功、${failedUserIds.length}人の追加に失敗しました`,
+      );
+    } else {
+      // 全件失敗
+      setError("追加に失敗しました");
     }
   };
 


### PR DESCRIPTION
## Summary

Closes #762

- `handleSubmit` 内の `for` ループに個別 `try/catch` を追加し、成功/失敗を userId 単位で追跡
- 部分成功時: `router.refresh()` で成功分をUIに反映し、失敗分のみ `selectedUserIds` に残す
- 全件失敗時: エラーメッセージを表示し選択状態を維持
- `setIsPending(false)` を `try/finally` で保護し、例外時のフリーズを防止

## Test plan

- [ ] 2人以上選択して全件成功 → ダイアログが閉じ、トーストに人数が表示される
- [ ] 部分失敗時 → 成功分がリストに反映、失敗分のみチェック状態で残り、エラーメッセージに成功/失敗件数が表示される
- [ ] 全件失敗時 → 「追加に失敗しました」エラーが表示され、選択状態が維持される
- [ ] 1人選択して成功 → 「メンバーを追加しました」トーストが表示される
- [ ] `npx tsc --noEmit` エラーなし

## Related

- Follow-up: #772 (エラー詳細の表示)

🤖 Generated with [Claude Code](https://claude.com/claude-code)