### PR TITLE
fix: updateRole スキーマで CircleOwner を入力段階で拒否する

### DIFF
--- a/app/(authenticated)/circles/components/member-role-dropdown.tsx
+++ b/app/(authenticated)/circles/components/member-role-dropdown.tsx
@@ -7,8 +7,10 @@ import {
   DropdownMenuTrigger,
 } from "@/components/ui/dropdown-menu";
 import { trpc } from "@/lib/trpc/client";
-import type { CircleRole } from "@/server/domain/models/circle/circle-role";
+import type { CircleMembershipRoleUpdateInput } from "@/server/presentation/dto/circle-membership";
 import type { CircleRoleKey } from "@/server/presentation/view-models/circle-overview";
+
+type AssignableCircleRole = CircleMembershipRoleUpdateInput["role"];
 import { Check, Pencil } from "lucide-react";
 import { useRouter } from "next/navigation";
 import { toast } from "sonner";
@@ -22,7 +24,7 @@ type MemberRoleDropdownProps = {
 const assignableRoles: ReadonlyArray<{
   key: CircleRoleKey;
   label: string;
-  apiValue: CircleRole;
+  apiValue: AssignableCircleRole;
 }> = [
   { key: "manager", label: "マネージャー", apiValue: "CircleManager" },
   { key: "member", label: "メンバー", apiValue: "CircleMember" },
@@ -44,7 +46,7 @@ export function MemberRoleDropdown({
     },
   });
 
-  const handleRoleChange = (apiValue: CircleRole) => {
+  const handleRoleChange = (apiValue: AssignableCircleRole) => {
     updateRole.mutate({ circleId, userId, role: apiValue });
   };
 

--- a/server/presentation/dto/circle-membership.test.ts
+++ b/server/presentation/dto/circle-membership.test.ts
@@ -1,0 +1,41 @@
+import { describe, expect, test } from "vitest";
+import { circleMembershipRoleUpdateInputSchema } from "@/server/presentation/dto/circle-membership";
+
+const validBase = {
+  circleId: "circle-1",
+  userId: "user-1",
+};
+
+describe("circleMembershipRoleUpdateInputSchema", () => {
+  test("CircleManagerを指定するとパースが成功する", () => {
+    const result = circleMembershipRoleUpdateInputSchema.safeParse({
+      ...validBase,
+      role: "CircleManager",
+    });
+    expect(result.success).toBe(true);
+  });
+
+  test("CircleMemberを指定するとパースが成功する", () => {
+    const result = circleMembershipRoleUpdateInputSchema.safeParse({
+      ...validBase,
+      role: "CircleMember",
+    });
+    expect(result.success).toBe(true);
+  });
+
+  test("CircleOwnerを指定するとバリデーションエラーになる", () => {
+    const result = circleMembershipRoleUpdateInputSchema.safeParse({
+      ...validBase,
+      role: "CircleOwner",
+    });
+    expect(result.success).toBe(false);
+  });
+
+  test("不正な文字列を指定するとバリデーションエラーになる", () => {
+    const result = circleMembershipRoleUpdateInputSchema.safeParse({
+      ...validBase,
+      role: "InvalidRole",
+    });
+    expect(result.success).toBe(false);
+  });
+});

--- a/server/presentation/dto/circle-membership.ts
+++ b/server/presentation/dto/circle-membership.ts
@@ -1,6 +1,9 @@
 import { z } from "zod";
 import { circleIdSchema, userIdSchema } from "@/server/presentation/dto/ids";
-import { circleRoleSchema } from "@/server/presentation/dto/roles";
+import {
+  assignableCircleRoleSchema,
+  circleRoleSchema,
+} from "@/server/presentation/dto/roles";
 
 export const circleMembershipDtoSchema = z.object({
   userId: userIdSchema,
@@ -32,7 +35,7 @@ export type CircleMembershipCreateInput = z.infer<
 export const circleMembershipRoleUpdateInputSchema = z.object({
   circleId: circleIdSchema,
   userId: userIdSchema,
-  role: circleRoleSchema,
+  role: assignableCircleRoleSchema,
 });
 
 export type CircleMembershipRoleUpdateInput = z.infer<

--- a/server/presentation/dto/roles.ts
+++ b/server/presentation/dto/roles.ts
@@ -11,6 +11,13 @@ const circleRoleValues = [
 export const circleRoleSchema = z.enum(circleRoleValues);
 export type CircleRoleDto = z.infer<typeof circleRoleSchema>;
 
+const assignableCircleRoleValues = [
+  CircleRole.CircleManager,
+  CircleRole.CircleMember,
+] as const;
+
+export const assignableCircleRoleSchema = z.enum(assignableCircleRoleValues);
+
 const circleSessionRoleValues = [
   CircleSessionRole.CircleSessionOwner,
   CircleSessionRole.CircleSessionManager,


### PR DESCRIPTION
## Summary

Closes #756

- `assignableCircleRoleSchema` を `roles.ts` に導入し、`CircleManager` / `CircleMember` のみ許可
- `circleMembershipRoleUpdateInputSchema` の `role` フィールドを `assignableCircleRoleSchema` に変更
- フロントエンド（`member-role-dropdown.tsx`）の型を `AssignableCircleRole` に統一
- バリデーション動作を検証するテストを追加

## Why

ドメイン層で既にキャッチされているが、Zod バリデーション段階で早期拒否することで defense-in-depth を向上させる。

## Test plan

- [ ] `npm run test:run -- server/presentation/dto/circle-membership.test.ts` でテスト通過を確認
- [ ] `npx tsc --noEmit` で型エラーがないことを確認
- [ ] 画面からロール変更操作が正常に動作すること

🤖 Generated with [Claude Code](https://claude.com/claude-code)