### PR TITLE
refactor: signup route.ts を service container 経由に移行する (#609)

### DIFF
--- a/app/api/auth/signup/route.ts
+++ b/app/api/auth/signup/route.ts
@@ -1,15 +1,7 @@
 import { NextResponse } from "next/server";
-import { createSignupService } from "@/server/application/auth/signup-service";
-import { prismaUserRepository } from "@/server/infrastructure/repository/user/prisma-user-repository";
-import {
-  hashPassword,
-  verifyPassword,
-} from "@/server/infrastructure/auth/password";
+import { buildServiceContainer } from "@/server/presentation/trpc/context";
 
-const signupService = createSignupService({
-  userRepository: prismaUserRepository,
-  passwordHasher: { hash: hashPassword, verify: verifyPassword },
-});
+const { signupService } = buildServiceContainer();
 
 type SignupPayload = {
   email?: string;

--- a/server/presentation/trpc/context.ts
+++ b/server/presentation/trpc/context.ts
@@ -27,7 +27,7 @@ const changePasswordRateLimiter = createPrismaRateLimiter({
   category: "changePassword",
 });
 
-/** @internal テスト用エクスポート。プロダクションコードでは createContext() を使用すること */
+/** @internal テスト・プロダクション共用。tRPC 外の Route Handler 等から利用可 */
 export const buildServiceContainer = (): ServiceContainer =>
   createServiceContainer({
     circleRepository: prismaCircleRepository,


### PR DESCRIPTION
## Summary

- `app/api/auth/signup/route.ts` から `@/server/infrastructure/` への直接 import を除去
- `buildServiceContainer()` 経由で `signupService` を取得するよう変更
- `buildServiceContainer` の JSDoc を tRPC 外からの利用も許容する記述に更新

Closes #609

## Test plan

- [ ] 全テスト（96ファイル / 1077テスト）がパスすることを確認
- [ ] `app/api/auth/signup/route.ts` に `@/server/infrastructure/` への import がないことを確認
- [ ] signup エンドポイント（POST /api/auth/signup）が正常に動作することを確認

## Verify results

- safety: 問題なし（入力バリデーション・パスワードハッシュ・認証モデル変更なし）
- design: `buildServiceContainer` の配置場所は将来の課題（→ #861）
- implementation: 問題なし

## Follow-up issues

- #861: buildServiceContainer を tRPC context.ts から独立したファイルへ抽出する
- #862: signup エンドポイントのテストを追加する

🤖 Generated with [Claude Code](https://claude.com/claude-code)