### PR TITLE
feat: 除外・参加取消したユーザーをセッションに再追加可能にする

### DIFF
--- a/server/application/circle-session/circle-session-membership-service.test.ts
+++ b/server/application/circle-session/circle-session-membership-service.test.ts
@@ -264,6 +264,64 @@ describe("CircleSession セッションメンバーシップサービス", () =>
     expect(result[0]?.title).toBe("第2回 研究会");
   });
 
+  test("addMembership は研究会非メンバーかつ過去セッション参加者の再追加が成功する", async () => {
+    await circleSessionRepository.addMembership(
+      circleSessionId("session-1"),
+      userId("user-owner"),
+      "CircleSessionOwner",
+    );
+    await circleSessionRepository.addMembership(
+      circleSessionId("session-1"),
+      userId("non-circle-member"),
+      "CircleSessionMember",
+    );
+    await circleSessionRepository.removeMembership(
+      circleSessionId("session-1"),
+      userId("non-circle-member"),
+      new Date(),
+    );
+
+    const result = await service.addMembership({
+      actorId: "user-actor",
+      circleSessionId: circleSessionId("session-1"),
+      userId: userId("non-circle-member"),
+      role: "CircleSessionMember",
+    });
+
+    expect(result).toBeUndefined();
+    const memberships = await circleSessionRepository.listMemberships(
+      circleSessionId("session-1"),
+    );
+    const rejoined = memberships.find(
+      (m) => m.userId === "non-circle-member",
+    );
+    expect(rejoined?.role).toBe("CircleSessionMember");
+  });
+
+  test("addMembership は研究会非メンバーかつ過去セッション参加歴なしの追加を拒否する", async () => {
+    await circleSessionRepository.addMembership(
+      circleSessionId("session-1"),
+      userId("user-owner"),
+      "CircleSessionOwner",
+    );
+
+    await expectReject(
+      service.addMembership({
+        actorId: "user-actor",
+        circleSessionId: circleSessionId("session-1"),
+        userId: userId("completely-new-user"),
+        role: "CircleSessionMember",
+      }),
+      BadRequestError,
+      "User is not an active member of the circle",
+    );
+
+    const memberships = await circleSessionRepository.listMemberships(
+      circleSessionId("session-1"),
+    );
+    expect(memberships).toHaveLength(1);
+  });
+
   test("addMembership は研究会メンバーでないユーザーの追加を拒否する", async () => {
     await circleSessionRepository.addMembership(
       circleSessionId("session-1"),

--- a/server/application/circle-session/circle-session-membership-service.ts
+++ b/server/application/circle-session/circle-session-membership-service.ts
@@ -144,6 +144,12 @@ export const createCircleSessionMembershipService = (
     return summaries;
   },
 
+  async listDeletedMemberships(
+    circleSessionId: CircleSessionId,
+  ): Promise<CircleSessionMembership[]> {
+    return deps.circleSessionRepository.listDeletedMemberships(circleSessionId);
+  },
+
   async addMembership(params: {
     actorId: string;
     circleSessionId: CircleSessionId;
@@ -170,7 +176,18 @@ export const createCircleSessionMembershipService = (
         params.userId,
       );
     if (!circleMembership) {
-      throw new BadRequestError("User is not an active member of the circle");
+      const deletedMemberships =
+        await deps.circleSessionRepository.listDeletedMemberships(
+          params.circleSessionId,
+        );
+      const hasPastMembership = deletedMemberships.some(
+        (m) => m.userId === params.userId,
+      );
+      if (!hasPastMembership) {
+        throw new BadRequestError(
+          "User is not an active member of the circle",
+        );
+      }
     }
 
     const memberships = await deps.circleSessionRepository.listMemberships(

--- a/server/application/test-helpers/mock-repositories.ts
+++ b/server/application/test-helpers/mock-repositories.ts
@@ -34,6 +34,7 @@ export const createMockCircleSessionRepository = () =>
     updateMembershipRole: vi.fn(),
     areUsersSessionMembers: vi.fn(),
     removeMembership: vi.fn(),
+    listDeletedMemberships: vi.fn(),
   }) satisfies CircleSessionRepository;
 
 export const createMockCircleRepository = () =>

--- a/server/domain/models/circle-session/circle-session-repository.ts
+++ b/server/domain/models/circle-session/circle-session-repository.ts
@@ -36,4 +36,7 @@ export type CircleSessionRepository = {
     userId: UserId,
     deletedAt: Date,
   ): Promise<void>;
+  listDeletedMemberships(
+    circleSessionId: CircleSessionId,
+  ): Promise<CircleSessionMembership[]>;
 };

--- a/server/infrastructure/repository/circle-session/prisma-circle-session-repository.ts
+++ b/server/infrastructure/repository/circle-session/prisma-circle-session-repository.ts
@@ -199,6 +199,28 @@ export const createPrismaCircleSessionRepository = (
     return count === uniqueIds.length;
   },
 
+  async listDeletedMemberships(
+    circleSessionId: CircleSessionId,
+  ): Promise<CircleSessionMembership[]> {
+    const persistedCircleSessionId = toPersistenceId(circleSessionId);
+
+    const memberships = await client.circleSessionMembership.findMany({
+      where: {
+        circleSessionId: persistedCircleSessionId,
+        deletedAt: { not: null },
+      },
+      select: {
+        circleSessionId: true,
+        userId: true,
+        role: true,
+        createdAt: true,
+        deletedAt: true,
+      },
+    });
+
+    return memberships.map(mapCircleSessionMembershipFromPersistence);
+  },
+
   async removeMembership(
     circleSessionId: CircleSessionId,
     userId: UserId,

--- a/server/infrastructure/repository/in-memory/in-memory-circle-session-repository.ts
+++ b/server/infrastructure/repository/in-memory/in-memory-circle-session-repository.ts
@@ -141,6 +141,13 @@ export const createInMemoryCircleSessionRepository = (
     return uniqueIds.every((id) => activeUserIds.has(id));
   },
 
+  async listDeletedMemberships(
+    circleSessionId: CircleSessionId,
+  ): Promise<CircleSessionMembership[]> {
+    const all = membershipStore.get(circleSessionId) ?? [];
+    return all.filter((m) => m.deletedAt !== null);
+  },
+
   async removeMembership(
     circleSessionId: CircleSessionId,
     userId: UserId,

--- a/server/presentation/providers/circle-session-detail-provider.ts
+++ b/server/presentation/providers/circle-session-detail-provider.ts
@@ -4,6 +4,7 @@ import {
   formatDateTimeRange,
 } from "@/lib/date-utils";
 import { CircleSessionRole } from "@/server/domain/models/circle-session/circle-session-role";
+import { circleSessionId as toCircleSessionId } from "@/server/domain/common/ids";
 import { appRouter } from "@/server/presentation/trpc/router";
 import { createContext } from "@/server/presentation/trpc/context";
 import type {
@@ -148,12 +149,25 @@ export async function getCircleSessionDetailViewModel(
       circleId: session.circleId,
     });
     const sessionMemberIds = new Set(memberships.map((m) => m.userId));
-    const candidateUserIds = circleMembers
-      .filter((cm) => !sessionMemberIds.has(cm.userId))
-      .map((cm) => cm.userId);
+    const candidateUserIds = new Set(
+      circleMembers
+        .filter((cm) => !sessionMemberIds.has(cm.userId))
+        .map((cm) => cm.userId),
+    );
 
-    if (candidateUserIds.length > 0) {
-      const candidateUserIdsToResolve = candidateUserIds.filter(
+    const deletedMemberships =
+      await ctx.circleSessionMembershipService.listDeletedMemberships(
+        toCircleSessionId(session.id),
+      );
+    for (const dm of deletedMemberships) {
+      if (!sessionMemberIds.has(dm.userId)) {
+        candidateUserIds.add(dm.userId);
+      }
+    }
+
+    const candidateUserIdArray = Array.from(candidateUserIds);
+    if (candidateUserIdArray.length > 0) {
+      const candidateUserIdsToResolve = candidateUserIdArray.filter(
         (id) => !userNameById.has(id),
       );
       if (candidateUserIdsToResolve.length > 0) {
@@ -164,7 +178,7 @@ export async function getCircleSessionDetailViewModel(
           userNameById.set(user.id, user.name);
         }
       }
-      addableMemberCandidates = candidateUserIds.map((id) => ({
+      addableMemberCandidates = candidateUserIdArray.map((id) => ({
         id,
         name: userNameById.get(id) ?? id,
       }));

--- a/server/presentation/trpc/router.test.ts
+++ b/server/presentation/trpc/router.test.ts
@@ -44,6 +44,7 @@ const createContext = () => {
     removeMembership: vi.fn(),
     transferOwnership: vi.fn(),
     withdrawMembership: vi.fn(),
+    listDeletedMemberships: vi.fn(),
   };
   const matchService = {
     listByCircleSessionId: vi.fn(),

--- a/server/presentation/trpc/routers/circle-invite-link.test.ts
+++ b/server/presentation/trpc/routers/circle-invite-link.test.ts
@@ -51,6 +51,7 @@ const createTestContext = () => {
       removeMembership: vi.fn(),
       transferOwnership: vi.fn(),
       withdrawMembership: vi.fn(),
+      listDeletedMemberships: vi.fn(),
     },
     matchService: {
       listByCircleSessionId: vi.fn(),

--- a/server/presentation/trpc/routers/circle-session.test.ts
+++ b/server/presentation/trpc/routers/circle-session.test.ts
@@ -43,6 +43,7 @@ const createTestContext = (
       removeMembership: vi.fn(),
       transferOwnership: vi.fn(),
       withdrawMembership: vi.fn(),
+      listDeletedMemberships: vi.fn(),
     },
     matchService: {
       listByCircleSessionId: vi.fn(),

--- a/server/presentation/trpc/routers/match.test.ts
+++ b/server/presentation/trpc/routers/match.test.ts
@@ -49,6 +49,7 @@ const createTestContext = (
       removeMembership: vi.fn(),
       transferOwnership: vi.fn(),
       withdrawMembership: vi.fn(),
+      listDeletedMemberships: vi.fn(),
     },
     matchService,
     userService: {

--- a/server/presentation/trpc/routers/user-circle-membership.test.ts
+++ b/server/presentation/trpc/routers/user-circle-membership.test.ts
@@ -43,6 +43,7 @@ const createTestContext = (
       removeMembership: vi.fn(),
       transferOwnership: vi.fn(),
       withdrawMembership: vi.fn(),
+      listDeletedMemberships: vi.fn(),
     },
     matchService: {
       listByCircleSessionId: vi.fn(),

--- a/server/presentation/trpc/routers/user-circle-session-membership.test.ts
+++ b/server/presentation/trpc/routers/user-circle-session-membership.test.ts
@@ -16,6 +16,7 @@ const createTestContext = (
     removeMembership: vi.fn(),
     transferOwnership: vi.fn(),
     withdrawMembership: vi.fn(),
+    listDeletedMemberships: vi.fn(),
   };
 
   const context: Context = {

--- a/server/presentation/trpc/routers/user.test.ts
+++ b/server/presentation/trpc/routers/user.test.ts
@@ -54,6 +54,7 @@ const createTestContext = (
       removeMembership: vi.fn(),
       transferOwnership: vi.fn(),
       withdrawMembership: vi.fn(),
+      listDeletedMemberships: vi.fn(),
     },
     matchService: {
       listByCircleSessionId: vi.fn(),


### PR DESCRIPTION
## Summary

Closes #795

- リポジトリインターフェースに `listDeletedMemberships()` を追加し、論理削除済みセッションメンバーシップを取得可能にした
- サービス層の `addMembership` バリデーションを緩和し、研究会非メンバーでも過去セッション参加歴があれば再追加を許可するようにした
- セッション詳細画面の追加候補リストに、過去参加者（除外・取消済み）を含めるようProviderを修正した

## Test plan

- [x] `npm run test:run` — 全995テスト パス
- [x] `npx tsc --noEmit` — 型エラーなし
- [x] `npm run lint` — エラーなし
- [ ] セッション参加者を除外後、追加候補リストに再表示されることを確認
- [ ] 候補リストから再追加を実行し、正常に追加されることを確認
- [ ] 研究会を脱退したユーザーがセッションから除外された場合、候補リストに表示されることを確認
- [ ] セッション参加歴のない研究会非メンバーは追加できないことを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)