### PR TITLE
refactor: changePassword のパラメータをオプションオブジェクト化する

### DIFF
--- a/server/application/user/user-service.test.ts
+++ b/server/application/user/user-service.test.ts
@@ -167,7 +167,7 @@ describe("changePassword", () => {
   test("パスワードを変更する", async () => {
     addTestUser("hashed:oldpass");
 
-    await service.changePassword(actorId, "oldpass", "newpass12", "1.2.3.4");
+    await service.changePassword(actorId, { currentPassword: "oldpass", newPassword: "newpass12", clientIp: "1.2.3.4" });
 
     const stored = userStore.get(actorId);
     expect(stored?.passwordHash).toBe("hashed:newpass12");
@@ -178,7 +178,7 @@ describe("changePassword", () => {
     addTestUser("hashed:correct");
 
     await expect(
-      service.changePassword(actorId, "wrong", "newpass12", "1.2.3.4"),
+      service.changePassword(actorId, { currentPassword: "wrong", newPassword: "newpass12", clientIp: "1.2.3.4" }),
     ).rejects.toThrow("Current password is incorrect");
 
     // パスワードが変更されていないことを検証
@@ -190,7 +190,7 @@ describe("changePassword", () => {
     addTestUser("hashed:oldpass");
 
     await expect(
-      service.changePassword(actorId, "oldpass", "short", "1.2.3.4"),
+      service.changePassword(actorId, { currentPassword: "oldpass", newPassword: "short", clientIp: "1.2.3.4" }),
     ).rejects.toThrow("Password too short");
 
     const stored = userStore.get(actorId);
@@ -201,7 +201,7 @@ describe("changePassword", () => {
     addTestUser("hashed:oldpass");
     const maxPassword = "a".repeat(128);
 
-    await service.changePassword(actorId, "oldpass", maxPassword, "1.2.3.4");
+    await service.changePassword(actorId, { currentPassword: "oldpass", newPassword: maxPassword, clientIp: "1.2.3.4" });
 
     const stored = userStore.get(actorId);
     expect(stored?.passwordHash).toBe(`hashed:${maxPassword}`);
@@ -212,7 +212,7 @@ describe("changePassword", () => {
     const longPassword = "a".repeat(129);
 
     await expect(
-      service.changePassword(actorId, "oldpass", longPassword, "1.2.3.4"),
+      service.changePassword(actorId, { currentPassword: "oldpass", newPassword: longPassword, clientIp: "1.2.3.4" }),
     ).rejects.toThrow("Password too long");
 
     const stored = userStore.get(actorId);
@@ -223,7 +223,7 @@ describe("changePassword", () => {
     addTestUser(null);
 
     await expect(
-      service.changePassword(actorId, "any", "newpass12", "1.2.3.4"),
+      service.changePassword(actorId, { currentPassword: "any", newPassword: "newpass12", clientIp: "1.2.3.4" }),
     ).rejects.toThrow("Password login is not enabled");
 
     const stored = userStore.get(actorId);
@@ -237,7 +237,7 @@ describe("changePassword", () => {
     addTestUser("hashed:oldpass");
 
     await expect(
-      service.changePassword(actorId, "oldpass", "newpass12", "1.2.3.4"),
+      service.changePassword(actorId, { currentPassword: "oldpass", newPassword: "newpass12", clientIp: "1.2.3.4" }),
     ).rejects.toThrow(TooManyRequestsError);
 
     // パスワードが変更されていないことを検証
@@ -249,7 +249,7 @@ describe("changePassword", () => {
     addTestUser("hashed:correct");
 
     await expect(
-      service.changePassword(actorId, "wrong", "newpass12", "1.2.3.4"),
+      service.changePassword(actorId, { currentPassword: "wrong", newPassword: "newpass12", clientIp: "1.2.3.4" }),
     ).rejects.toThrow("Current password is incorrect");
 
     expect(changePasswordRateLimiter.recordFailure).toHaveBeenCalledWith(
@@ -260,7 +260,7 @@ describe("changePassword", () => {
   test("パスワード変更成功時に reset が呼ばれる", async () => {
     addTestUser("hashed:oldpass");
 
-    await service.changePassword(actorId, "oldpass", "newpass12", "1.2.3.4");
+    await service.changePassword(actorId, { currentPassword: "oldpass", newPassword: "newpass12", clientIp: "1.2.3.4" });
 
     expect(changePasswordRateLimiter.reset).toHaveBeenCalledWith(
       `${actorId}:1.2.3.4`,

--- a/server/application/user/user-service.ts
+++ b/server/application/user/user-service.ts
@@ -73,10 +73,13 @@ export const createUserService = (deps: UserServiceDeps) => ({
 
   async changePassword(
     actorId: UserId,
-    currentPassword: string,
-    newPassword: string,
-    clientIp: string,
+    params: {
+      currentPassword: string;
+      newPassword: string;
+      clientIp: string;
+    },
   ): Promise<void> {
+    const { currentPassword, newPassword, clientIp } = params;
     const rateLimitKey = `${actorId}:${clientIp}`;
     await deps.changePasswordRateLimiter.check(rateLimitKey);
 

--- a/server/presentation/trpc/routers/user.ts
+++ b/server/presentation/trpc/routers/user.ts
@@ -81,12 +81,11 @@ export const userRouter = router({
     .output(z.void())
     .mutation(({ ctx, input }) =>
       handleTrpcError(async () => {
-        await ctx.userService.changePassword(
-          ctx.actorId,
-          input.currentPassword,
-          input.newPassword,
-          ctx.clientIp,
-        );
+        await ctx.userService.changePassword(ctx.actorId, {
+          currentPassword: input.currentPassword,
+          newPassword: input.newPassword,
+          clientIp: ctx.clientIp,
+        });
       }),
     ),
 


### PR DESCRIPTION
## Summary

- `changePassword` の位置パラメータ (`currentPassword`, `newPassword`, `clientIp`) をオプションオブジェクトに変更
- サービス層、tRPCルーター、テストの呼び出し箇所を更新

closes #844

## Test plan

- [ ] `user-service.test.ts` の全テストがパスすることを確認
- [ ] `changePassword` の呼び出し箇所がすべてオブジェクト形式に更新されていることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)