### PR TITLE
fix: CircleOverviewCalendar の日付比較をローカルタイムゾーンベースに変更する

### DIFF
--- a/app/(authenticated)/circles/components/circle-overview-calendar.tsx
+++ b/app/(authenticated)/circles/components/circle-overview-calendar.tsx
@@ -3,6 +3,7 @@
 import {
   SessionCalendar,
   type SessionExtendedProps,
+  toLocalDateString,
 } from "@/components/calendar/session-calendar";
 import { Button } from "@/components/ui/button";
 import type { CircleOverviewSession } from "@/server/presentation/view-models/circle-overview";
@@ -51,7 +52,7 @@ export function CircleOverviewCalendar({
           typeof e.start === "string"
             ? e.start.slice(0, 10)
             : e.start instanceof Date
-              ? e.start.toISOString().slice(0, 10)
+              ? toLocalDateString(e.start)
               : String(e.start).slice(0, 10);
         return eventDate === clickedDate;
       });


### PR DESCRIPTION
## Summary

- `CircleOverviewCalendar` の日付比較で `toISOString().slice(0, 10)`（UTC基準）を `toLocalDateString()`（ローカルタイムゾーン基準）に置換
- #201 で導入済みの `toLocalDateString` ユーティリティを再利用
- JST 深夜帯のセッションが前日として扱われるバグを修正

Closes #855

## Test plan

- [ ] 開発サーバーで研究会概要ページのカレンダーを表示し、セッションが正しい日付に表示されることを確認
- [ ] カレンダーの日付クリック時のナビゲーションが正常に動作することを確認
- [ ] `toLocalDateString` は #201 でテスト済み

🤖 Generated with [Claude Code](https://claude.com/claude-code)