### PR TITLE
docs: プライバシーポリシーの収集データ一覧をスキーマと整合させる (#708)

### DIFF
--- a/app/privacy/page.tsx
+++ b/app/privacy/page.tsx
@@ -35,6 +35,9 @@ export default function PrivacyPage() {
         <ul className="mt-3 ml-5 list-disc space-y-1 text-sm leading-relaxed text-(--brand-ink-muted)">
           <li>メールアドレス</li>
           <li>表示名（ニックネーム）</li>
+          <li>プロフィール画像（Googleアカウント連携時）</li>
+          <li>アカウント作成日時</li>
+          <li>プロフィール公開範囲の設定</li>
         </ul>
         <p className="mt-4 text-sm leading-relaxed text-(--brand-ink-muted)">
           また、ユーザーが本サービスを利用する過程で、以下の情報が記録されます。


### PR DESCRIPTION
## Summary

- プライバシーポリシー第2条の収集データ一覧に、Prismaスキーマに存在するが未記載だった項目を追加
  - プロフィール画像（`User.image`）
  - アカウント作成日時（`User.createdAt`）
  - プロフィール公開範囲の設定（`User.profileVisibility`）

Closes #708

## Test plan

- [ ] `app/privacy/page.tsx` の第2条リストが `prisma/schema.prisma` の `User` モデルと整合していることを確認
- [ ] 追加項目のHTML構造が既存項目と一貫していることを確認
- [ ] 日本語表現が自然であることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)