### PR TITLE
test: cron エンドポイントのユニットテストを追加する (#850)

### DIFF
--- a/app/api/cron/cleanup-rate-limits/route.test.ts
+++ b/app/api/cron/cleanup-rate-limits/route.test.ts
@@ -28,6 +28,13 @@ describe("GET /api/cron/cleanup-rate-limits", () => {
     expect(response.status).toBe(401);
   });
 
+  test("Authorizationヘッダーなしの場合は401を返す", async () => {
+    const request = new Request("http://localhost/api/cron/cleanup-rate-limits");
+
+    const response = await GET(request);
+    expect(response.status).toBe(401);
+  });
+
   test("Authorizationヘッダーが不正な場合は401を返す", async () => {
     const request = new Request("http://localhost/api/cron/cleanup-rate-limits", {
       headers: { authorization: "Bearer wrong-secret" },


### PR DESCRIPTION
## Summary

- `GET /api/cron/cleanup-rate-limits` の `!authHeader` 分岐（Authorizationヘッダーなし）のテストケースを追加
- これにより、認証フローの全5分岐がテストでカバーされた状態になる

## Verification

- `npx vitest run app/api/cron/cleanup-rate-limits/route.test.ts` で全5テストがパスすることを確認済み
- 分岐カバレッジ: CRON_SECRET未設定→401, ヘッダーなし→401, 不正トークン→401, 正常系→200, DBエラー→500

Closes #850

🤖 Generated with [Claude Code](https://claude.com/claude-code)