### PR TITLE
test: signup POST ハンドラーのテストを追加する (#862)

### DIFF
--- a/app/api/auth/signup/route.test.ts
+++ b/app/api/auth/signup/route.test.ts
@@ -1,8 +1,8 @@
 import { beforeEach, describe, expect, test, vi } from "vitest";
-import { createServiceContainer } from "@/server/infrastructure/service-container";
 import { type UserId } from "@/server/domain/common/ids";
 import {
   createMockDeps,
+  createServiceContainer,
   toServiceContainerDeps,
 } from "@/server/presentation/providers/__tests__/helpers/create-mock-deps";
 

--- a/server/presentation/providers/__tests__/helpers/create-mock-deps.ts
+++ b/server/presentation/providers/__tests__/helpers/create-mock-deps.ts
@@ -114,3 +114,5 @@ export const createMockDeps = (): MockDeps => ({
 export const toServiceContainerDeps = (
   mockDeps: MockDeps,
 ): ServiceContainerDeps => mockDeps as unknown as ServiceContainerDeps;
+
+export { createServiceContainer } from "@/server/infrastructure/service-container";


### PR DESCRIPTION
## Summary

- `app/api/auth/signup/route.ts` に対するテストを追加
- リポジトリモック境界パターン（`createMockDeps` + `createServiceContainer`）でプロジェクト規約に準拠
- 正常系（201）、バリデーション失敗（400 x 4パターン）、重複メール（409）の計6テスト

Closes #862

## Test plan

- [ ] `npx vitest run app/api/auth/signup/route.test.ts` で6テスト全パスを確認
- [ ] モック戦略がリポジトリ層境界であることを確認（サービス層はモックしていない）
- [ ] テストケース名が振る舞いを日本語で明記していることを確認

## Related issues

- #864 signup エンドポイントにレート制限を追加する（verify で発見、別issue管理）
- #865 signup エンドポイントのエラーメッセージからユーザー列挙を防止する（verify で発見、別issue管理）

🤖 Generated with [Claude Code](https://claude.com/claude-code)