### PR TITLE
fix: updateProfile のメール一意性 TOCTOU 競合条件を修正する

### DIFF
--- a/server/application/user/user-service.test.ts
+++ b/server/application/user/user-service.test.ts
@@ -10,7 +10,10 @@ import {
   createUser,
   ProfileVisibility,
 } from "@/server/domain/models/user/user";
-import { TooManyRequestsError } from "@/server/domain/common/errors";
+import {
+  ConflictError,
+  TooManyRequestsError,
+} from "@/server/domain/common/errors";
 
 const userStore: UserStore = new Map();
 const userRepository = createInMemoryUserRepository(userStore);
@@ -100,7 +103,7 @@ describe("updateProfile", () => {
     expect(stored?.email).toBeNull();
   });
 
-  test("メール重複時に BadRequest エラー", async () => {
+  test("メール重複時に ConflictError", async () => {
     addTestUser("hashed:pass");
     // 別のユーザーが同じメールを使用中
     userStore.set("other-user", {
@@ -116,12 +119,27 @@ describe("updateProfile", () => {
 
     await expect(
       service.updateProfile(actorId, "NewName", "taken@example.com"),
-    ).rejects.toThrow("Email already in use");
+    ).rejects.toThrow(ConflictError);
 
     // ストアが変更されていないことを検証
     const stored = userStore.get(actorId);
     expect(stored?.name).toBe("Taro");
     expect(stored?.email).toBe("taro@example.com");
+  });
+
+  test("TOCTOU競合: リポジトリが ConflictError をスローした場合そのまま伝播する", async () => {
+    addTestUser("hashed:pass");
+
+    const originalUpdateProfile = userRepository.updateProfile;
+    vi.spyOn(userRepository, "updateProfile").mockRejectedValueOnce(
+      new ConflictError("Email already in use"),
+    );
+
+    await expect(
+      service.updateProfile(actorId, "NewName", "new@example.com"),
+    ).rejects.toThrow(ConflictError);
+
+    userRepository.updateProfile = originalUpdateProfile;
   });
 
   test("name=null, email=null の場合はメール重複チェックをスキップして更新する", async () => {

--- a/server/application/user/user-service.ts
+++ b/server/application/user/user-service.ts
@@ -4,7 +4,11 @@ import type { UserRepository } from "@/server/domain/models/user/user-repository
 import type { createAccessService } from "@/server/application/authz/access-service";
 import type { PasswordHasher } from "@/server/domain/common/password-hasher";
 import type { RateLimiter } from "@/server/domain/common/rate-limiter";
-import { BadRequestError, ForbiddenError } from "@/server/domain/common/errors";
+import {
+  BadRequestError,
+  ConflictError,
+  ForbiddenError,
+} from "@/server/domain/common/errors";
 import { USER_PASSWORD_MAX_LENGTH } from "@/server/domain/models/user/user";
 
 const MIN_PASSWORD_LENGTH = 8;
@@ -64,7 +68,7 @@ export const createUserService = (deps: UserServiceDeps) => ({
 
       const exists = await deps.userRepository.emailExists(email, actorId);
       if (exists) {
-        throw new BadRequestError("Email already in use");
+        throw new ConflictError("Email already in use");
       }
     }
 

--- a/server/infrastructure/repository/user/prisma-user-repository.test.ts
+++ b/server/infrastructure/repository/user/prisma-user-repository.test.ts
@@ -6,6 +6,7 @@ vi.mock("@/server/infrastructure/db", () => ({
       findUnique: vi.fn(),
       findMany: vi.fn(),
       upsert: vi.fn(),
+      update: vi.fn(),
       create: vi.fn(),
     },
   },
@@ -107,6 +108,48 @@ describe("Prisma User リポジトリ", () => {
       },
       create: data,
     });
+  });
+
+  test("updateProfile は P2002（email 一意制約違反）で ConflictError をスローする", async () => {
+    mockedPrisma.user.update.mockRejectedValueOnce(
+      new Prisma.PrismaClientKnownRequestError("Unique constraint failed", {
+        code: "P2002",
+        clientVersion: "0.0.0",
+        meta: { target: ["email"] },
+      }),
+    );
+
+    await expect(
+      prismaUserRepository.updateProfile(userId("user-1"), "Name", "dup@example.com"),
+    ).rejects.toThrow(ConflictError);
+  });
+
+  test("updateProfile は P2002 で target が期待と異なる場合そのまま再スローする", async () => {
+    const error = new Prisma.PrismaClientKnownRequestError(
+      "Unique constraint failed",
+      {
+        code: "P2002",
+        clientVersion: "0.0.0",
+        meta: { target: ["other_field"] },
+      },
+    );
+    mockedPrisma.user.update.mockRejectedValueOnce(error);
+
+    await expect(
+      prismaUserRepository.updateProfile(userId("user-1"), "Name", "dup@example.com"),
+    ).rejects.toThrow(error);
+  });
+
+  test("updateProfile は P2002 以外の Prisma エラーはそのまま伝播する", async () => {
+    const otherError = new Prisma.PrismaClientKnownRequestError(
+      "Foreign key constraint failed",
+      { code: "P2003", clientVersion: "0.0.0" },
+    );
+    mockedPrisma.user.update.mockRejectedValueOnce(otherError);
+
+    await expect(
+      prismaUserRepository.updateProfile(userId("user-1"), "Name", "dup@example.com"),
+    ).rejects.toThrow(otherError);
   });
 
   test("createUser は P2002（email 一意制約違反）で ConflictError をスローする", async () => {

--- a/server/infrastructure/repository/user/prisma-user-repository.ts
+++ b/server/infrastructure/repository/user/prisma-user-repository.ts
@@ -70,10 +70,24 @@ export const createPrismaUserRepository = (
     name: string | null,
     email: string | null,
   ): Promise<void> {
-    await client.user.update({
-      where: { id: toPersistenceId(id) },
-      data: { name, email },
-    });
+    try {
+      await client.user.update({
+        where: { id: toPersistenceId(id) },
+        data: { name, email },
+      });
+    } catch (error) {
+      if (
+        error instanceof Prisma.PrismaClientKnownRequestError &&
+        error.code === "P2002"
+      ) {
+        const target = error.meta?.target;
+        if (Array.isArray(target) && target.includes("email")) {
+          throw new ConflictError("Email already in use");
+        }
+        throw error;
+      }
+      throw error;
+    }
   },
 
   async emailExists(email: string, excludeUserId?: UserId): Promise<boolean> {


### PR DESCRIPTION
## Summary

- `updateProfile` のリポジトリ呼び出しで Prisma P2002（UNIQUE制約違反）をキャッチし、`ConflictError` に変換することで TOCTOU 競合条件に対処
- メール重複エラーを `BadRequestError`(400) → `ConflictError`(409) に統一し、HTTPセマンティクスを改善
- 楽観的チェック（`emailExists`）+ 悲観的キャッチ（P2002）の二層防御を実現

Closes #297

## Test plan

- [ ] `vitest run server/application/user/user-service.test.ts` — 22テスト全パス
- [ ] `vitest run server/infrastructure/repository/user/prisma-user-repository.test.ts` — 10テスト全パス
- [ ] P2002（email）→ ConflictError 変換を確認
- [ ] P2002（email以外）→ 元エラー再スローを確認
- [ ] P2002以外のPrismaエラー → そのまま伝播を確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)