### PR TITLE
feat: レートリミッターに DB エラーハンドリングを追加する (#627)

### DIFF
--- a/server/infrastructure/rate-limit/prisma-rate-limiter.test.ts
+++ b/server/infrastructure/rate-limit/prisma-rate-limiter.test.ts
@@ -149,4 +149,62 @@ describe("PrismaRateLimiter", () => {
       },
     });
   });
+
+  describe("DBエラー時の振る舞い", () => {
+    test("checkはDBエラー時にTooManyRequestsErrorをスローする（fail-closed）", async () => {
+      const consoleErrorSpy = vi
+        .spyOn(console, "error")
+        .mockImplementation(() => {});
+      mockedPrisma.$transaction.mockRejectedValueOnce(
+        new Error("DB connection failed"),
+      );
+
+      const limiter = createPrismaRateLimiter(config);
+      await expect(limiter.check("user-1")).rejects.toThrow(
+        TooManyRequestsError,
+      );
+
+      expect(consoleErrorSpy).toHaveBeenCalledWith(
+        "[rate-limit] DB error during check:",
+        expect.any(Error),
+      );
+      consoleErrorSpy.mockRestore();
+    });
+
+    test("recordFailureはDBエラー時に例外をスローしない（fail-open）", async () => {
+      const consoleErrorSpy = vi
+        .spyOn(console, "error")
+        .mockImplementation(() => {});
+      mockedPrisma.rateLimitAttempt.create.mockRejectedValueOnce(
+        new Error("DB connection failed"),
+      );
+
+      const limiter = createPrismaRateLimiter(config);
+      await expect(limiter.recordFailure("user-1")).resolves.toBeUndefined();
+
+      expect(consoleErrorSpy).toHaveBeenCalledWith(
+        "[rate-limit] DB error during recordFailure:",
+        expect.any(Error),
+      );
+      consoleErrorSpy.mockRestore();
+    });
+
+    test("resetはDBエラー時に例外をスローしない（fail-open）", async () => {
+      const consoleErrorSpy = vi
+        .spyOn(console, "error")
+        .mockImplementation(() => {});
+      mockedPrisma.rateLimitAttempt.deleteMany.mockRejectedValueOnce(
+        new Error("DB connection failed"),
+      );
+
+      const limiter = createPrismaRateLimiter(config);
+      await expect(limiter.reset("user-1")).resolves.toBeUndefined();
+
+      expect(consoleErrorSpy).toHaveBeenCalledWith(
+        "[rate-limit] DB error during reset:",
+        expect.any(Error),
+      );
+      consoleErrorSpy.mockRestore();
+    });
+  });
 });

--- a/server/infrastructure/rate-limit/prisma-rate-limiter.ts
+++ b/server/infrastructure/rate-limit/prisma-rate-limiter.ts
@@ -13,61 +13,75 @@ export const createPrismaRateLimiter = (
 ): RateLimiter => {
   return {
     async check(key) {
-      const now = Date.now();
-      const windowStart = new Date(now - config.windowMs);
+      try {
+        const now = Date.now();
+        const windowStart = new Date(now - config.windowMs);
 
-      // pruning + count をトランザクションで実行（競合状態を防止）
-      const [, count] = await prisma.$transaction([
-        prisma.rateLimitAttempt.deleteMany({
-          where: {
-            category: config.category,
-            attemptedAt: { lt: windowStart },
-          },
-        }),
-        prisma.rateLimitAttempt.count({
-          where: {
-            key,
-            category: config.category,
-            attemptedAt: { gte: windowStart },
-          },
-        }),
-      ]);
+        // pruning + count をトランザクションで実行（競合状態を防止）
+        const [, count] = await prisma.$transaction([
+          prisma.rateLimitAttempt.deleteMany({
+            where: {
+              category: config.category,
+              attemptedAt: { lt: windowStart },
+            },
+          }),
+          prisma.rateLimitAttempt.count({
+            where: {
+              key,
+              category: config.category,
+              attemptedAt: { gte: windowStart },
+            },
+          }),
+        ]);
 
-      if (count >= config.maxAttempts) {
-        const oldest = await prisma.rateLimitAttempt.findFirst({
-          where: {
-            key,
-            category: config.category,
-            attemptedAt: { gte: windowStart },
-          },
-          orderBy: { attemptedAt: "asc" },
-          select: { attemptedAt: true },
-        });
+        if (count >= config.maxAttempts) {
+          const oldest = await prisma.rateLimitAttempt.findFirst({
+            where: {
+              key,
+              category: config.category,
+              attemptedAt: { gte: windowStart },
+            },
+            orderBy: { attemptedAt: "asc" },
+            select: { attemptedAt: true },
+          });
 
-        const retryAfterMs = oldest
-          ? oldest.attemptedAt.getTime() + config.windowMs - now
-          : config.windowMs;
+          const retryAfterMs = oldest
+            ? oldest.attemptedAt.getTime() + config.windowMs - now
+            : config.windowMs;
 
-        throw new TooManyRequestsError(retryAfterMs);
+          throw new TooManyRequestsError(retryAfterMs);
+        }
+      } catch (error) {
+        if (error instanceof TooManyRequestsError) throw error;
+        console.error("[rate-limit] DB error during check:", error);
+        throw new TooManyRequestsError(config.windowMs);
       }
     },
 
     async recordFailure(key) {
-      await prisma.rateLimitAttempt.create({
-        data: {
-          key,
-          category: config.category,
-        },
-      });
+      try {
+        await prisma.rateLimitAttempt.create({
+          data: {
+            key,
+            category: config.category,
+          },
+        });
+      } catch (error) {
+        console.error("[rate-limit] DB error during recordFailure:", error);
+      }
     },
 
     async reset(key) {
-      await prisma.rateLimitAttempt.deleteMany({
-        where: {
-          key,
-          category: config.category,
-        },
-      });
+      try {
+        await prisma.rateLimitAttempt.deleteMany({
+          where: {
+            key,
+            category: config.category,
+          },
+        });
+      } catch (error) {
+        console.error("[rate-limit] DB error during reset:", error);
+      }
     },
   };
 };


### PR DESCRIPTION
## Summary

Closes #627

- `check()`: DB エラー時に fail-closed（`TooManyRequestsError` をスロー）+ エラーログ出力
- `recordFailure()`: DB エラー時に fail-open（例外を飲み込みログ出力のみ）で認証フローを継続
- `reset()`: DB エラー時に fail-open（例外を飲み込みログ出力のみ）でログイン成功フローを継続

## Test plan

- [x] 既存テスト 8 件が引き続きパス
- [x] 新規テスト 3 件（DB エラーシナリオ）がパス
- [x] `npx tsc --noEmit` 型エラーなし
- [x] `npm run lint` エラーなし

## Verification

- `check()` の DB エラーで `TooManyRequestsError` がスローされること（fail-closed）
- `recordFailure()` の DB エラーで例外がスローされないこと（fail-open）
- `reset()` の DB エラーで例外がスローされないこと（fail-open）
- 各エラーケースで `console.error` にログが出力されること

🤖 Generated with [Claude Code](https://claude.com/claude-code)