### PR TITLE
test: エラー型・メッセージの二重呼び出しパターンを単一呼び出しに統一する (#775)

### DIFF
--- a/server/application/circle-session/circle-session-membership-service.test.ts
+++ b/server/application/circle-session/circle-session-membership-service.test.ts
@@ -8,9 +8,23 @@ import {
 import {
   BadRequestError,
   ConflictError,
-  ForbiddenError,
 } from "@/server/domain/common/errors";
 import { circleId, circleSessionId, userId } from "@/server/domain/common/ids";
+
+async function expectReject<T extends Error>(
+  promise: Promise<unknown>,
+  errorClass: new (...args: never[]) => T,
+  message: string,
+) {
+  let caught: unknown;
+  try {
+    await promise;
+  } catch (e) {
+    caught = e;
+  }
+  expect(caught).toBeInstanceOf(errorClass);
+  expect(caught).toHaveProperty("message", message);
+}
 import { createCircleSession } from "@/server/domain/models/circle-session/circle-session";
 
 const circleSessionRepository = createInMemoryCircleSessionRepository();
@@ -185,22 +199,16 @@ describe("CircleSession セッションメンバーシップサービス", () =>
       "CircleMember",
     );
 
-    await expect(
+    await expectReject(
       service.addMembership({
         actorId: "user-actor",
         circleSessionId: circleSessionId("session-1"),
         userId: userId("user-1"),
         role: "CircleSessionMember",
       }),
-    ).rejects.toThrow(BadRequestError);
-    await expect(
-      service.addMembership({
-        actorId: "user-actor",
-        circleSessionId: circleSessionId("session-1"),
-        userId: userId("user-1"),
-        role: "CircleSessionMember",
-      }),
-    ).rejects.toThrow("CircleSession must have exactly one owner");
+      BadRequestError,
+      "CircleSession must have exactly one owner",
+    );
 
     const memberships = await circleSessionRepository.listMemberships(
       circleSessionId("session-1"),
@@ -266,22 +274,16 @@ describe("CircleSession セッションメンバーシップサービス", () =>
       "CircleSessionOwner",
     );
 
-    await expect(
+    await expectReject(
       service.addMembership({
         actorId: "user-actor",
         circleSessionId: circleSessionId("session-1"),
         userId: userId("non-circle-member"),
         role: "CircleSessionMember",
       }),
-    ).rejects.toThrow(BadRequestError);
-    await expect(
-      service.addMembership({
-        actorId: "user-actor",
-        circleSessionId: circleSessionId("session-1"),
-        userId: userId("non-circle-member"),
-        role: "CircleSessionMember",
-      }),
-    ).rejects.toThrow("User is not an active member of the circle");
+      BadRequestError,
+      "User is not an active member of the circle",
+    );
 
     const memberships = await circleSessionRepository.listMemberships(
       circleSessionId("session-1"),

--- a/server/application/circle/circle-membership-service.test.ts
+++ b/server/application/circle/circle-membership-service.test.ts
@@ -12,6 +12,21 @@ import {
 } from "@/server/domain/common/errors";
 import { circleId, userId } from "@/server/domain/common/ids";
 
+async function expectReject<T extends Error>(
+  promise: Promise<unknown>,
+  errorClass: new (...args: never[]) => T,
+  message: string,
+) {
+  let caught: unknown;
+  try {
+    await promise;
+  } catch (e) {
+    caught = e;
+  }
+  expect(caught).toBeInstanceOf(errorClass);
+  expect(caught).toHaveProperty("message", message);
+}
+
 const circleRepository = createInMemoryCircleRepository();
 
 const accessService = createAccessServiceStub();
@@ -192,22 +207,16 @@ describe("Circle メンバーシップサービス", () => {
   });
 
   test("addMembership は Owner がいない状態で Member を拒否する", async () => {
-    await expect(
+    await expectReject(
       service.addMembership({
         actorId: "user-actor",
         circleId: circleId("circle-1"),
         userId: userId("user-1"),
         role: "CircleMember",
       }),
-    ).rejects.toThrow(BadRequestError);
-    await expect(
-      service.addMembership({
-        actorId: "user-actor",
-        circleId: circleId("circle-1"),
-        userId: userId("user-1"),
-        role: "CircleMember",
-      }),
-    ).rejects.toThrow("Circle must have exactly one owner");
+      BadRequestError,
+      "Circle must have exactly one owner",
+    );
 
     const memberships = await circleRepository.listMembershipsByCircleId(
       circleId("circle-1"),
@@ -360,20 +369,15 @@ describe("Circle メンバーシップサービス", () => {
       "CircleOwner",
     );
 
-    await expect(
+    await expectReject(
       service.removeMembership({
         actorId: "user-actor",
         circleId: circleId("circle-1"),
         userId: userId("user-1"),
       }),
-    ).rejects.toThrow(ForbiddenError);
-    await expect(
-      service.removeMembership({
-        actorId: "user-actor",
-        circleId: circleId("circle-1"),
-        userId: userId("user-1"),
-      }),
-    ).rejects.toThrow("Use transferOwnership to remove owner");
+      ForbiddenError,
+      "Use transferOwnership to remove owner",
+    );
 
     const memberships = await circleRepository.listMembershipsByCircleId(
       circleId("circle-1"),

--- a/server/domain/services/authz/ownership.test.ts
+++ b/server/domain/services/authz/ownership.test.ts
@@ -18,6 +18,21 @@ import { userId } from "@/server/domain/common/ids";
 import { CircleRole } from "@/server/domain/models/circle/circle-role";
 import { CircleSessionRole } from "@/server/domain/models/circle-session/circle-session-role";
 
+function expectThrow<T extends Error>(
+  fn: () => void,
+  errorClass: new (...args: never[]) => T,
+  message: string,
+) {
+  let caught: unknown;
+  try {
+    fn();
+  } catch (e) {
+    caught = e;
+  }
+  expect(caught).toBeInstanceOf(errorClass);
+  expect(caught).toHaveProperty("message", message);
+}
+
 describe("Owner の不変条件", () => {
   test("assertSingleCircleOwner は Owner がいない場合に失敗する", () => {
     expect(() =>
@@ -215,43 +230,32 @@ describe("Owner の不変条件", () => {
 
 describe("assertCanAddSessionMemberWithRole", () => {
   test("Owner がいない状態で Owner 以外を追加しようとするとエラー", () => {
-    expect(() =>
-      assertCanAddSessionMemberWithRole(
-        [],
-        CircleSessionRole.CircleSessionMember,
-      ),
-    ).toThrow(BadRequestError);
-    expect(() =>
-      assertCanAddSessionMemberWithRole(
-        [],
-        CircleSessionRole.CircleSessionMember,
-      ),
-    ).toThrow("CircleSession must have exactly one owner");
+    expectThrow(
+      () =>
+        assertCanAddSessionMemberWithRole(
+          [],
+          CircleSessionRole.CircleSessionMember,
+        ),
+      BadRequestError,
+      "CircleSession must have exactly one owner",
+    );
   });
 
   test("Owner がいる状態で Owner を追加しようとするとエラー", () => {
-    expect(() =>
-      assertCanAddSessionMemberWithRole(
-        [
-          {
-            userId: userId("user-1"),
-            role: CircleSessionRole.CircleSessionOwner,
-          },
-        ],
-        CircleSessionRole.CircleSessionOwner,
-      ),
-    ).toThrow(BadRequestError);
-    expect(() =>
-      assertCanAddSessionMemberWithRole(
-        [
-          {
-            userId: userId("user-1"),
-            role: CircleSessionRole.CircleSessionOwner,
-          },
-        ],
-        CircleSessionRole.CircleSessionOwner,
-      ),
-    ).toThrow("CircleSession must have exactly one owner");
+    expectThrow(
+      () =>
+        assertCanAddSessionMemberWithRole(
+          [
+            {
+              userId: userId("user-1"),
+              role: CircleSessionRole.CircleSessionOwner,
+            },
+          ],
+          CircleSessionRole.CircleSessionOwner,
+        ),
+      BadRequestError,
+      "CircleSession must have exactly one owner",
+    );
   });
 
   test("Owner がいない状態で Owner を追加できる", () => {
@@ -291,10 +295,9 @@ describe("assertCanAddSessionMemberWithRole", () => {
 
 describe("assertCanWithdraw", () => {
   test("Owner は退会できない", () => {
-    expect(() => assertCanWithdraw(CircleRole.CircleOwner)).toThrow(
+    expectThrow(
+      () => assertCanWithdraw(CircleRole.CircleOwner),
       ForbiddenError,
-    );
-    expect(() => assertCanWithdraw(CircleRole.CircleOwner)).toThrow(
       "Owner cannot withdraw from circle. Use transferOwnership instead",
     );
   });
@@ -310,12 +313,10 @@ describe("assertCanWithdraw", () => {
 
 describe("assertCanWithdrawFromSession", () => {
   test("Owner は退会できない", () => {
-    expect(() =>
-      assertCanWithdrawFromSession(CircleSessionRole.CircleSessionOwner),
-    ).toThrow(ForbiddenError);
-    expect(() =>
-      assertCanWithdrawFromSession(CircleSessionRole.CircleSessionOwner),
-    ).toThrow(
+    expectThrow(
+      () =>
+        assertCanWithdrawFromSession(CircleSessionRole.CircleSessionOwner),
+      ForbiddenError,
       "Owner cannot withdraw from session. Use transferOwnership instead",
     );
   });
@@ -335,10 +336,9 @@ describe("assertCanWithdrawFromSession", () => {
 
 describe("assertCanRemoveCircleMember", () => {
   test("Owner を削除しようとすると ForbiddenError", () => {
-    expect(() => assertCanRemoveCircleMember(CircleRole.CircleOwner)).toThrow(
+    expectThrow(
+      () => assertCanRemoveCircleMember(CircleRole.CircleOwner),
       ForbiddenError,
-    );
-    expect(() => assertCanRemoveCircleMember(CircleRole.CircleOwner)).toThrow(
       "Use transferOwnership to remove owner",
     );
   });
@@ -358,33 +358,27 @@ describe("assertCanRemoveCircleMember", () => {
 
 describe("assertCanChangeCircleMemberRole", () => {
   test("Owner への変更は ForbiddenError", () => {
-    expect(() =>
-      assertCanChangeCircleMemberRole(
-        CircleRole.CircleMember,
-        CircleRole.CircleOwner,
-      ),
-    ).toThrow(ForbiddenError);
-    expect(() =>
-      assertCanChangeCircleMemberRole(
-        CircleRole.CircleMember,
-        CircleRole.CircleOwner,
-      ),
-    ).toThrow("Use transferOwnership to assign owner");
+    expectThrow(
+      () =>
+        assertCanChangeCircleMemberRole(
+          CircleRole.CircleMember,
+          CircleRole.CircleOwner,
+        ),
+      ForbiddenError,
+      "Use transferOwnership to assign owner",
+    );
   });
 
   test("Owner からの変更は ForbiddenError", () => {
-    expect(() =>
-      assertCanChangeCircleMemberRole(
-        CircleRole.CircleOwner,
-        CircleRole.CircleManager,
-      ),
-    ).toThrow(ForbiddenError);
-    expect(() =>
-      assertCanChangeCircleMemberRole(
-        CircleRole.CircleOwner,
-        CircleRole.CircleManager,
-      ),
-    ).toThrow("Use transferOwnership to change owner");
+    expectThrow(
+      () =>
+        assertCanChangeCircleMemberRole(
+          CircleRole.CircleOwner,
+          CircleRole.CircleManager,
+        ),
+      ForbiddenError,
+      "Use transferOwnership to change owner",
+    );
   });
 
   test("Member から Manager への変更は可能", () => {
@@ -408,12 +402,14 @@ describe("assertCanChangeCircleMemberRole", () => {
 
 describe("assertCanRemoveCircleSessionMember", () => {
   test("Owner を削除しようとすると ForbiddenError", () => {
-    expect(() =>
-      assertCanRemoveCircleSessionMember(CircleSessionRole.CircleSessionOwner),
-    ).toThrow(ForbiddenError);
-    expect(() =>
-      assertCanRemoveCircleSessionMember(CircleSessionRole.CircleSessionOwner),
-    ).toThrow("Use transferOwnership to remove owner");
+    expectThrow(
+      () =>
+        assertCanRemoveCircleSessionMember(
+          CircleSessionRole.CircleSessionOwner,
+        ),
+      ForbiddenError,
+      "Use transferOwnership to remove owner",
+    );
   });
 
   test("Manager を削除できる", () => {
@@ -433,33 +429,27 @@ describe("assertCanRemoveCircleSessionMember", () => {
 
 describe("assertCanChangeCircleSessionMemberRole", () => {
   test("Owner への変更は ForbiddenError", () => {
-    expect(() =>
-      assertCanChangeCircleSessionMemberRole(
-        CircleSessionRole.CircleSessionMember,
-        CircleSessionRole.CircleSessionOwner,
-      ),
-    ).toThrow(ForbiddenError);
-    expect(() =>
-      assertCanChangeCircleSessionMemberRole(
-        CircleSessionRole.CircleSessionMember,
-        CircleSessionRole.CircleSessionOwner,
-      ),
-    ).toThrow("Use transferOwnership to assign owner");
+    expectThrow(
+      () =>
+        assertCanChangeCircleSessionMemberRole(
+          CircleSessionRole.CircleSessionMember,
+          CircleSessionRole.CircleSessionOwner,
+        ),
+      ForbiddenError,
+      "Use transferOwnership to assign owner",
+    );
   });
 
   test("Owner からの変更は ForbiddenError", () => {
-    expect(() =>
-      assertCanChangeCircleSessionMemberRole(
-        CircleSessionRole.CircleSessionOwner,
-        CircleSessionRole.CircleSessionManager,
-      ),
-    ).toThrow(ForbiddenError);
-    expect(() =>
-      assertCanChangeCircleSessionMemberRole(
-        CircleSessionRole.CircleSessionOwner,
-        CircleSessionRole.CircleSessionManager,
-      ),
-    ).toThrow("Use transferOwnership to change owner");
+    expectThrow(
+      () =>
+        assertCanChangeCircleSessionMemberRole(
+          CircleSessionRole.CircleSessionOwner,
+          CircleSessionRole.CircleSessionManager,
+        ),
+      ForbiddenError,
+      "Use transferOwnership to change owner",
+    );
   });
 
   test("Member から Manager への変更は可能", () => {
@@ -483,27 +473,23 @@ describe("assertCanChangeCircleSessionMemberRole", () => {
 
 describe("assertCanAddCircleMemberWithRole", () => {
   test("Owner がいない状態で Owner 以外を追加しようとするとエラー", () => {
-    expect(() =>
-      assertCanAddCircleMemberWithRole([], CircleRole.CircleMember),
-    ).toThrow(BadRequestError);
-    expect(() =>
-      assertCanAddCircleMemberWithRole([], CircleRole.CircleMember),
-    ).toThrow("Circle must have exactly one owner");
+    expectThrow(
+      () => assertCanAddCircleMemberWithRole([], CircleRole.CircleMember),
+      BadRequestError,
+      "Circle must have exactly one owner",
+    );
   });
 
   test("Owner がいる状態で Owner を追加しようとするとエラー", () => {
-    expect(() =>
-      assertCanAddCircleMemberWithRole(
-        [{ userId: userId("user-1"), role: CircleRole.CircleOwner }],
-        CircleRole.CircleOwner,
-      ),
-    ).toThrow(BadRequestError);
-    expect(() =>
-      assertCanAddCircleMemberWithRole(
-        [{ userId: userId("user-1"), role: CircleRole.CircleOwner }],
-        CircleRole.CircleOwner,
-      ),
-    ).toThrow("Circle must have exactly one owner");
+    expectThrow(
+      () =>
+        assertCanAddCircleMemberWithRole(
+          [{ userId: userId("user-1"), role: CircleRole.CircleOwner }],
+          CircleRole.CircleOwner,
+        ),
+      BadRequestError,
+      "Circle must have exactly one owner",
+    );
   });
 
   test("Owner がいない状態で Owner を追加できる", () => {


### PR DESCRIPTION
## Summary

- エラーをスローするテストで同一操作を2回呼び出してエラー型・メッセージを別々に検証していたパターンを、1回の呼び出しで両方検証するパターンに統一
- 同期関数用 `expectThrow` / 非同期関数用 `expectReject` ヘルパーを導入
- 対象: ownership.test.ts（12箇所）、circle-membership-service.test.ts（2箇所）、circle-session-membership-service.test.ts（2箇所）

Closes #775

## Test plan

- [x] 対象3ファイルの全テスト（85件）がパス
- [x] 型チェック（`npx tsc --noEmit`）エラーなし
- [x] プロダクションコード変更なし（テストファイルのみ）
- [ ] diff でエラー型の `instanceof` チェックが維持されていることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)