### PR TITLE
test: context.ts のサービスコンテナワイヤリングに統合テストを追加する

### DIFF
--- a/server/presentation/trpc/__tests__/context-wiring.test.ts
+++ b/server/presentation/trpc/__tests__/context-wiring.test.ts
@@ -1,0 +1,105 @@
+import { describe, expect, test, vi } from "vitest";
+import type { ServiceContainerDeps } from "@/server/infrastructure/service-container";
+
+vi.mock("@/server/infrastructure/service-container", () => ({
+  createServiceContainer: vi.fn(() => ({})),
+}));
+
+vi.mock("@/server/infrastructure/repository/circle/prisma-circle-repository", () => ({
+  prismaCircleRepository: {},
+}));
+
+vi.mock("@/server/infrastructure/repository/circle-session/prisma-circle-session-repository", () => ({
+  prismaCircleSessionRepository: {},
+}));
+
+vi.mock("@/server/infrastructure/repository/match/prisma-match-repository", () => ({
+  prismaMatchRepository: {},
+}));
+
+vi.mock("@/server/infrastructure/repository/user/prisma-user-repository", () => ({
+  prismaUserRepository: {},
+}));
+
+vi.mock("@/server/infrastructure/repository/authz/prisma-authz-repository", () => ({
+  prismaAuthzRepository: {},
+}));
+
+vi.mock("@/server/infrastructure/repository/circle-invite-link/prisma-circle-invite-link-repository", () => ({
+  prismaCircleInviteLinkRepository: {},
+}));
+
+vi.mock("@/server/infrastructure/repository/round-robin-schedule/prisma-round-robin-schedule-repository", () => ({
+  prismaRoundRobinScheduleRepository: {},
+}));
+
+vi.mock("@/server/infrastructure/auth/password", () => ({
+  hashPassword: vi.fn(),
+  verifyPassword: vi.fn(),
+}));
+
+vi.mock("@/server/infrastructure/auth/nextauth-session-service", () => ({
+  nextAuthSessionService: {},
+}));
+
+vi.mock("@/server/infrastructure/transaction/prisma-unit-of-work", () => ({
+  prismaUnitOfWork: vi.fn(),
+}));
+
+vi.mock("@/server/infrastructure/holiday/japanese-holiday-provider", () => ({
+  createJapaneseHolidayProvider: vi.fn(() => ({
+    getHolidayDateStrings: vi.fn(),
+    getHolidayDateStringsForRange: vi.fn(),
+  })),
+}));
+
+vi.mock("@/server/infrastructure/rate-limit/prisma-rate-limiter", () => ({
+  createPrismaRateLimiter: vi.fn(() => ({
+    check: vi.fn(),
+    recordFailure: vi.fn(),
+    reset: vi.fn(),
+  })),
+}));
+
+describe("buildServiceContainer ワイヤリング", () => {
+  test("buildServiceContainer() を複数回呼び出しても holidayProvider が同一インスタンスである", async () => {
+    const { createServiceContainer } = await import(
+      "@/server/infrastructure/service-container"
+    );
+    const { buildServiceContainer } = await import(
+      "@/server/presentation/trpc/context"
+    );
+
+    const spy = vi.mocked(createServiceContainer);
+
+    buildServiceContainer();
+    buildServiceContainer();
+
+    const deps1 = spy.mock.calls[0]?.[0] as ServiceContainerDeps;
+    const deps2 = spy.mock.calls[1]?.[0] as ServiceContainerDeps;
+
+    expect(deps1.holidayProvider).toBe(deps2.holidayProvider);
+  });
+
+  test("buildServiceContainer() を複数回呼び出しても changePasswordRateLimiter が同一インスタンスである", async () => {
+    const { createServiceContainer } = await import(
+      "@/server/infrastructure/service-container"
+    );
+    const { buildServiceContainer } = await import(
+      "@/server/presentation/trpc/context"
+    );
+
+    const spy = vi.mocked(createServiceContainer);
+    spy.mockClear();
+
+    buildServiceContainer();
+    buildServiceContainer();
+
+    const deps1 = spy.mock.calls[0]?.[0] as ServiceContainerDeps;
+    const deps2 = spy.mock.calls[1]?.[0] as ServiceContainerDeps;
+
+    expect(deps1.changePasswordRateLimiter).toBe(
+      deps2.changePasswordRateLimiter,
+    );
+  });
+});

--- a/server/presentation/trpc/context.ts
+++ b/server/presentation/trpc/context.ts
@@ -26,7 +26,7 @@ const changePasswordRateLimiter = createPrismaRateLimiter({
   category: "changePassword",
 });
 
-const buildServiceContainer = (): ServiceContainer =>
+export const buildServiceContainer = (): ServiceContainer =>
   createServiceContainer({
     circleRepository: prismaCircleRepository,
     circleSessionRepository: prismaCircleSessionRepository,


### PR DESCRIPTION
## Summary

- `buildServiceContainer()` のワイヤリングを検証する統合テストを追加
- `buildServiceContainer` を export に変更（テストからアクセスするため）
- `holidayProvider` と `changePasswordRateLimiter` が複数回呼び出しで同一インスタンスを返すことを検証

Closes #621

## Test plan

- [x] `npm run test:run -- server/presentation/trpc/__tests__/context-wiring.test.ts` — 2 tests passed
- [ ] `npx tsc --noEmit` で型エラーなし
- [ ] `npm run lint` で lint エラーなし

🤖 Generated with [Claude Code](https://claude.com/claude-code)