### PR TITLE
fix: createInput スキーマで CircleOwner を入力段階で拒否する (#782)

### DIFF
--- a/server/presentation/dto/circle-membership.test.ts
+++ b/server/presentation/dto/circle-membership.test.ts
@@ -1,10 +1,47 @@
 import { describe, expect, test } from "vitest";
-import { circleMembershipRoleUpdateInputSchema } from "@/server/presentation/dto/circle-membership";
+import {
+  circleMembershipCreateInputSchema,
+  circleMembershipRoleUpdateInputSchema,
+} from "@/server/presentation/dto/circle-membership";
 
 const validBase = {
   circleId: "circle-1",
   userId: "user-1",
 };
+
+describe("circleMembershipCreateInputSchema", () => {
+  test("CircleManagerを指定するとパースが成功する", () => {
+    const result = circleMembershipCreateInputSchema.safeParse({
+      ...validBase,
+      role: "CircleManager",
+    });
+    expect(result.success).toBe(true);
+  });
+
+  test("CircleMemberを指定するとパースが成功する", () => {
+    const result = circleMembershipCreateInputSchema.safeParse({
+      ...validBase,
+      role: "CircleMember",
+    });
+    expect(result.success).toBe(true);
+  });
+
+  test("CircleOwnerを指定するとバリデーションエラーになる", () => {
+    const result = circleMembershipCreateInputSchema.safeParse({
+      ...validBase,
+      role: "CircleOwner",
+    });
+    expect(result.success).toBe(false);
+  });
+
+  test("不正な文字列を指定するとバリデーションエラーになる", () => {
+    const result = circleMembershipCreateInputSchema.safeParse({
+      ...validBase,
+      role: "InvalidRole",
+    });
+    expect(result.success).toBe(false);
+  });
+});
 
 describe("circleMembershipRoleUpdateInputSchema", () => {
   test("CircleManagerを指定するとパースが成功する", () => {

--- a/server/presentation/dto/circle-membership.ts
+++ b/server/presentation/dto/circle-membership.ts
@@ -25,7 +25,7 @@ export type CircleMembershipListInput = z.infer<
 export const circleMembershipCreateInputSchema = z.object({
   circleId: circleIdSchema,
   userId: userIdSchema,
-  role: circleRoleSchema,
+  role: assignableCircleRoleSchema,
 });
 
 export type CircleMembershipCreateInput = z.infer<


### PR DESCRIPTION
## Summary

- `circleMembershipCreateInputSchema` の `role` を `circleRoleSchema` から `assignableCircleRoleSchema` に差し替え
- `CircleOwner` を Zod バリデーション段階で拒否するようにした
- #756 の `updateRole` スキーマと同じ defense-in-depth パターンを適用

Closes #782

## Test plan

- [x] `CircleManager` / `CircleMember` でパース成功を確認
- [x] `CircleOwner` でバリデーションエラーを確認
- [x] 不正な文字列でバリデーションエラーを確認
- [x] 既存の `circleMembershipRoleUpdateInputSchema` テストが引き続きパスすることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)