### PR TITLE
feat: 総当たりスケジュールのドメインモデルを実装する (#812)

### DIFF
--- a/server/domain/common/ids.ts
+++ b/server/domain/common/ids.ts
@@ -8,6 +8,7 @@ export type CircleSessionId = Brand<string, "CircleSessionId">;
 export type MatchId = Brand<string, "MatchId">;
 export type CircleInviteLinkId = Brand<string, "CircleInviteLinkId">;
 export type InviteLinkToken = Brand<string, "InviteLinkToken">;
+export type RoundRobinScheduleId = Brand<string, "RoundRobinScheduleId">;
 
 export const userId = (value: string): UserId => {
   if (!value) throw new BadRequestError("Invalid user ID");
@@ -28,6 +29,12 @@ export const matchId = (value: string): MatchId => {
 export const circleInviteLinkId = (value: string): CircleInviteLinkId => {
   if (!value) throw new BadRequestError("Invalid circle invite link ID");
   return value as CircleInviteLinkId;
+};
+export const roundRobinScheduleId = (
+  value: string,
+): RoundRobinScheduleId => {
+  if (!value) throw new BadRequestError("Invalid round robin schedule ID");
+  return value as RoundRobinScheduleId;
 };
 
 const UUID_RE =

--- a/server/domain/models/round-robin-schedule/generate-rounds.test.ts
+++ b/server/domain/models/round-robin-schedule/generate-rounds.test.ts
@@ -1,0 +1,127 @@
+import { describe, expect, test } from "vitest";
+import { userId } from "@/server/domain/common/ids";
+import { generateRounds } from "@/server/domain/models/round-robin-schedule/generate-rounds";
+import type { UserId } from "@/server/domain/common/ids";
+
+const ids = (...names: string[]): UserId[] => names.map((n) => userId(n));
+
+describe("generateRounds", () => {
+  describe("バリデーション", () => {
+    test("0人の場合エラーになる", () => {
+      expect(() => generateRounds([])).toThrow(
+        "Round-robin requires at least 2 participants",
+      );
+    });
+
+    test("1人の場合エラーになる", () => {
+      expect(() => generateRounds(ids("u1"))).toThrow(
+        "Round-robin requires at least 2 participants",
+      );
+    });
+
+    test("重複IDの場合エラーになる", () => {
+      expect(() => generateRounds(ids("u1", "u1"))).toThrow(
+        "Duplicate participant IDs are not allowed",
+      );
+    });
+  });
+
+  describe("偶数人数", () => {
+    test("2人の場合: 1ラウンド1対戦", () => {
+      const rounds = generateRounds(ids("u1", "u2"));
+
+      expect(rounds).toHaveLength(1);
+      expect(rounds[0].pairings).toHaveLength(1);
+    });
+
+    test("4人の場合: 3ラウンド各2対戦", () => {
+      const rounds = generateRounds(ids("u1", "u2", "u3", "u4"));
+
+      expect(rounds).toHaveLength(3);
+      for (const round of rounds) {
+        expect(round.pairings).toHaveLength(2);
+      }
+    });
+
+    test("6人の場合: 5ラウンド各3対戦", () => {
+      const rounds = generateRounds(
+        ids("u1", "u2", "u3", "u4", "u5", "u6"),
+      );
+
+      expect(rounds).toHaveLength(5);
+      for (const round of rounds) {
+        expect(round.pairings).toHaveLength(3);
+      }
+    });
+  });
+
+  describe("奇数人数", () => {
+    test("3人の場合: 3ラウンド各1対戦", () => {
+      const rounds = generateRounds(ids("u1", "u2", "u3"));
+
+      expect(rounds).toHaveLength(3);
+      for (const round of rounds) {
+        expect(round.pairings).toHaveLength(1);
+      }
+    });
+
+    test("5人の場合: 5ラウンド各2対戦", () => {
+      const rounds = generateRounds(ids("u1", "u2", "u3", "u4", "u5"));
+
+      expect(rounds).toHaveLength(5);
+      for (const round of rounds) {
+        expect(round.pairings).toHaveLength(2);
+      }
+    });
+  });
+
+  describe("不変条件", () => {
+    test("全ペアがちょうど1回出現する", () => {
+      const participants = ids("u1", "u2", "u3", "u4");
+      const rounds = generateRounds(participants);
+
+      const pairSet = new Set<string>();
+      for (const round of rounds) {
+        for (const p of round.pairings) {
+          const key = [p.player1Id, p.player2Id].sort().join("-");
+          expect(pairSet.has(key)).toBe(false);
+          pairSet.add(key);
+        }
+      }
+
+      const expectedPairs = (participants.length * (participants.length - 1)) / 2;
+      expect(pairSet.size).toBe(expectedPairs);
+    });
+
+    test("ラウンド内で同一プレイヤーが重複しない", () => {
+      const rounds = generateRounds(ids("u1", "u2", "u3", "u4", "u5"));
+
+      for (const round of rounds) {
+        const playersInRound: string[] = [];
+        for (const p of round.pairings) {
+          playersInRound.push(p.player1Id, p.player2Id);
+        }
+        expect(new Set(playersInRound).size).toBe(playersInRound.length);
+      }
+    });
+
+    test("合計対戦数が n*(n-1)/2 と一致する", () => {
+      const participants = ids("u1", "u2", "u3", "u4", "u5", "u6");
+      const rounds = generateRounds(participants);
+
+      const totalPairings = rounds.reduce(
+        (sum, r) => sum + r.pairings.length,
+        0,
+      );
+      const expected = (participants.length * (participants.length - 1)) / 2;
+      expect(totalPairings).toBe(expected);
+    });
+
+    test("ラウンド番号が1始まり連番である", () => {
+      const rounds = generateRounds(ids("u1", "u2", "u3", "u4"));
+
+      const numbers = rounds.map((r) => r.roundNumber);
+      expect(numbers).toEqual([1, 2, 3]);
+    });
+  });
+});

--- a/server/domain/models/round-robin-schedule/generate-rounds.ts
+++ b/server/domain/models/round-robin-schedule/generate-rounds.ts
@@ -1,0 +1,71 @@
+import type { UserId } from "../../common/ids";
+import { BadRequestError } from "../../common/errors";
+
+export type Pairing = {
+  player1Id: UserId;
+  player2Id: UserId;
+};
+
+export type Round = {
+  roundNumber: number;
+  pairings: Pairing[];
+};
+
+/**
+ * ラウンドロビン対戦スケジュールを生成する（サークルメソッド）
+ *
+ * - 先頭の参加者を固定し、残りを回転させてペアリングを作る
+ * - 奇数人数の場合は BYE（null）を追加し、BYE とのペアリングは除外する
+ */
+export const generateRounds = (participantIds: UserId[]): Round[] => {
+  if (participantIds.length < 2) {
+    throw new BadRequestError(
+      "Round-robin requires at least 2 participants",
+    );
+  }
+
+  const uniqueIds = new Set(participantIds);
+  if (uniqueIds.size !== participantIds.length) {
+    throw new BadRequestError("Duplicate participant IDs are not allowed");
+  }
+
+  // 奇数の場合は BYE (null) を追加して偶数にする
+  const players: (UserId | null)[] = [...participantIds];
+  if (players.length % 2 !== 0) {
+    players.push(null);
+  }
+
+  const n = players.length;
+  const totalRounds = n - 1;
+  const rounds: Round[] = [];
+
+  // サークルメソッド: 先頭固定、残りを回転
+  const fixed = players[0];
+  const rotating = players.slice(1);
+
+  for (let r = 0; r < totalRounds; r++) {
+    const pairings: Pairing[] = [];
+
+    // 先頭 vs 回転リストの最後
+    const opponent = rotating[rotating.length - 1];
+    if (fixed !== null && opponent !== null) {
+      pairings.push({ player1Id: fixed, player2Id: opponent });
+    }
+
+    // 残りのペアリング: 対称的に内側へ
+    for (let i = 0; i < (n - 2) / 2; i++) {
+      const p1 = rotating[i];
+      const p2 = rotating[rotating.length - 2 - i];
+      if (p1 !== null && p2 !== null) {
+        pairings.push({ player1Id: p1, player2Id: p2 });
+      }
+    }
+
+    rounds.push({ roundNumber: r + 1, pairings });
+
+    // 回転: 最後の要素を先頭に移動
+    rotating.unshift(rotating.pop()!);
+  }
+
+  return rounds;
+};

--- a/server/domain/models/round-robin-schedule/round-robin-schedule-repository.ts
+++ b/server/domain/models/round-robin-schedule/round-robin-schedule-repository.ts
@@ -1,0 +1,10 @@
+import type { CircleSessionId } from "../../common/ids";
+import type { RoundRobinSchedule } from "./round-robin-schedule";
+
+export type RoundRobinScheduleRepository = {
+  findByCircleSessionId(
+    circleSessionId: CircleSessionId,
+  ): Promise<RoundRobinSchedule | null>;
+  save(schedule: RoundRobinSchedule): Promise<void>;
+  deleteByCircleSessionId(circleSessionId: CircleSessionId): Promise<void>;
+};

--- a/server/domain/models/round-robin-schedule/round-robin-schedule.test.ts
+++ b/server/domain/models/round-robin-schedule/round-robin-schedule.test.ts
@@ -1,0 +1,66 @@
+import { describe, expect, test } from "vitest";
+import {
+  circleSessionId,
+  roundRobinScheduleId,
+  userId,
+} from "@/server/domain/common/ids";
+import {
+  createRoundRobinSchedule,
+  restoreRoundRobinSchedule,
+} from "@/server/domain/models/round-robin-schedule/round-robin-schedule";
+
+describe("RoundRobinSchedule ドメイン", () => {
+  test("createRoundRobinSchedule は rounds と totalMatchCount を正しく生成する", () => {
+    const schedule = createRoundRobinSchedule({
+      id: roundRobinScheduleId("schedule-1"),
+      circleSessionId: circleSessionId("session-1"),
+      participantIds: [
+        userId("u1"),
+        userId("u2"),
+        userId("u3"),
+        userId("u4"),
+      ],
+    });
+
+    expect(schedule.id).toBe("schedule-1");
+    expect(schedule.circleSessionId).toBe("session-1");
+    expect(schedule.rounds).toHaveLength(3);
+    expect(schedule.totalMatchCount).toBe(6);
+    expect(schedule.createdAt).toBeInstanceOf(Date);
+  });
+
+  test("restoreRoundRobinSchedule はすべてのフィールドを復元する", () => {
+    const createdAt = new Date("2024-06-01T00:00:00Z");
+    const rounds = [
+      {
+        roundNumber: 1,
+        pairings: [{ player1Id: userId("u1"), player2Id: userId("u2") }],
+      },
+    ];
+
+    const schedule = restoreRoundRobinSchedule({
+      id: roundRobinScheduleId("schedule-1"),
+      circleSessionId: circleSessionId("session-1"),
+      rounds,
+      totalMatchCount: 1,
+      createdAt,
+    });
+
+    expect(schedule.id).toBe("schedule-1");
+    expect(schedule.rounds).toEqual(rounds);
+    expect(schedule.totalMatchCount).toBe(1);
+    expect(schedule.createdAt).toBe(createdAt);
+  });
+
+  test("restoreRoundRobinSchedule は不正な createdAt を拒否する", () => {
+    expect(() =>
+      restoreRoundRobinSchedule({
+        id: roundRobinScheduleId("schedule-1"),
+        circleSessionId: circleSessionId("session-1"),
+        rounds: [],
+        totalMatchCount: 0,
+        createdAt: new Date("invalid"),
+      }),
+    ).toThrow("createdAt must be a valid date");
+  });
+});

--- a/server/domain/models/round-robin-schedule/round-robin-schedule.ts
+++ b/server/domain/models/round-robin-schedule/round-robin-schedule.ts
@@ -1,0 +1,57 @@
+import type { CircleSessionId, RoundRobinScheduleId, UserId } from "../../common/ids";
+import { assertValidDate } from "../../common/validation";
+import { generateRounds, type Round } from "./generate-rounds";
+
+export type RoundRobinSchedule = {
+  id: RoundRobinScheduleId;
+  circleSessionId: CircleSessionId;
+  rounds: Round[];
+  totalMatchCount: number;
+  createdAt: Date;
+};
+
+export type RoundRobinScheduleCreateParams = {
+  id: RoundRobinScheduleId;
+  circleSessionId: CircleSessionId;
+  participantIds: UserId[];
+};
+
+export type RoundRobinScheduleRestoreParams = {
+  id: RoundRobinScheduleId;
+  circleSessionId: CircleSessionId;
+  rounds: Round[];
+  totalMatchCount: number;
+  createdAt: Date;
+};
+
+export const createRoundRobinSchedule = (
+  params: RoundRobinScheduleCreateParams,
+): RoundRobinSchedule => {
+  const rounds = generateRounds(params.participantIds);
+  const totalMatchCount = rounds.reduce(
+    (sum, r) => sum + r.pairings.length,
+    0,
+  );
+
+  return {
+    id: params.id,
+    circleSessionId: params.circleSessionId,
+    rounds,
+    totalMatchCount,
+    createdAt: new Date(),
+  };
+};
+
+export const restoreRoundRobinSchedule = (
+  params: RoundRobinScheduleRestoreParams,
+): RoundRobinSchedule => {
+  assertValidDate(params.createdAt, "createdAt");
+
+  return {
+    id: params.id,
+    circleSessionId: params.circleSessionId,
+    rounds: params.rounds,
+    totalMatchCount: params.totalMatchCount,
+    createdAt: params.createdAt,
+  };
+};


### PR DESCRIPTION
## Summary

Closes #812

サークルメソッド（ポリゴンスケジューリング）によるラウンドロビン対戦表生成のドメインモデルを追加。

- `RoundRobinScheduleId` ブランド型を `ids.ts` に追加
- `generateRounds` 純粋関数（サークルメソッドアルゴリズム）を実装
- `RoundRobinSchedule` 集約ルート（`create` / `restore`）を定義
- `RoundRobinScheduleRepository` インターフェースを定義
- 単体テスト 15件（バリデーション、偶数/奇数人数、不変条件）

## 残タスク

- [ ] `index.ts` バレルエクスポートの追加（issueに記載あるが未実装）
- [ ] アプリケーション層・tRPC 統合（後続タスク）
- [ ] Prismaスキーマ・リポジトリ実装（後続タスク）

## Test plan

- [x] `npm run test:run -- server/domain/models/round-robin-schedule/` → 15 tests passed
- [x] `npx tsc --noEmit` → clean
- [x] `npm run lint` → clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)