### PR TITLE
docs: buildServiceContainer に @internal JSDoc コメントを追加する

### DIFF
--- a/server/presentation/trpc/context.ts
+++ b/server/presentation/trpc/context.ts
@@ -27,6 +27,7 @@ const changePasswordRateLimiter = createPrismaRateLimiter({
   category: "changePassword",
 });
 
+/** @internal テスト用エクスポート。プロダクションコードでは createContext() を使用すること */
 export const buildServiceContainer = (): ServiceContainer =>
   createServiceContainer({
     circleRepository: prismaCircleRepository,


### PR DESCRIPTION
## Summary

- `buildServiceContainer` にテスト用エクスポートであることを明示する `@internal` JSDoc コメントを追加
- プロダクションコードでは `createContext()` を使用すべきことをコメントで案内

Closes #840

## Test plan

- [x] `server/presentation/trpc/context.ts` の `buildServiceContainer` に `@internal` JSDoc が付与されていることを確認
- [ ] 既存テストが通ることを確認（CI）

🤖 Generated with [Claude Code](https://claude.com/claude-code)