### PR TITLE
fix: USER_NAME_MAX_LENGTH の長さカウントをコードポイント単位に統一する

### DIFF
--- a/server/application/auth/signup-service.test.ts
+++ b/server/application/auth/signup-service.test.ts
@@ -107,6 +107,29 @@ describe("SignupService", () => {
     expect(userStore.size).toBe(1);
   });
 
+  test("絵文字を含む名前が50コードポイント以内の場合は許可される", async () => {
+    const { deps, userStore } = createDeps();
+    const service = createSignupService(deps);
+    // 🎉 is 1 codepoint but 2 UTF-16 code units (String.length === 2)
+    const nameWithEmoji = "🎉".repeat(50);
+
+    const result = await service.signup({ ...validInput, name: nameWithEmoji });
+
+    expect(result).toEqual({ success: true, userId: expect.any(String) });
+    expect(userStore.size).toBe(1);
+  });
+
+  test("絵文字を含む名前が50コードポイントを超える場合 name_too_long を返す", async () => {
+    const { deps, userStore } = createDeps();
+    const service = createSignupService(deps);
+    const nameWithEmoji = "🎉".repeat(51);
+
+    const result = await service.signup({ ...validInput, name: nameWithEmoji });
+
+    expect(result).toEqual({ success: false, error: "name_too_long" });
+    expect(userStore.size).toBe(0);
+  });
+
   test("名前がnullの場合は name_too_long チェックをスキップする", async () => {
     const { deps, userStore } = createDeps();
     const service = createSignupService(deps);

--- a/server/application/auth/signup-service.ts
+++ b/server/application/auth/signup-service.ts
@@ -56,7 +56,7 @@ export const createSignupService = (deps: SignupServiceDeps) => ({
       return { success: false, error: "password_too_long" };
     }
 
-    if (name !== null && name.length > USER_NAME_MAX_LENGTH) {
+    if (name !== null && [...name].length > USER_NAME_MAX_LENGTH) {
       return { success: false, error: "name_too_long" };
     }
 

--- a/server/presentation/dto/user.test.ts
+++ b/server/presentation/dto/user.test.ts
@@ -1,0 +1,41 @@
+import { describe, expect, test } from "vitest";
+import { updateProfileInputSchema } from "@/server/presentation/dto/user";
+
+describe("updateProfileInputSchema", () => {
+  test("名前が50コードポイント以内の場合はバリデーション成功", () => {
+    const result = updateProfileInputSchema.safeParse({
+      name: "あ".repeat(50),
+      email: "test@example.com",
+    });
+
+    expect(result.success).toBe(true);
+  });
+
+  test("名前が50コードポイントを超える場合はバリデーション失敗", () => {
+    const result = updateProfileInputSchema.safeParse({
+      name: "あ".repeat(51),
+      email: "test@example.com",
+    });
+
+    expect(result.success).toBe(false);
+  });
+
+  test("絵文字を含む名前が50コードポイント以内の場合はバリデーション成功", () => {
+    // 🎉 is 1 codepoint but 2 UTF-16 code units (String.length === 2)
+    const result = updateProfileInputSchema.safeParse({
+      name: "🎉".repeat(50),
+      email: "test@example.com",
+    });
+
+    expect(result.success).toBe(true);
+  });
+
+  test("絵文字を含む名前が50コードポイントを超える場合はバリデーション失敗", () => {
+    const result = updateProfileInputSchema.safeParse({
+      name: "🎉".repeat(51),
+      email: "test@example.com",
+    });
+
+    expect(result.success).toBe(false);
+  });
+});

--- a/server/presentation/dto/user.ts
+++ b/server/presentation/dto/user.ts
@@ -42,7 +42,14 @@ export const meDtoSchema = userDtoSchema.extend({
 export type MeDto = z.infer<typeof meDtoSchema>;
 
 export const updateProfileInputSchema = z.object({
-  name: z.string().trim().min(1).max(USER_NAME_MAX_LENGTH).nullable(),
+  name: z
+    .string()
+    .trim()
+    .min(1)
+    .refine((v) => [...v].length <= USER_NAME_MAX_LENGTH, {
+      message: `名前は${String(USER_NAME_MAX_LENGTH)}文字以内で入力してください`,
+    })
+    .nullable(),
   email: z.string().trim().min(1).max(USER_EMAIL_MAX_LENGTH).nullable(),
 });
 


### PR DESCRIPTION
## Summary

Closes #676

- Zod バリデーション (`z.string().max()`) と `SignupService` の名前長チェックが UTF-16 コードユニット (`String.length`) でカウントしていたため、OAuth 切り詰め（コードポイント単位）との不整合を修正
- `dto/user.ts`: `z.string().max()` → `.refine(v => [...v].length <= MAX)` に変更
- `signup-service.ts`: `name.length` → `[...name].length` に変更
- 絵文字を含む名前のテストケースを両箇所に追加

## Test plan

- [x] `signup-service.test.ts` — 絵文字50文字（許可）/ 51文字（拒否）のテスト追加・パス
- [x] `user.test.ts` — Zod スキーマの絵文字バリデーションテスト追加・パス
- [ ] 手動: プロフィール編集画面で絵文字を含む名前（50文字以内）が保存できることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)