### PR TITLE
feat: セッション参加者の除外UIを追加する (#788)

### DIFF
--- a/app/(authenticated)/circle-sessions/components/circle-session-detail-view.test.tsx
+++ b/app/(authenticated)/circle-sessions/components/circle-session-detail-view.test.tsx
@@ -263,8 +263,20 @@ describe("CircleSessionDetailView 複製ボタン", () => {
 });
 
 const twoMemberships = [
-  { id: "p1", name: "藤井太郎", role: "member" as const, canChangeRole: false },
-  { id: "p2", name: "羽生次郎", role: "member" as const, canChangeRole: false },
+  {
+    id: "p1",
+    name: "藤井太郎",
+    role: "member" as const,
+    canChangeRole: false,
+    canRemoveMember: false,
+  },
+  {
+    id: "p2",
+    name: "羽生次郎",
+    role: "member" as const,
+    canChangeRole: false,
+    canRemoveMember: false,
+  },
 ];
 
 const oneMatch = [

--- a/app/(authenticated)/circle-sessions/components/circle-session-detail-view.tsx
+++ b/app/(authenticated)/circle-sessions/components/circle-session-detail-view.tsx
@@ -19,6 +19,7 @@ import type {
 import { AddSessionMemberDialog } from "@/app/(authenticated)/circle-sessions/components/add-session-member-dialog";
 import { CircleSessionEditDialog } from "@/app/(authenticated)/circle-sessions/components/circle-session-edit-dialog";
 import { CircleSessionWithdrawButton } from "@/app/(authenticated)/circle-sessions/components/circle-session-withdraw-button";
+import { RemoveSessionMemberButton } from "@/app/(authenticated)/circle-sessions/components/remove-session-member-button";
 import { SessionMemberRoleDropdown } from "@/app/(authenticated)/circle-sessions/components/session-member-role-dropdown";
 import { Copy, Trash2 } from "lucide-react";
 import { useRouter } from "next/navigation";
@@ -326,9 +327,7 @@ export function CircleSessionDetailView({
   const activePairMatches = activeDialog
     ? getPairMatches(matches, activeDialog.rowId, activeDialog.columnId)
     : [];
-  const dialogRowName = activeDialog
-    ? getMemberName(activeDialog.rowId)
-    : "";
+  const dialogRowName = activeDialog ? getMemberName(activeDialog.rowId) : "";
   const dialogColumnName = activeDialog
     ? getMemberName(activeDialog.columnId)
     : "";
@@ -524,6 +523,13 @@ export function CircleSessionDetailView({
                       circleSessionId={detail.circleSessionId}
                       userId={membership.id}
                       currentRole={membership.role}
+                    />
+                  ) : null}
+                  {membership.canRemoveMember ? (
+                    <RemoveSessionMemberButton
+                      circleSessionId={detail.circleSessionId}
+                      userId={membership.id}
+                      memberName={membership.name}
                     />
                   ) : null}
                 </div>

--- a/app/(authenticated)/circle-sessions/components/remove-session-member-button.tsx
+++ b/app/(authenticated)/circle-sessions/components/remove-session-member-button.tsx
@@ -1,0 +1,91 @@
+"use client";
+
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+  AlertDialogTrigger,
+} from "@/components/ui/alert-dialog";
+import { trpc } from "@/lib/trpc/client";
+import { UserMinus } from "lucide-react";
+import { useRouter } from "next/navigation";
+import { useState } from "react";
+import { toast } from "sonner";
+
+type RemoveSessionMemberButtonProps = {
+  circleSessionId: string;
+  userId: string;
+  memberName: string;
+};
+
+export function RemoveSessionMemberButton({
+  circleSessionId,
+  userId,
+  memberName,
+}: RemoveSessionMemberButtonProps) {
+  const [open, setOpen] = useState(false);
+  const router = useRouter();
+
+  const remove = trpc.circleSessions.memberships.remove.useMutation({
+    onSuccess: () => {
+      setOpen(false);
+      router.refresh();
+      toast.success(`${memberName}を除外しました`);
+    },
+    onError: () => {
+      setOpen(false);
+      toast.error("除外に失敗しました");
+    },
+  });
+
+  const handleRemove = () => {
+    remove.mutate({ circleSessionId, userId });
+  };
+
+  return (
+    <AlertDialog
+      open={open}
+      onOpenChange={(v) => {
+        if (!remove.isPending) setOpen(v);
+      }}
+    >
+      <AlertDialogTrigger asChild>
+        <button
+          type="button"
+          className="inline-flex size-7 items-center justify-center rounded-md text-(--brand-ink-muted) transition hover:bg-red-50 hover:text-red-700"
+          aria-label={`${memberName}を除外`}
+        >
+          <UserMinus className="size-3.5" aria-hidden="true" />
+        </button>
+      </AlertDialogTrigger>
+      <AlertDialogContent>
+        <AlertDialogHeader>
+          <AlertDialogTitle>セッションから除外</AlertDialogTitle>
+          <AlertDialogDescription>
+            {memberName}をこのセッションから除外しますか？
+          </AlertDialogDescription>
+        </AlertDialogHeader>
+        <AlertDialogFooter>
+          <AlertDialogCancel disabled={remove.isPending}>
+            キャンセル
+          </AlertDialogCancel>
+          <AlertDialogAction
+            variant="destructive"
+            onClick={(e) => {
+              e.preventDefault();
+              handleRemove();
+            }}
+            disabled={remove.isPending}
+          >
+            {remove.isPending ? "除外中…" : "除外する"}
+          </AlertDialogAction>
+        </AlertDialogFooter>
+      </AlertDialogContent>
+    </AlertDialog>
+  );
+}

--- a/server/presentation/providers/circle-session-detail-provider.ts
+++ b/server/presentation/providers/circle-session-detail-provider.ts
@@ -38,12 +38,14 @@ const mapMemberships = (
   memberships: Array<{ userId: string; role: CircleSessionRole }>,
   nameById: Map<string, string | null>,
   canChangeRoleById: Map<string, boolean>,
+  canRemoveById: Map<string, boolean>,
 ): CircleSessionMembership[] =>
   memberships.map((membership) => ({
     id: membership.userId,
     name: nameById.get(membership.userId) ?? membership.userId,
     role: roleKeyByDto[membership.role] ?? null,
     canChangeRole: canChangeRoleById.get(membership.userId) ?? false,
+    canRemoveMember: canRemoveById.get(membership.userId) ?? false,
   }));
 
 const mergeMembershipIds = (
@@ -62,6 +64,7 @@ const mergeMembershipIds = (
         name: nameById.get(match.player1Id) ?? match.player1Id,
         role: null,
         canChangeRole: false,
+        canRemoveMember: false,
       });
     }
     if (!ids.has(match.player2Id)) {
@@ -71,6 +74,7 @@ const mergeMembershipIds = (
         name: nameById.get(match.player2Id) ?? match.player2Id,
         role: null,
         canChangeRole: false,
+        canRemoveMember: false,
       });
     }
   }
@@ -112,6 +116,7 @@ export async function getCircleSessionDetailViewModel(
     canDeleteCircleSession,
     canWithdrawFromCircleSession,
     canAddCircleSessionMember,
+    canRemoveCircleSessionMember,
   ] = await Promise.all([
     caller.users.list({ userIds: Array.from(userIds) }),
     viewerId
@@ -128,6 +133,9 @@ export async function getCircleSessionDetailViewModel(
       : Promise.resolve(false),
     viewerId
       ? ctx.accessService.canAddCircleSessionMember(viewerId, session.id)
+      : Promise.resolve(false),
+    viewerId
+      ? ctx.accessService.canRemoveCircleSessionMember(viewerId, session.id)
       : Promise.resolve(false),
   ]);
 
@@ -177,12 +185,11 @@ export async function getCircleSessionDetailViewModel(
   if (viewerId) {
     const canChangeResults = await Promise.all(
       memberships.map(async (membership) => {
-        const can =
-          await ctx.accessService.canChangeCircleSessionMemberRole(
-            viewerId,
-            membership.userId,
-            session.id,
-          );
+        const can = await ctx.accessService.canChangeCircleSessionMemberRole(
+          viewerId,
+          membership.userId,
+          session.id,
+        );
         return [membership.userId, can] as const;
       }),
     );
@@ -191,8 +198,17 @@ export async function getCircleSessionDetailViewModel(
     }
   }
 
+  const canRemoveById = new Map<string, boolean>();
+  if (canRemoveCircleSessionMember && viewerId) {
+    for (const membership of memberships) {
+      const roleKey = roleKeyByDto[membership.role];
+      const isSelf = membership.userId === viewerId;
+      canRemoveById.set(membership.userId, roleKey !== "owner" && !isSelf);
+    }
+  }
+
   const membershipViewModels = mergeMembershipIds(
-    mapMemberships(memberships, userNameById, canChangeRoleById),
+    mapMemberships(memberships, userNameById, canChangeRoleById, canRemoveById),
     matchViewModels,
     userNameById,
   );

--- a/server/presentation/view-models/circle-session-detail.ts
+++ b/server/presentation/view-models/circle-session-detail.ts
@@ -11,6 +11,7 @@ export type CircleSessionMembership = {
   name: string;
   role: CircleSessionRoleKey | null;
   canChangeRole: boolean;
+  canRemoveMember: boolean;
 };
 
 export type CircleSessionMatch = {


### PR DESCRIPTION
## Summary

- セッション詳細画面にメンバー除外ボタン（`RemoveSessionMemberButton`）を新規追加
- `canRemoveMember` フラグをビューモデル・プロバイダーに追加し、権限に基づいて除外ボタンの表示を制御
- 既存の `circleSessions.memberships.remove` tRPC エンドポイントを利用し、AlertDialog による確認付きで除外を実行

Closes #788

## 変更内容

| ファイル | 変更 |
|---|---|
| `remove-session-member-button.tsx` | 新規作成: 確認ダイアログ付き除外ボタンコンポーネント |
| `circle-session-detail-view.tsx` | 除外ボタンをメンバーリストに統合 |
| `circle-session-detail-view.test.tsx` | `canRemoveMember` フィールドをテストデータに追加 |
| `circle-session-detail.ts` | ビューモデルに `canRemoveMember` を追加 |
| `circle-session-detail-provider.ts` | 除外可否の算出ロジックを追加 |

## Test plan

- [ ] オーナー/マネージャーでログインし、セッション詳細画面でメンバー横に除外ボタンが表示されることを確認
- [ ] オーナー自身には除外ボタンが表示されないことを確認
- [ ] 一般メンバーでログインした場合、除外ボタンが表示されないことを確認
- [ ] 除外ボタンクリック → 確認ダイアログ → 除外実行 → トースト表示の一連のフローを確認
- [ ] `npm run test:run` が通ることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)