### PR TITLE
fix: cron エンドポイントの Bearer トークン比較を timing-safe にする

### DIFF
--- a/app/api/cron/cleanup-rate-limits/route.ts
+++ b/app/api/cron/cleanup-rate-limits/route.ts
@@ -1,3 +1,5 @@
+import crypto from "node:crypto";
+
 import { NextResponse } from "next/server";
 
 import { rateLimitCleanupService } from "@/server/presentation/cron/rate-limit-cleanup";
@@ -6,7 +8,18 @@ export async function GET(request: Request) {
   const authHeader = request.headers.get("authorization");
   const cronSecret = process.env.CRON_SECRET;
 
-  if (!cronSecret || authHeader !== `Bearer ${cronSecret}`) {
+  if (!cronSecret || !authHeader) {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
+
+  const expected = `Bearer ${cronSecret}`;
+  const headerBuf = Buffer.from(authHeader);
+  const expectedBuf = Buffer.from(expected);
+
+  if (
+    headerBuf.length !== expectedBuf.length ||
+    !crypto.timingSafeEqual(headerBuf, expectedBuf)
+  ) {
     return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
   }
 


### PR DESCRIPTION
Closes #848

## Summary

- `!==` による文字列比較を `crypto.timingSafeEqual` に変更し、タイミング攻撃の理論的可能性を排除
- `authHeader` / `cronSecret` の null チェックをガード節として分離し、`timingSafeEqual` に null が渡らないよう保証
- 長さ不一致時の早期リターンは Node.js 公式ドキュメント推奨パターン

## Test plan

- [ ] `tsc --noEmit` がパスすること
- [ ] 正しい Bearer トークンで 200 が返ること
- [ ] 不正なトークンで 401 が返ること
- [ ] Authorization ヘッダーなしで 401 が返ること
- [ ] `CRON_SECRET` 未設定で 401 が返ること

## Follow-up

- #850: cron エンドポイントのユニットテストを追加する

🤖 Generated with [Claude Code](https://claude.com/claude-code)