### PR TITLE
feat: セッション参加者の追加ボタンを候補者が0名でも表示する

### DIFF
--- a/app/(authenticated)/circle-sessions/components/add-session-member-dialog.tsx
+++ b/app/(authenticated)/circle-sessions/components/add-session-member-dialog.tsx
@@ -22,6 +22,7 @@ import { toast } from "sonner";
 type AddSessionMemberDialogProps = {
   circleSessionId: string;
   candidates: AddableMemberCandidate[];
+  disabled?: boolean;
 };
 
 type RoleValue = "CircleSessionManager" | "CircleSessionMember";
@@ -45,6 +46,7 @@ function toUserFacingMessage(error: unknown): string {
 export function AddSessionMemberDialog({
   circleSessionId,
   candidates,
+  disabled,
 }: AddSessionMemberDialogProps) {
   const [open, setOpen] = useState(false);
   const [selectedUserIds, setSelectedUserIds] = useState<Set<string>>(
@@ -141,7 +143,8 @@ export function AddSessionMemberDialog({
       <DialogTrigger asChild>
         <button
           type="button"
-          className="inline-flex items-center gap-1 rounded-md px-2 py-1 text-xs font-medium text-(--brand-moss) transition hover:bg-(--brand-moss)/10"
+          disabled={disabled}
+          className="inline-flex items-center gap-1 rounded-md px-2 py-1 text-xs font-medium text-(--brand-moss) transition hover:bg-(--brand-moss)/10 disabled:opacity-50 disabled:pointer-events-none"
         >
           <UserPlus className="size-3.5" aria-hidden="true" />
           追加

--- a/app/(authenticated)/circle-sessions/components/circle-session-detail-view.test.tsx
+++ b/app/(authenticated)/circle-sessions/components/circle-session-detail-view.test.tsx
@@ -475,6 +475,54 @@ describe("CircleSessionDetailView 編集ボタン", () => {
   });
 });
 
+describe("CircleSessionDetailView 追加ボタン", () => {
+  it("canAddCircleSessionMember: true かつ候補者がいる場合、ボタンが有効状態で表示される", () => {
+    render(
+      <CircleSessionDetailView
+        detail={buildDetail({
+          canAddCircleSessionMember: true,
+          addableMemberCandidates: [{ id: "u1", name: "候補者A" }],
+        })}
+      />,
+    );
+
+    const button = screen.getByRole("button", { name: /追加/ });
+    expect(button).toBeInTheDocument();
+    expect(button).not.toBeDisabled();
+  });
+
+  it("canAddCircleSessionMember: true かつ候補者が0名の場合、ボタンがdisabled状態で表示される", () => {
+    render(
+      <CircleSessionDetailView
+        detail={buildDetail({
+          canAddCircleSessionMember: true,
+          addableMemberCandidates: [],
+        })}
+      />,
+    );
+
+    const button = screen.getByRole("button", { name: /追加/ });
+    expect(button).toBeInTheDocument();
+    expect(button).toBeDisabled();
+  });
+
+  it("canAddCircleSessionMember: false の場合、追加ボタンが表示されない", () => {
+    render(
+      <CircleSessionDetailView
+        detail={buildDetail({
+          canAddCircleSessionMember: false,
+          addableMemberCandidates: [{ id: "u1", name: "候補者A" }],
+        })}
+      />,
+    );
+
+    const section = screen.getByText("参加メンバー").closest("section")!;
+    expect(
+      within(section).queryByRole("button", { name: /追加/ }),
+    ).not.toBeInTheDocument();
+  });
+});
+
 describe("編集ダイアログの日付プリフィル", () => {
   it("編集ダイアログを開くと対局日にcreatedAtInputの値がプリフィルされる", async () => {
     await openEditDialogViaDropdown();

--- a/app/(authenticated)/circle-sessions/components/circle-session-detail-view.tsx
+++ b/app/(authenticated)/circle-sessions/components/circle-session-detail-view.tsx
@@ -483,11 +483,11 @@ export function CircleSessionDetailView({
           <p className="text-sm font-semibold text-(--brand-ink)">
             参加メンバー
           </p>
-          {detail.canAddCircleSessionMember &&
-          detail.addableMemberCandidates.length > 0 ? (
+          {detail.canAddCircleSessionMember ? (
             <AddSessionMemberDialog
               circleSessionId={detail.circleSessionId}
               candidates={detail.addableMemberCandidates}
+              disabled={detail.addableMemberCandidates.length === 0}
             />
           ) : null}
         </div>


### PR DESCRIPTION
## Summary

Closes #794

- `canAddCircleSessionMember` が `true` の場合、追加ボタンを常に表示するよう変更
- 候補者が0名の場合は `disabled` 状態にし、ユーザーに状態を伝える
- `AddSessionMemberDialog` に `disabled` prop を追加

## 変更ファイル

- `add-session-member-dialog.tsx`: `disabled` prop を追加し、ボタンに `disabled` 属性と視覚的スタイルを適用
- `circle-session-detail-view.tsx`: 候補者数の条件分岐を削除し、`disabled` prop で制御するよう変更
- `circle-session-detail-view.test.tsx`: 追加ボタンの表示・非表示・disabled 状態に関するテスト3件を追加

## Test plan

- [ ] 候補者がいる場合、追加ボタンが有効状態で表示されること
- [ ] 候補者が0名の場合、追加ボタンが disabled 状態で表示されること
- [ ] 権限がない場合、追加ボタンが表示されないこと
- [ ] `npm run test:run` でテストが全件パスすること

🤖 Generated with [Claude Code](https://claude.com/claude-code)