### PR TITLE
refactor: CircleRepository に findMembershipByCircleAndUser を追加する (#765)

### DIFF
--- a/server/application/circle-session/circle-session-membership-service.ts
+++ b/server/application/circle-session/circle-session-membership-service.ts
@@ -172,9 +172,12 @@ export const createCircleSessionMembershipService = (
       throw new ForbiddenError();
     }
 
-    const circleMembers =
-      await deps.circleRepository.listMembershipsByCircleId(session.circleId);
-    if (!circleMembers.some((m) => m.userId === params.userId)) {
+    const circleMembership =
+      await deps.circleRepository.findMembershipByCircleAndUser(
+        session.circleId,
+        params.userId,
+      );
+    if (!circleMembership) {
       throw new BadRequestError(
         "User is not an active member of the circle",
       );

--- a/server/application/test-helpers/mock-repositories.ts
+++ b/server/application/test-helpers/mock-repositories.ts
@@ -42,6 +42,7 @@ export const createMockCircleRepository = () =>
     findByIds: vi.fn(),
     save: vi.fn(),
     delete: vi.fn(),
+    findMembershipByCircleAndUser: vi.fn(),
     listMembershipsByCircleId: vi.fn(),
     listMembershipsByUserId: vi.fn(),
     addMembership: vi.fn(),

--- a/server/domain/models/circle/circle-repository.ts
+++ b/server/domain/models/circle/circle-repository.ts
@@ -8,6 +8,10 @@ export type CircleRepository = {
   findByIds(ids: readonly CircleId[]): Promise<Circle[]>;
   save(circle: Circle): Promise<void>;
   delete(id: CircleId): Promise<void>;
+  findMembershipByCircleAndUser(
+    circleId: CircleId,
+    userId: UserId,
+  ): Promise<CircleMembership | null>;
   listMembershipsByCircleId(circleId: CircleId): Promise<CircleMembership[]>;
   listMembershipsByUserId(userId: UserId): Promise<CircleMembership[]>;
   addMembership(

--- a/server/infrastructure/repository/circle/prisma-circle-repository.ts
+++ b/server/infrastructure/repository/circle/prisma-circle-repository.ts
@@ -62,6 +62,28 @@ export const createPrismaCircleRepository = (
     await client.circle.delete({ where: { id: toPersistenceId(id) } });
   },
 
+  async findMembershipByCircleAndUser(
+    circleId: CircleId,
+    userId: UserId,
+  ): Promise<CircleMembership | null> {
+    const found = await client.circleMembership.findFirst({
+      where: {
+        circleId: toPersistenceId(circleId),
+        userId: toPersistenceId(userId),
+        deletedAt: null,
+      },
+      select: {
+        circleId: true,
+        userId: true,
+        role: true,
+        createdAt: true,
+        deletedAt: true,
+      },
+    });
+
+    return found ? mapCircleMembershipFromPersistence(found) : null;
+  },
+
   async listMembershipsByCircleId(
     circleId: CircleId,
   ): Promise<CircleMembership[]> {

--- a/server/infrastructure/repository/in-memory/in-memory-circle-repository.ts
+++ b/server/infrastructure/repository/in-memory/in-memory-circle-repository.ts
@@ -38,6 +38,14 @@ export const createInMemoryCircleRepository = (
     circleStore.delete(id);
   },
 
+  async findMembershipByCircleAndUser(
+    circleId: CircleId,
+    userId: UserId,
+  ): Promise<CircleMembership | null> {
+    const all = membershipStore.get(circleId) ?? [];
+    return all.find((m) => m.userId === userId && m.deletedAt === null) ?? null;
+  },
+
   async listMembershipsByCircleId(
     circleId: CircleId,
   ): Promise<CircleMembership[]> {


### PR DESCRIPTION
## Summary

- `CircleRepository` インターフェースに `findMembershipByCircleAndUser` メソッドを追加
- Prisma / InMemory 両リポジトリに実装を追加（`deletedAt: null` フィルタ付き）
- `CircleSessionMembershipService.addMembership` の研究会メンバーシップ検証を全件取得+`some()`から単一レコード検索に置き換え

Closes #765

## Test plan

- [x] `npx tsc --noEmit` 型エラーなし
- [x] `circle-session-membership-service.test.ts` 21/21 tests passed
- [ ] Prisma実装の `select` 句が既存の `listMembershipsByCircleId` と一致していること
- [ ] InMemory実装のフィルタ条件が Prisma 実装と同等であること
- [ ] サービス層のエラーメッセージ・エラー型が変更されていないこと

🤖 Generated with [Claude Code](https://claude.com/claude-code)