### PR TITLE
test: サインアップフォームの未テストエラーパス3件にテストを追加する (#750)

### DIFF
--- a/app/components/signup-form.test.tsx
+++ b/app/components/signup-form.test.tsx
@@ -144,6 +144,74 @@ describe("SignupForm 利用規約チェックボックス", () => {
     );
   });
 
+  it("パスワードが128文字超の場合にエラーメッセージが表示される", async () => {
+    const user = userEvent.setup();
+    render(<SignupForm />);
+
+    const passwordInputs = screen.getAllByPlaceholderText("••••••••");
+    fireEvent.change(passwordInputs[0], {
+      target: { value: "a".repeat(129) },
+    });
+    await user.type(screen.getByPlaceholderText("demo1@example.com"), "test@example.com");
+    await user.type(passwordInputs[1], "password123");
+
+    const submitButton = screen.getByRole("button", {
+      name: "アカウントを作成",
+    });
+    await user.click(submitButton);
+
+    expect(screen.getByRole("alert")).toHaveTextContent(
+      SIGNUP_ERROR_MESSAGES.passwordTooLong,
+    );
+  });
+
+  it("サインアップAPIがエラーを返した場合にフォールバックエラーメッセージが表示される", async () => {
+    vi.spyOn(globalThis, "fetch").mockResolvedValue(
+      new Response(JSON.stringify({}), { status: 400 }),
+    );
+
+    const user = userEvent.setup();
+    render(<SignupForm />);
+
+    await fillRequiredFields(user);
+    await user.click(screen.getByRole("checkbox"));
+
+    const submitButton = screen.getByRole("button", {
+      name: "アカウントを作成",
+    });
+    await user.click(submitButton);
+
+    await waitFor(() => {
+      expect(screen.getByRole("alert")).toHaveTextContent(
+        SIGNUP_ERROR_MESSAGES.signupFailed,
+      );
+    });
+  });
+
+  it("サインアップ成功後にsignInが失敗した場合にエラーメッセージが表示される", async () => {
+    vi.spyOn(globalThis, "fetch").mockResolvedValue(
+      new Response(JSON.stringify({}), { status: 200 }),
+    );
+    signInMock.mockResolvedValue({ error: "some error" });
+
+    const user = userEvent.setup();
+    render(<SignupForm />);
+
+    await fillRequiredFields(user);
+    await user.click(screen.getByRole("checkbox"));
+
+    const submitButton = screen.getByRole("button", {
+      name: "アカウントを作成",
+    });
+    await user.click(submitButton);
+
+    await waitFor(() => {
+      expect(screen.getByRole("alert")).toHaveTextContent(
+        SIGNUP_ERROR_MESSAGES.loginAfterSignupFailed,
+      );
+    });
+  });
+
   it("利用規約リンクが新しいタブで開くように設定されている", () => {
     render(<SignupForm />);
 


### PR DESCRIPTION
## Summary

Closes #750

- `passwordTooLong`: パスワード128文字超のバリデーションエラー表示を検証
- `signupFailed`: `POST /api/auth/signup` がエラーを返した場合のフォールバックメッセージ表示を検証
- `loginAfterSignupFailed`: サインアップ成功後に `signIn` が失敗した場合のエラー表示を検証

## Test plan

- [x] `npm run test:run -- app/components/signup-form.test.tsx` で全9テスト合格
- [x] 全テストスイート（981テスト）合格
- [ ] 追加テストが対応するエラーパスを正しく検証していることをコードレビューで確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)