### PR TITLE
refactor: ユーザー名フォールバック文字列「不明」を定数に抽出する

### DIFF
--- a/server/presentation/constants.ts
+++ b/server/presentation/constants.ts
@@ -1,0 +1,4 @@
+/**
+ * ユーザー名が取得できない場合のフォールバック表示名
+ */
+export const UNKNOWN_USER_NAME = "不明";

--- a/server/presentation/providers/circle-overview-provider.ts
+++ b/server/presentation/providers/circle-overview-provider.ts
@@ -1,6 +1,7 @@
 import { formatDateTimeRange } from "@/lib/date-utils";
 import { CircleRole } from "@/server/domain/models/circle/circle-role";
 import { NotFoundError } from "@/server/domain/common/errors";
+import { UNKNOWN_USER_NAME } from "@/server/presentation/constants";
 import { appRouter } from "@/server/presentation/trpc/router";
 import { createContext } from "@/server/presentation/trpc/context";
 import type {
@@ -120,7 +121,7 @@ export async function getCircleOverviewViewModel(
   const members = memberships
     .map((membership) => ({
       userId: membership.userId,
-      name: userNameById.get(membership.userId) ?? "不明",
+      name: userNameById.get(membership.userId) ?? UNKNOWN_USER_NAME,
       role: roleKeyByDto[membership.role] ?? "member",
       canChangeRole: canChangeRoleByUserId.get(membership.userId) ?? false,
       canRemoveMember:

--- a/server/presentation/providers/circle-session-detail-provider.ts
+++ b/server/presentation/providers/circle-session-detail-provider.ts
@@ -5,6 +5,7 @@ import {
 } from "@/lib/date-utils";
 import { CircleSessionRole } from "@/server/domain/models/circle-session/circle-session-role";
 import { circleSessionId as toCircleSessionId } from "@/server/domain/common/ids";
+import { UNKNOWN_USER_NAME } from "@/server/presentation/constants";
 import { appRouter } from "@/server/presentation/trpc/router";
 import { createContext } from "@/server/presentation/trpc/context";
 import type {
@@ -44,7 +45,7 @@ const mapMemberships = (
 ): CircleSessionMembership[] =>
   memberships.map((membership) => ({
     id: membership.userId,
-    name: nameById.get(membership.userId) ?? "不明",
+    name: nameById.get(membership.userId) ?? UNKNOWN_USER_NAME,
     role: roleKeyByDto[membership.role] ?? null,
     canChangeRole: canChangeRoleById.get(membership.userId) ?? false,
     canRemoveMember: canRemoveById.get(membership.userId) ?? false,
@@ -63,7 +64,7 @@ const mergeMembershipIds = (
       ids.add(match.player1Id);
       extras.push({
         id: match.player1Id,
-        name: nameById.get(match.player1Id) ?? "不明",
+        name: nameById.get(match.player1Id) ?? UNKNOWN_USER_NAME,
         role: null,
         canChangeRole: false,
         canRemoveMember: false,
@@ -73,7 +74,7 @@ const mergeMembershipIds = (
       ids.add(match.player2Id);
       extras.push({
         id: match.player2Id,
-        name: nameById.get(match.player2Id) ?? "不明",
+        name: nameById.get(match.player2Id) ?? UNKNOWN_USER_NAME,
         role: null,
         canChangeRole: false,
         canRemoveMember: false,
@@ -197,7 +198,7 @@ export async function getCircleSessionDetailViewModel(
       }
       addableMemberCandidates = candidateUserIdArray.map((id) => ({
         id,
-        name: userNameById.get(id) ?? "不明",
+        name: userNameById.get(id) ?? UNKNOWN_USER_NAME,
       }));
     }
   }
@@ -261,11 +262,11 @@ export async function getCircleSessionDetailViewModel(
             pairings: round.pairings.map((pairing) => ({
               player1: {
                 id: pairing.player1.id,
-                name: pairing.player1.name ?? "不明",
+                name: pairing.player1.name ?? UNKNOWN_USER_NAME,
               },
               player2: {
                 id: pairing.player2.id,
-                name: pairing.player2.name ?? "不明",
+                name: pairing.player2.name ?? UNKNOWN_USER_NAME,
               },
             })),
           })),


### PR DESCRIPTION
## Summary

- `"不明"` 文字列リテラル（計7箇所）を `UNKNOWN_USER_NAME` 定数に抽出
- `server/presentation/constants.ts` に定数を定義し、2つの provider ファイルから参照

Closes #829

## Changes

| File | Change |
|------|--------|
| `server/presentation/constants.ts` | 新規: `UNKNOWN_USER_NAME` 定数定義 |
| `server/presentation/providers/circle-overview-provider.ts` | 1箇所の文字列リテラルを定数参照に置換 |
| `server/presentation/providers/circle-session-detail-provider.ts` | 6箇所の文字列リテラルを定数参照に置換 |

## Verification

- [x] `tsc --noEmit` pass
- [x] Provider tests (4ファイル, 14テスト) all pass
- [x] `server/presentation/providers/` 内に `"不明"` リテラル残存なし

## Notes

- application層（`circle-session-detail-service.ts`）の同リテラルは依存方向の制約上スコープ外 → #832 で対応予定

## Test plan

- [ ] `npm run test:run` で既存テストが全て通ること
- [ ] `npx tsc --noEmit` で型エラーがないこと

🤖 Generated with [Claude Code](https://claude.com/claude-code)