### PR TITLE
fix: 入力スキーマで CircleSessionOwner を入力段階で拒否する (#783)

### DIFF
--- a/app/(authenticated)/circle-sessions/components/session-member-role-dropdown.tsx
+++ b/app/(authenticated)/circle-sessions/components/session-member-role-dropdown.tsx
@@ -7,7 +7,6 @@ import {
   DropdownMenuTrigger,
 } from "@/components/ui/dropdown-menu";
 import { trpc } from "@/lib/trpc/client";
-import type { CircleSessionRole } from "@/server/domain/models/circle-session/circle-session-role";
 import type { CircleSessionRoleKey } from "@/server/presentation/view-models/circle-session-detail";
 import { Check, Pencil } from "lucide-react";
 import { useRouter } from "next/navigation";
@@ -19,10 +18,12 @@ type SessionMemberRoleDropdownProps = {
   currentRole: CircleSessionRoleKey;
 };
 
+type AssignableSessionRole = "CircleSessionManager" | "CircleSessionMember";
+
 const assignableRoles: ReadonlyArray<{
   key: CircleSessionRoleKey;
   label: string;
-  apiValue: CircleSessionRole;
+  apiValue: AssignableSessionRole;
 }> = [
   {
     key: "manager",
@@ -48,7 +49,7 @@ export function SessionMemberRoleDropdown({
     },
   });
 
-  const handleRoleChange = (apiValue: CircleSessionRole) => {
+  const handleRoleChange = (apiValue: AssignableSessionRole) => {
     updateRole.mutate({ circleSessionId, userId, role: apiValue });
   };
 

--- a/server/presentation/dto/circle-session-membership.test.ts
+++ b/server/presentation/dto/circle-session-membership.test.ts
@@ -1,0 +1,78 @@
+import { describe, expect, test } from "vitest";
+import {
+  circleSessionMembershipCreateInputSchema,
+  circleSessionMembershipRoleUpdateInputSchema,
+} from "@/server/presentation/dto/circle-session-membership";
+
+const validBase = {
+  circleSessionId: "session-1",
+  userId: "user-1",
+};
+
+describe("circleSessionMembershipCreateInputSchema", () => {
+  test("CircleSessionManagerを指定するとパースが成功する", () => {
+    const result = circleSessionMembershipCreateInputSchema.safeParse({
+      ...validBase,
+      role: "CircleSessionManager",
+    });
+    expect(result.success).toBe(true);
+  });
+
+  test("CircleSessionMemberを指定するとパースが成功する", () => {
+    const result = circleSessionMembershipCreateInputSchema.safeParse({
+      ...validBase,
+      role: "CircleSessionMember",
+    });
+    expect(result.success).toBe(true);
+  });
+
+  test("CircleSessionOwnerを指定するとバリデーションエラーになる", () => {
+    const result = circleSessionMembershipCreateInputSchema.safeParse({
+      ...validBase,
+      role: "CircleSessionOwner",
+    });
+    expect(result.success).toBe(false);
+  });
+
+  test("不正な文字列を指定するとバリデーションエラーになる", () => {
+    const result = circleSessionMembershipCreateInputSchema.safeParse({
+      ...validBase,
+      role: "InvalidRole",
+    });
+    expect(result.success).toBe(false);
+  });
+});
+
+describe("circleSessionMembershipRoleUpdateInputSchema", () => {
+  test("CircleSessionManagerを指定するとパースが成功する", () => {
+    const result = circleSessionMembershipRoleUpdateInputSchema.safeParse({
+      ...validBase,
+      role: "CircleSessionManager",
+    });
+    expect(result.success).toBe(true);
+  });
+
+  test("CircleSessionMemberを指定するとパースが成功する", () => {
+    const result = circleSessionMembershipRoleUpdateInputSchema.safeParse({
+      ...validBase,
+      role: "CircleSessionMember",
+    });
+    expect(result.success).toBe(true);
+  });
+
+  test("CircleSessionOwnerを指定するとバリデーションエラーになる", () => {
+    const result = circleSessionMembershipRoleUpdateInputSchema.safeParse({
+      ...validBase,
+      role: "CircleSessionOwner",
+    });
+    expect(result.success).toBe(false);
+  });
+
+  test("不正な文字列を指定するとバリデーションエラーになる", () => {
+    const result = circleSessionMembershipRoleUpdateInputSchema.safeParse({
+      ...validBase,
+      role: "InvalidRole",
+    });
+    expect(result.success).toBe(false);
+  });
+});

--- a/server/presentation/dto/circle-session-membership.ts
+++ b/server/presentation/dto/circle-session-membership.ts
@@ -3,7 +3,10 @@ import {
   circleSessionIdSchema,
   userIdSchema,
 } from "@/server/presentation/dto/ids";
-import { circleSessionRoleSchema } from "@/server/presentation/dto/roles";
+import {
+  assignableCircleSessionRoleSchema,
+  circleSessionRoleSchema,
+} from "@/server/presentation/dto/roles";
 
 export const circleSessionMembershipDtoSchema = z.object({
   userId: userIdSchema,
@@ -25,7 +28,7 @@ export type CircleSessionMembershipListInput = z.infer<
 export const circleSessionMembershipCreateInputSchema = z.object({
   circleSessionId: circleSessionIdSchema,
   userId: userIdSchema,
-  role: circleSessionRoleSchema,
+  role: assignableCircleSessionRoleSchema,
 });
 
 export type CircleSessionMembershipCreateInput = z.infer<
@@ -35,7 +38,7 @@ export type CircleSessionMembershipCreateInput = z.infer<
 export const circleSessionMembershipRoleUpdateInputSchema = z.object({
   circleSessionId: circleSessionIdSchema,
   userId: userIdSchema,
-  role: circleSessionRoleSchema,
+  role: assignableCircleSessionRoleSchema,
 });
 
 export type CircleSessionMembershipRoleUpdateInput = z.infer<

--- a/server/presentation/dto/roles.ts
+++ b/server/presentation/dto/roles.ts
@@ -18,6 +18,15 @@ const assignableCircleRoleValues = [
 
 export const assignableCircleRoleSchema = z.enum(assignableCircleRoleValues);
 
+const assignableCircleSessionRoleValues = [
+  CircleSessionRole.CircleSessionManager,
+  CircleSessionRole.CircleSessionMember,
+] as const;
+
+export const assignableCircleSessionRoleSchema = z.enum(
+  assignableCircleSessionRoleValues,
+);
+
 const circleSessionRoleValues = [
   CircleSessionRole.CircleSessionOwner,
   CircleSessionRole.CircleSessionManager,


### PR DESCRIPTION
## Summary

- `assignableCircleSessionRoleSchema`（`CircleSessionManager`, `CircleSessionMember` のみ）を `server/presentation/dto/roles.ts` に新設
- `circleSessionMembershipCreateInputSchema` と `circleSessionMembershipRoleUpdateInputSchema` の `role` を差し替え
- フロントエンドのドロップダウン型を `AssignableSessionRole` に修正
- テスト 8 ケース追加（両スキーマの受理/拒否パスを網羅）

Closes #783

## Test plan

- [x] `npm run test:run -- server/presentation/dto/circle-session-membership.test.ts`: 8 テスト全パス
- [x] `npx tsc --noEmit`: エラーなし
- [ ] Zod バリデーションで `CircleSessionOwner` が拒否されることを手動確認
- [ ] 出力 DTO（`circleSessionMembershipDtoSchema`）が全ロール含む `circleSessionRoleSchema` のままであることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)