### PR TITLE
refactor(authz): ForbiddenErrorとValidationErrorの使い分けを整理する

### DIFF
--- a/server/application/circle-session/circle-session-membership-service.test.ts
+++ b/server/application/circle-session/circle-session-membership-service.test.ts
@@ -5,7 +5,11 @@ import {
   createInMemoryCircleRepository,
   createInMemoryCircleSessionRepository,
 } from "@/server/infrastructure/repository/in-memory";
-import { ConflictError, ForbiddenError } from "@/server/domain/common/errors";
+import {
+  BadRequestError,
+  ConflictError,
+  ForbiddenError,
+} from "@/server/domain/common/errors";
 import { circleId, circleSessionId, userId } from "@/server/domain/common/ids";
 import { createCircleSession } from "@/server/domain/models/circle-session/circle-session";
 
@@ -188,6 +192,14 @@ describe("CircleSession セッションメンバーシップサービス", () =>
         userId: userId("user-1"),
         role: "CircleSessionMember",
       }),
+    ).rejects.toThrow(BadRequestError);
+    await expect(
+      service.addMembership({
+        actorId: "user-actor",
+        circleSessionId: circleSessionId("session-1"),
+        userId: userId("user-1"),
+        role: "CircleSessionMember",
+      }),
     ).rejects.toThrow("CircleSession must have exactly one owner");
 
     const memberships = await circleSessionRepository.listMemberships(
@@ -254,6 +266,14 @@ describe("CircleSession セッションメンバーシップサービス", () =>
       "CircleSessionOwner",
     );
 
+    await expect(
+      service.addMembership({
+        actorId: "user-actor",
+        circleSessionId: circleSessionId("session-1"),
+        userId: userId("non-circle-member"),
+        role: "CircleSessionMember",
+      }),
+    ).rejects.toThrow(BadRequestError);
     await expect(
       service.addMembership({
         actorId: "user-actor",

--- a/server/application/circle-session/circle-session-membership-service.ts
+++ b/server/application/circle-session/circle-session-membership-service.ts
@@ -18,6 +18,7 @@ import { CircleSessionRole } from "@/server/domain/models/circle-session/circle-
 import type { CircleSessionMembership } from "@/server/domain/models/circle-session/circle-session-membership";
 import type { CircleRepository } from "@/server/domain/models/circle/circle-repository";
 import {
+  BadRequestError,
   ConflictError,
   ForbiddenError,
   NotFoundError,
@@ -174,7 +175,7 @@ export const createCircleSessionMembershipService = (
     const circleMembers =
       await deps.circleRepository.listMembershipsByCircleId(session.circleId);
     if (!circleMembers.some((m) => m.userId === params.userId)) {
-      throw new ForbiddenError(
+      throw new BadRequestError(
         "User is not an active member of the circle",
       );
     }

--- a/server/application/circle/circle-membership-service.test.ts
+++ b/server/application/circle/circle-membership-service.test.ts
@@ -5,7 +5,11 @@ import {
   createInMemoryCircleRepository,
   createInMemoryRepositories,
 } from "@/server/infrastructure/repository/in-memory";
-import { ConflictError, ForbiddenError } from "@/server/domain/common/errors";
+import {
+  BadRequestError,
+  ConflictError,
+  ForbiddenError,
+} from "@/server/domain/common/errors";
 import { circleId, userId } from "@/server/domain/common/ids";
 
 const circleRepository = createInMemoryCircleRepository();
@@ -188,6 +192,14 @@ describe("Circle メンバーシップサービス", () => {
   });
 
   test("addMembership は Owner がいない状態で Member を拒否する", async () => {
+    await expect(
+      service.addMembership({
+        actorId: "user-actor",
+        circleId: circleId("circle-1"),
+        userId: userId("user-1"),
+        role: "CircleMember",
+      }),
+    ).rejects.toThrow(BadRequestError);
     await expect(
       service.addMembership({
         actorId: "user-actor",

--- a/server/domain/services/authz/ownership.test.ts
+++ b/server/domain/services/authz/ownership.test.ts
@@ -13,7 +13,7 @@ import {
   transferCircleOwnership,
   transferCircleSessionOwnership,
 } from "@/server/domain/services/authz/ownership";
-import { ForbiddenError } from "@/server/domain/common/errors";
+import { BadRequestError, ForbiddenError } from "@/server/domain/common/errors";
 import { userId } from "@/server/domain/common/ids";
 import { CircleRole } from "@/server/domain/models/circle/circle-role";
 import { CircleSessionRole } from "@/server/domain/models/circle-session/circle-session-role";
@@ -220,10 +220,27 @@ describe("assertCanAddSessionMemberWithRole", () => {
         [],
         CircleSessionRole.CircleSessionMember,
       ),
+    ).toThrow(BadRequestError);
+    expect(() =>
+      assertCanAddSessionMemberWithRole(
+        [],
+        CircleSessionRole.CircleSessionMember,
+      ),
     ).toThrow("CircleSession must have exactly one owner");
   });
 
   test("Owner がいる状態で Owner を追加しようとするとエラー", () => {
+    expect(() =>
+      assertCanAddSessionMemberWithRole(
+        [
+          {
+            userId: userId("user-1"),
+            role: CircleSessionRole.CircleSessionOwner,
+          },
+        ],
+        CircleSessionRole.CircleSessionOwner,
+      ),
+    ).toThrow(BadRequestError);
     expect(() =>
       assertCanAddSessionMemberWithRole(
         [
@@ -468,10 +485,19 @@ describe("assertCanAddCircleMemberWithRole", () => {
   test("Owner がいない状態で Owner 以外を追加しようとするとエラー", () => {
     expect(() =>
       assertCanAddCircleMemberWithRole([], CircleRole.CircleMember),
+    ).toThrow(BadRequestError);
+    expect(() =>
+      assertCanAddCircleMemberWithRole([], CircleRole.CircleMember),
     ).toThrow("Circle must have exactly one owner");
   });
 
   test("Owner がいる状態で Owner を追加しようとするとエラー", () => {
+    expect(() =>
+      assertCanAddCircleMemberWithRole(
+        [{ userId: userId("user-1"), role: CircleRole.CircleOwner }],
+        CircleRole.CircleOwner,
+      ),
+    ).toThrow(BadRequestError);
     expect(() =>
       assertCanAddCircleMemberWithRole(
         [{ userId: userId("user-1"), role: CircleRole.CircleOwner }],

--- a/server/domain/services/authz/ownership.ts
+++ b/server/domain/services/authz/ownership.ts
@@ -1,4 +1,8 @@
-import { ForbiddenError, NotFoundError } from "@/server/domain/common/errors";
+import {
+  BadRequestError,
+  ForbiddenError,
+  NotFoundError,
+} from "@/server/domain/common/errors";
 import type { UserId } from "@/server/domain/common/ids";
 import { assertDifferentIds } from "@/server/domain/common/validation";
 import { CircleRole } from "@/server/domain/models/circle/circle-role";
@@ -33,10 +37,10 @@ export const assertCanAddCircleMemberWithRole = (
 ): void => {
   const hasOwner = members.some((m) => m.role === CircleRole.CircleOwner);
   if (!hasOwner && newRole !== CircleRole.CircleOwner) {
-    throw new Error("Circle must have exactly one owner");
+    throw new BadRequestError("Circle must have exactly one owner");
   }
   if (hasOwner && newRole === CircleRole.CircleOwner) {
-    throw new Error("Circle must have exactly one owner");
+    throw new BadRequestError("Circle must have exactly one owner");
   }
 };
 
@@ -57,10 +61,10 @@ export const assertCanAddSessionMemberWithRole = (
     (m) => m.role === CircleSessionRole.CircleSessionOwner,
   );
   if (!hasOwner && newRole !== CircleSessionRole.CircleSessionOwner) {
-    throw new Error("CircleSession must have exactly one owner");
+    throw new BadRequestError("CircleSession must have exactly one owner");
   }
   if (hasOwner && newRole === CircleSessionRole.CircleSessionOwner) {
-    throw new Error("CircleSession must have exactly one owner");
+    throw new BadRequestError("CircleSession must have exactly one owner");
   }
 };
 


### PR DESCRIPTION
## Summary

Closes #766

- `ownership.ts` の `assertCanAddCircleMemberWithRole` / `assertCanAddSessionMemberWithRole` で plain `Error` → `BadRequestError` に変更
- `circle-session-membership-service.ts` の非研究会メンバー検証で `ForbiddenError` → `BadRequestError` に変更
- 各テストファイルでエラー型（`BadRequestError`）の検証を追加

**使い分け基準:**
- `ForbiddenError`（403）: アクターの認可失敗（権限不足）
- `BadRequestError`（400）: リクエストデータの不正（入力バリデーション失敗）

## Test plan

- [x] `ownership.test.ts`: 85テスト全パス
- [x] `circle-session-membership-service.test.ts`: 全パス
- [x] `circle-membership-service.test.ts`: 全パス
- [x] `tsc --noEmit`: 型エラーなし
- [ ] フロントエンドで認可エラーと入力バリデーションエラーが区別されることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)