### PR TITLE
fix: NEXT_PUBLIC_CONTACT_FORM_URL に URL バリデーションを追加する

### DIFF
--- a/app/(authenticated)/help/page.tsx
+++ b/app/(authenticated)/help/page.tsx
@@ -99,7 +99,13 @@ function renderPermissionCell(value: string, noteId?: string) {
   }
 }
 
-const contactFormUrl = process.env.NEXT_PUBLIC_CONTACT_FORM_URL;
+const GOOGLE_FORMS_URL_PATTERN = /^https:\/\/docs\.google\.com\/forms\//;
+
+const rawContactFormUrl = process.env.NEXT_PUBLIC_CONTACT_FORM_URL;
+const contactFormUrl =
+  rawContactFormUrl && GOOGLE_FORMS_URL_PATTERN.test(rawContactFormUrl)
+    ? rawContactFormUrl
+    : undefined;
 
 export default function HelpPage() {
   return (


### PR DESCRIPTION
## Summary

- `NEXT_PUBLIC_CONTACT_FORM_URL` 環境変数に Google Forms ドメインの `https://` URL のみ許可するバリデーションを追加
- 不正な値（`javascript:` URI、外部ドメイン等）の場合はお問い合わせセクションを非表示にする
- defense-in-depth としてのセキュリティ改善

Closes #647

## Verification

- [x] `npx tsc --noEmit`: OK
- [x] `npx eslint`: OK

### 手動確認手順

1. `NEXT_PUBLIC_CONTACT_FORM_URL` に正しい Google Forms URL → セクション表示
2. `javascript:alert(1)` → セクション非表示
3. `https://evil.example.com` → セクション非表示
4. 未設定 → セクション非表示

## Follow-up

- #838: validateContactFormUrl のユニットテストを追加する

🤖 Generated with [Claude Code](https://claude.com/claude-code)