### PR TITLE
fix(ui): セッションメンバー追加失敗時にエラー詳細を表示する

### DIFF
--- a/app/(authenticated)/circle-sessions/components/add-session-member-dialog.tsx
+++ b/app/(authenticated)/circle-sessions/components/add-session-member-dialog.tsx
@@ -26,6 +26,22 @@ type AddSessionMemberDialogProps = {
 
 type RoleValue = "CircleSessionManager" | "CircleSessionMember";
 
+function toUserFacingMessage(error: unknown): string {
+  if (!(error instanceof Error)) return "不明なエラー";
+  switch (error.message) {
+    case "Membership already exists":
+      return "すでに参加しています";
+    case "User is not an active member of the circle":
+      return "研究会のメンバーではありません";
+    case "Forbidden":
+      return "権限がありません";
+    case "CircleSession not found":
+      return "セッションが見つかりません";
+    default:
+      return "不明なエラー";
+  }
+}
+
 export function AddSessionMemberDialog({
   circleSessionId,
   candidates,
@@ -66,6 +82,7 @@ export function AddSessionMemberDialog({
 
     const succeededUserIds: string[] = [];
     const failedUserIds: string[] = [];
+    const errorMessages = new Set<string>();
 
     try {
       for (const userId of selectedUserIds) {
@@ -76,8 +93,9 @@ export function AddSessionMemberDialog({
             role: selectedRole,
           });
           succeededUserIds.push(userId);
-        } catch {
+        } catch (error) {
           failedUserIds.push(userId);
+          errorMessages.add(toUserFacingMessage(error));
         }
       }
     } finally {
@@ -97,12 +115,14 @@ export function AddSessionMemberDialog({
       // 部分成功
       router.refresh();
       setSelectedUserIds(new Set(failedUserIds));
+      const reasons = [...errorMessages].join("、");
       setError(
-        `${succeededUserIds.length}人の追加に成功、${failedUserIds.length}人の追加に失敗しました`,
+        `${succeededUserIds.length}人の追加に成功、${failedUserIds.length}人の追加に失敗しました（${reasons}）`,
       );
     } else {
       // 全件失敗
-      setError("追加に失敗しました");
+      const reasons = [...errorMessages].join("、");
+      setError(`追加に失敗しました（${reasons}）`);
     }
   };
 


### PR DESCRIPTION
## Summary

Closes #772

- セッションメンバー追加の部分失敗・全件失敗時に、件数だけでなくエラーの理由を表示するように変更
- サーバーの英語エラーメッセージを日本語に変換する `toUserFacingMessage` 関数を追加
- `Set<string>` で重複するエラーメッセージを排除

## Changes

- `add-session-member-dialog.tsx`:
  - `toUserFacingMessage()`: 英語→日本語マッピング（`Membership already exists` → `すでに参加しています` 等）
  - `catch` ブロックでエラーメッセージを収集し、失敗通知に含める

## Test plan

- [ ] 型チェック・lint 通過済み
- [ ] 未参加メンバー1人追加 → 成功toast表示
- [ ] 未参加メンバー複数人追加 → 成功toast表示
- [ ] 既参加メンバー追加 → 「追加に失敗しました（すでに参加しています）」表示
- [ ] 既参加+未参加を同時追加 → 「1人の追加に成功、1人の追加に失敗しました（すでに参加しています）」表示

🤖 Generated with [Claude Code](https://claude.com/claude-code)