### PR TITLE
fix: signup エンドポイントのユーザー列挙攻撃を防止する

### DIFF
--- a/app/api/auth/signup/route.test.ts
+++ b/app/api/auth/signup/route.test.ts
@@ -81,11 +81,11 @@ describe("POST /api/auth/signup", () => {
     expect(body.message).toContain("パスワード");
   });
 
-  test("既存メールで409が返る", async () => {
+  test("既存メールで400と汎用メッセージが返る", async () => {
     mockDeps.userRepository.emailExists.mockResolvedValue(true);
     const res = await postJson(validBody);
-    expect(res.status).toBe(409);
+    expect(res.status).toBe(400);
     const body = await res.json();
-    expect(body.message).toContain("既に登録");
+    expect(body.message).toBe("アカウントの作成に失敗しました。");
   });
 });

--- a/app/api/auth/signup/route.ts
+++ b/app/api/auth/signup/route.ts
@@ -41,7 +41,7 @@ export async function POST(request: Request) {
       password_too_short: "パスワードは8文字以上で入力してください。",
       password_too_long: "パスワードは128文字以内で入力してください。",
       name_too_long: "表示名は50文字以内で入力してください。",
-      email_exists: "このメールアドレスは既に登録されています。",
+      signup_failed: "アカウントの作成に失敗しました。",
     };
     const statusCodes = {
       terms_not_agreed: 400,
@@ -49,7 +49,7 @@ export async function POST(request: Request) {
       password_too_short: 400,
       password_too_long: 400,
       name_too_long: 400,
-      email_exists: 409,
+      signup_failed: 400,
     };
     return NextResponse.json(
       { message: errorMessages[result.error] },

--- a/server/application/auth/signup-service.test.ts
+++ b/server/application/auth/signup-service.test.ts
@@ -31,7 +31,7 @@ const createDeps = (
 };
 
 describe("SignupService", () => {
-  test("createUser が ConflictError をスローした場合 email_exists を返す", async () => {
+  test("createUser が ConflictError をスローした場合 signup_failed を返す", async () => {
     const { deps } = createDeps();
     // createUser を差し替えてレースコンディション（emailExists通過後のConflictError）を再現
     deps.userRepository.createUser = async () => {
@@ -41,7 +41,7 @@ describe("SignupService", () => {
 
     const result = await service.signup(validInput);
 
-    expect(result).toEqual({ success: false, error: "email_exists" });
+    expect(result).toEqual({ success: false, error: "signup_failed" });
   });
 
   test("agreedToTerms が false の場合 terms_not_agreed を返す", async () => {

--- a/server/application/auth/signup-service.ts
+++ b/server/application/auth/signup-service.ts
@@ -31,7 +31,7 @@ export type SignupResult =
         | "password_too_short"
         | "password_too_long"
         | "name_too_long"
-        | "email_exists";
+        | "signup_failed";
     };
 
 export const createSignupService = (deps: SignupServiceDeps) => ({
@@ -62,7 +62,7 @@ export const createSignupService = (deps: SignupServiceDeps) => ({
 
     const exists = await deps.userRepository.emailExists(email);
     if (exists) {
-      return { success: false, error: "email_exists" };
+      return { success: false, error: "signup_failed" };
     }
 
     const passwordHash = deps.passwordHasher.hash(password);
@@ -77,7 +77,7 @@ export const createSignupService = (deps: SignupServiceDeps) => ({
       return { success: true, userId };
     } catch (error) {
       if (error instanceof ConflictError) {
-        return { success: false, error: "email_exists" };
+        return { success: false, error: "signup_failed" };
       }
       throw error;
     }


### PR DESCRIPTION
## Summary

- 重複メール時のエラーレスポンスを `409 + "既に登録されています"` → `400 + "アカウントの作成に失敗しました。"` に変更
- エラーコード `email_exists` → `signup_failed` に統一し、外部からメール登録有無を判別不能にする
- 関連テストのアサーションを更新

Closes #865

## Test plan

- [ ] `npm test -- server/application/auth/signup-service.test.ts` — 10 tests passed
- [ ] `npm test -- app/api/auth/signup/route.test.ts` — 6 tests passed
- [ ] 既存メールで signup → 400 + 汎用メッセージが返ること
- [ ] バリデーションエラーとの区別が外部から不能であること

## Remaining Limitations

- タイミングサイドチャネル（hash スキップ）は #867 で対応予定
- emailExists=true パスの単体テスト不足は #868 で対応予定

🤖 Generated with [Claude Code](https://claude.com/claude-code)