### PR TITLE
test: 総当たりスケジュールルーターの統合テストを追加する (#821)

### DIFF
--- a/server/presentation/trpc/routers/round-robin-schedule.test.ts
+++ b/server/presentation/trpc/routers/round-robin-schedule.test.ts
@@ -1,0 +1,300 @@
+import { beforeEach, describe, expect, test, vi } from "vitest";
+import { appRouter } from "@/server/presentation/trpc/router";
+import type { Context } from "@/server/presentation/trpc/context";
+import {
+  circleSessionId,
+  roundRobinScheduleId,
+  userId,
+} from "@/server/domain/common/ids";
+import { BadRequestError, ForbiddenError } from "@/server/domain/common/errors";
+import type { RoundRobinSchedule } from "@/server/domain/models/round-robin-schedule/round-robin-schedule";
+import type { User } from "@/server/domain/models/user/user";
+
+const createTestContext = (
+  actorIdValue: ReturnType<typeof userId> | null = userId("user-1"),
+) => {
+  const roundRobinScheduleService = {
+    getSchedule: vi.fn(),
+    generateSchedule: vi.fn(),
+    deleteSchedule: vi.fn(),
+  };
+
+  const userService = {
+    getUser: vi.fn(),
+    listUsers: vi.fn(),
+    getMe: vi.fn(),
+    updateProfile: vi.fn(),
+    updateProfileVisibility: vi.fn(),
+    changePassword: vi.fn(),
+  };
+
+  const context: Context = {
+    actorId: actorIdValue,
+    circleService: {
+      getCircle: vi.fn(),
+      createCircle: vi.fn(),
+      renameCircle: vi.fn(),
+      deleteCircle: vi.fn(),
+    },
+    circleMembershipService: {
+      listByCircleId: vi.fn(),
+      listByUserId: vi.fn(),
+      addMembership: vi.fn(),
+      changeMembershipRole: vi.fn(),
+      withdrawMembership: vi.fn(),
+      removeMembership: vi.fn(),
+      transferOwnership: vi.fn(),
+    },
+    circleSessionService: {
+      listByCircleId: vi.fn(),
+      getCircleSession: vi.fn(),
+      createCircleSession: vi.fn(),
+      rescheduleCircleSession: vi.fn(),
+      updateCircleSessionDetails: vi.fn(),
+      deleteCircleSession: vi.fn(),
+    },
+    circleSessionMembershipService: {
+      countPastSessionsByUserId: vi.fn(),
+      listMemberships: vi.fn(),
+      listByUserId: vi.fn(),
+      addMembership: vi.fn(),
+      changeMembershipRole: vi.fn(),
+      removeMembership: vi.fn(),
+      transferOwnership: vi.fn(),
+      withdrawMembership: vi.fn(),
+      listDeletedMemberships: vi.fn(),
+    },
+    matchService: {
+      listByCircleSessionId: vi.fn(),
+      getMatch: vi.fn(),
+      recordMatch: vi.fn(),
+      updateMatch: vi.fn(),
+      deleteMatch: vi.fn(),
+    },
+    userService,
+    signupService: {
+      signup: vi.fn(),
+    },
+    circleInviteLinkService: {
+      createInviteLink: vi.fn(),
+      getInviteLinkInfo: vi.fn(),
+      redeemInviteLink: vi.fn(),
+    },
+    accessService: {} as Context["accessService"],
+    userStatisticsService: {} as Context["userStatisticsService"],
+    roundRobinScheduleService,
+    holidayProvider: {} as Context["holidayProvider"],
+  };
+
+  return { context, mocks: { roundRobinScheduleService, userService } };
+};
+
+const baseSchedule = (): RoundRobinSchedule => ({
+  id: roundRobinScheduleId("schedule-1"),
+  circleSessionId: circleSessionId("session-1"),
+  rounds: [
+    {
+      roundNumber: 1,
+      pairings: [
+        { player1Id: userId("player-1"), player2Id: userId("player-2") },
+      ],
+    },
+  ],
+  totalMatchCount: 1,
+  createdAt: new Date("2024-06-01T10:00:00Z"),
+});
+
+const baseUsers = (): User[] => [
+  {
+    id: userId("player-1"),
+    name: "Player 1",
+    email: "player1@example.com",
+    image: null,
+    profileVisibility: "PUBLIC",
+    createdAt: new Date("2024-01-01T00:00:00Z"),
+  },
+  {
+    id: userId("player-2"),
+    name: "Player 2",
+    email: "player2@example.com",
+    image: null,
+    profileVisibility: "PUBLIC",
+    createdAt: new Date("2024-01-01T00:00:00Z"),
+  },
+];
+
+describe("roundRobinSchedule tRPC ルーター", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  describe("get", () => {
+    test("スケジュール存在時: DTO形式で返却される", async () => {
+      const { context, mocks } = createTestContext();
+      mocks.roundRobinScheduleService.getSchedule.mockResolvedValueOnce(
+        baseSchedule(),
+      );
+      mocks.userService.listUsers.mockResolvedValueOnce(baseUsers());
+
+      const caller = appRouter.createCaller(context);
+      const result = await caller.roundRobinSchedules.get({
+        circleId: "circle-1",
+        circleSessionId: "session-1",
+      });
+
+      expect(result).not.toBeNull();
+      expect(result!.id).toBe("schedule-1");
+      expect(result!.circleSessionId).toBe("session-1");
+      expect(result!.totalMatchCount).toBe(1);
+      expect(result!.rounds).toHaveLength(1);
+      expect(result!.rounds[0].pairings[0].player1.id).toBe("player-1");
+      expect(result!.rounds[0].pairings[0].player1.name).toBe("Player 1");
+      expect(result!.rounds[0].pairings[0].player2.id).toBe("player-2");
+    });
+
+    test("スケジュール未存在時: nullを返す", async () => {
+      const { context, mocks } = createTestContext();
+      mocks.roundRobinScheduleService.getSchedule.mockResolvedValueOnce(null);
+
+      const caller = appRouter.createCaller(context);
+      const result = await caller.roundRobinSchedules.get({
+        circleId: "circle-1",
+        circleSessionId: "session-1",
+      });
+
+      expect(result).toBeNull();
+    });
+
+    test("ForbiddenError → FORBIDDEN", async () => {
+      const { context, mocks } = createTestContext();
+      mocks.roundRobinScheduleService.getSchedule.mockRejectedValueOnce(
+        new ForbiddenError(),
+      );
+
+      const caller = appRouter.createCaller(context);
+
+      await expect(
+        caller.roundRobinSchedules.get({
+          circleId: "circle-1",
+          circleSessionId: "session-1",
+        }),
+      ).rejects.toMatchObject({ code: "FORBIDDEN" });
+    });
+
+    test("未認証: actorId null → UNAUTHORIZED", async () => {
+      const { context } = createTestContext(null);
+      const caller = appRouter.createCaller(context);
+
+      await expect(
+        caller.roundRobinSchedules.get({
+          circleId: "circle-1",
+          circleSessionId: "session-1",
+        }),
+      ).rejects.toMatchObject({ code: "UNAUTHORIZED" });
+    });
+  });
+
+  describe("generate", () => {
+    test("正常生成: DTO形式で返却される", async () => {
+      const { context, mocks } = createTestContext();
+      mocks.roundRobinScheduleService.generateSchedule.mockResolvedValueOnce(
+        baseSchedule(),
+      );
+      mocks.userService.listUsers.mockResolvedValueOnce(baseUsers());
+
+      const caller = appRouter.createCaller(context);
+      const result = await caller.roundRobinSchedules.generate({
+        circleSessionId: "session-1",
+      });
+
+      expect(result.id).toBe("schedule-1");
+      expect(result.circleSessionId).toBe("session-1");
+      expect(result.rounds).toHaveLength(1);
+      expect(result.rounds[0].pairings[0].player1.id).toBe("player-1");
+      expect(result.rounds[0].pairings[0].player2.id).toBe("player-2");
+    });
+
+    test("ForbiddenError → FORBIDDEN", async () => {
+      const { context, mocks } = createTestContext();
+      mocks.roundRobinScheduleService.generateSchedule.mockRejectedValueOnce(
+        new ForbiddenError(),
+      );
+
+      const caller = appRouter.createCaller(context);
+
+      await expect(
+        caller.roundRobinSchedules.generate({
+          circleSessionId: "session-1",
+        }),
+      ).rejects.toMatchObject({ code: "FORBIDDEN" });
+    });
+
+    test("BadRequestError → BAD_REQUEST", async () => {
+      const { context, mocks } = createTestContext();
+      mocks.roundRobinScheduleService.generateSchedule.mockRejectedValueOnce(
+        new BadRequestError("Schedule already exists"),
+      );
+
+      const caller = appRouter.createCaller(context);
+
+      await expect(
+        caller.roundRobinSchedules.generate({
+          circleSessionId: "session-1",
+        }),
+      ).rejects.toMatchObject({ code: "BAD_REQUEST" });
+    });
+
+    test("未認証: actorId null → UNAUTHORIZED", async () => {
+      const { context } = createTestContext(null);
+      const caller = appRouter.createCaller(context);
+
+      await expect(
+        caller.roundRobinSchedules.generate({
+          circleSessionId: "session-1",
+        }),
+      ).rejects.toMatchObject({ code: "UNAUTHORIZED" });
+    });
+  });
+
+  describe("delete", () => {
+    test("正常削除: voidを返す", async () => {
+      const { context, mocks } = createTestContext();
+      mocks.roundRobinScheduleService.deleteSchedule.mockResolvedValueOnce(
+        undefined,
+      );
+
+      const caller = appRouter.createCaller(context);
+      const result = await caller.roundRobinSchedules.delete({
+        circleSessionId: "session-1",
+      });
+
+      expect(result).toBeUndefined();
+    });
+
+    test("ForbiddenError → FORBIDDEN", async () => {
+      const { context, mocks } = createTestContext();
+      mocks.roundRobinScheduleService.deleteSchedule.mockRejectedValueOnce(
+        new ForbiddenError(),
+      );
+
+      const caller = appRouter.createCaller(context);
+
+      await expect(
+        caller.roundRobinSchedules.delete({
+          circleSessionId: "session-1",
+        }),
+      ).rejects.toMatchObject({ code: "FORBIDDEN" });
+    });
+
+    test("未認証: actorId null → UNAUTHORIZED", async () => {
+      const { context } = createTestContext(null);
+      const caller = appRouter.createCaller(context);
+
+      await expect(
+        caller.roundRobinSchedules.delete({
+          circleSessionId: "session-1",
+        }),
+      ).rejects.toMatchObject({ code: "UNAUTHORIZED" });
+    });
+  });
+});


