### PR TITLE
fix: SessionCalendar の日付比較をローカルタイムゾーンベースに変更する

### DIFF
--- a/components/calendar/session-calendar-hover.test.ts
+++ b/components/calendar/session-calendar-hover.test.ts
@@ -1,5 +1,9 @@
 import { describe, expect, it } from "vitest";
-import { buildSessionDates, getDayCellClassNames } from "./session-calendar";
+import {
+  buildSessionDates,
+  getDayCellClassNames,
+  toLocalDateString,
+} from "./session-calendar";
 
 describe("buildSessionDates", () => {
   it("events が undefined → 空 Set を返す", () => {
@@ -12,7 +16,7 @@ describe("buildSessionDates", () => {
     expect(result.size).toBe(0);
   });
 
-  it("start が Date オブジェクト → toISOString().slice(0, 10) で日付文字列を生成", () => {
+  it("start が Date オブジェクト → ローカル日付文字列を生成", () => {
     const result = buildSessionDates([{ start: new Date(2025, 0, 15, 14, 0) }]);
     expect(result.has("2025-01-15")).toBe(true);
     expect(result.size).toBe(1);
@@ -113,5 +117,18 @@ describe("getDayCellClassNames", () => {
       emptyHolidays,
     );
     expect(result).not.toContain("fc-day-holiday");
+  });
+});
+
+describe("toLocalDateString", () => {
+  it("Date オブジェクトからローカル日付の YYYY-MM-DD 文字列を返す", () => {
+    // 日中の時刻: タイムゾーンに依存しない
+    const date = new Date(2025, 0, 15, 14, 0);
+    expect(toLocalDateString(date)).toBe("2025-01-15");
+  });
+
+  it("月・日が1桁の場合もゼロ埋めされる", () => {
+    const date = new Date(2025, 2, 5, 10, 0);
+    expect(toLocalDateString(date)).toBe("2025-03-05");
   });
 });

--- a/components/calendar/session-calendar.tsx
+++ b/components/calendar/session-calendar.tsx
@@ -20,6 +20,13 @@ import { trpc } from "@/lib/trpc/client";
 
 const FC_PLUGINS = [dayGridPlugin, interactionPlugin];
 
+export function toLocalDateString(date: Date): string {
+  const y = date.getFullYear();
+  const m = String(date.getMonth() + 1).padStart(2, "0");
+  const d = String(date.getDate()).padStart(2, "0");
+  return `${y}-${m}-${d}`;
+}
+
 export type SessionExtendedProps = {
   startsAt: string | Date;
   endsAt: string | Date;
@@ -70,7 +77,7 @@ export function buildSessionDates(events?: EventInput[]): Set<string> {
   return new Set(
     events.map((e) => {
       const d = e.start;
-      if (d instanceof Date) return d.toISOString().slice(0, 10);
+      if (d instanceof Date) return toLocalDateString(d);
       return typeof d === "string" ? d.slice(0, 10) : "";
     }),
   );
@@ -284,7 +291,7 @@ export function SessionCalendar({
         dateClick={onDateClick}
         datesSet={handleDatesSet}
         dayCellClassNames={(arg) => {
-          const dateStr = arg.date.toISOString().slice(0, 10);
+          const dateStr = toLocalDateString(arg.date);
           return getDayCellClassNames(
             dateStr,
             sessionDates,


### PR DESCRIPTION
## Summary

- `toISOString().slice(0, 10)` による UTC ベースの日付比較を、ローカルタイムゾーンベースの `toLocalDateString()` に置き換え
- `buildSessionDates` と `dayCellClassNames` の2箇所を修正
- `toLocalDateString` の単体テスト2件を追加

Closes #201

## Test plan

- [ ] `npx vitest run components/calendar/session-calendar-hover.test.ts` で全テストがパス
- [ ] 深夜帯のセッションがカレンダー上で正しい日付にハイライトされることを目視確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)