### PR TITLE
refactor: ユーザー名欠損時のフォールバック値を「不明」に統一する (#820)

### DIFF
--- a/server/presentation/providers/circle-overview-provider.ts
+++ b/server/presentation/providers/circle-overview-provider.ts
@@ -120,7 +120,7 @@ export async function getCircleOverviewViewModel(
   const members = memberships
     .map((membership) => ({
       userId: membership.userId,
-      name: userNameById.get(membership.userId) ?? membership.userId,
+      name: userNameById.get(membership.userId) ?? "不明",
       role: roleKeyByDto[membership.role] ?? "member",
       canChangeRole: canChangeRoleByUserId.get(membership.userId) ?? false,
       canRemoveMember:

--- a/server/presentation/providers/circle-session-detail-provider.ts
+++ b/server/presentation/providers/circle-session-detail-provider.ts
@@ -44,7 +44,7 @@ const mapMemberships = (
 ): CircleSessionMembership[] =>
   memberships.map((membership) => ({
     id: membership.userId,
-    name: nameById.get(membership.userId) ?? membership.userId,
+    name: nameById.get(membership.userId) ?? "不明",
     role: roleKeyByDto[membership.role] ?? null,
     canChangeRole: canChangeRoleById.get(membership.userId) ?? false,
     canRemoveMember: canRemoveById.get(membership.userId) ?? false,
@@ -63,7 +63,7 @@ const mergeMembershipIds = (
       ids.add(match.player1Id);
       extras.push({
         id: match.player1Id,
-        name: nameById.get(match.player1Id) ?? match.player1Id,
+        name: nameById.get(match.player1Id) ?? "不明",
         role: null,
         canChangeRole: false,
         canRemoveMember: false,
@@ -73,7 +73,7 @@ const mergeMembershipIds = (
       ids.add(match.player2Id);
       extras.push({
         id: match.player2Id,
-        name: nameById.get(match.player2Id) ?? match.player2Id,
+        name: nameById.get(match.player2Id) ?? "不明",
         role: null,
         canChangeRole: false,
         canRemoveMember: false,
@@ -197,7 +197,7 @@ export async function getCircleSessionDetailViewModel(
       }
       addableMemberCandidates = candidateUserIdArray.map((id) => ({
         id,
-        name: userNameById.get(id) ?? id,
+        name: userNameById.get(id) ?? "不明",
       }));
     }
   }
@@ -261,11 +261,11 @@ export async function getCircleSessionDetailViewModel(
             pairings: round.pairings.map((pairing) => ({
               player1: {
                 id: pairing.player1.id,
-                name: pairing.player1.name ?? pairing.player1.id,
+                name: pairing.player1.name ?? "不明",
               },
               player2: {
                 id: pairing.player2.id,
-                name: pairing.player2.name ?? pairing.player2.id,
+                name: pairing.player2.name ?? "不明",
               },
             })),
           })),


### PR DESCRIPTION
## Summary

- Provider層で他ユーザー名が取得できない場合のフォールバック値を「不明」に統一
- `circle-overview-provider.ts`: 1箇所（`userId` → `"不明"`）
- `circle-session-detail-provider.ts`: 5箇所（`userId`/`id` → `"不明"`）

Closes #820

## Verification

- [x] `npx tsc --noEmit` 型チェック通過
- [x] circle-overview-provider テスト 3件パス
- [x] circle-session-detail-provider テスト 4件パス
- [x] 手動確認: メンバー一覧、セッション詳細、対局表示でフォールバック値が「不明」に統一されていること

## Follow-up Issues

- #829: マジックストリング「不明」を定数に抽出する
- #830: getCircleSessionDetailViewModel の長大メソッドをリファクタリングする

## Review Points

- フォールバック値「不明」がマジックストリングとして7箇所に散在（#829 で対応予定）
- View Model の型は変更なし（既存の `string` 型を維持）

🤖 Generated with [Claude Code](https://claude.com/claude-code)