### PR DESCRIPTION
## Summary

- 総当たりスケジュールルーター（`round-robin-schedule.ts`）の統合テストを追加
- get / generate / delete 全3エンドポイントに対し計11テストケースをカバー
- `match.test.ts` の `createTestContext` パターンに準拠

Closes #821

## Test plan

- [x] `npm run test:run -- server/presentation/trpc/routers/round-robin-schedule.test.ts` → 11 tests passed
- [x] `npx tsc --noEmit` → エラーなし
- [x] `npx eslint` → 0 errors, 0 warnings

## テストケース一覧

| エンドポイント | テストケース |
|---|---|
| get | スケジュール存在時: DTO形式（player付き）で返却 |
| get | スケジュール未存在時: null を返す |
| get | ForbiddenError → FORBIDDEN |
| get | 未認証 → UNAUTHORIZED |
| generate | 正常生成: DTO形式で返却 |
| generate | ForbiddenError → FORBIDDEN |
| generate | BadRequestError → BAD_REQUEST |
| generate | 未認証 → UNAUTHORIZED |
| delete | 正常削除: void を返す |
| delete | ForbiddenError → FORBIDDEN |
| delete | 未認証 → UNAUTHORIZED |

🤖 Generated with [Claude Code](https://claude.com/claude-code)