### PR TITLE
feat: signup エンドポイントに IP ベースのレート制限を追加する

### DIFF
--- a/app/api/auth/signup/route.test.ts
+++ b/app/api/auth/signup/route.test.ts
@@ -1,5 +1,6 @@
 import { beforeEach, describe, expect, test, vi } from "vitest";
 import { type UserId } from "@/server/domain/common/ids";
+import { TooManyRequestsError } from "@/server/domain/common/errors";
 import {
   createMockDeps,
   createServiceContainer,
@@ -8,9 +9,29 @@ import {
 
 const mockDeps = createMockDeps();
 
+const { mockCheck, mockRecordFailure } = vi.hoisted(() => ({
+  mockCheck: vi.fn(),
+  mockRecordFailure: vi.fn(),
+}));
+
 vi.mock("@/server/presentation/trpc/context", () => ({
   buildServiceContainer: () => {
     return createServiceContainer(toServiceContainerDeps(mockDeps));
+  },
+}));
+
+vi.mock("@/server/infrastructure/rate-limit/prisma-rate-limiter", () => ({
+  createPrismaRateLimiter: () => ({
+    check: mockCheck,
+    recordFailure: mockRecordFailure,
+  }),
+}));
+
+vi.mock("@/server/infrastructure/auth/auth-config", () => ({
+  SIGNUP_RATE_LIMIT_CONFIG: {
+    maxAttempts: 10,
+    windowMs: 60_000,
+    category: "signup",
   },
 }));
 
@@ -27,7 +48,10 @@ const postJson = (body: unknown) =>
   POST(
     new Request("http://localhost/api/auth/signup", {
       method: "POST",
-      headers: { "Content-Type": "application/json" },
+      headers: {
+        "Content-Type": "application/json",
+        "x-forwarded-for": "1.2.3.4",
+      },
       body: JSON.stringify(body),
     }),
   );
@@ -41,6 +65,8 @@ describe("POST /api/auth/signup", () => {
       "new-user-id" as UserId,
     );
     mockDeps.passwordHasher.hash.mockReturnValue("hashed");
+    mockCheck.mockResolvedValue(undefined);
+    mockRecordFailure.mockResolvedValue(undefined);
   });
 
   test("有効な入力でユーザーが作成される（201）", async () => {
@@ -53,7 +79,10 @@ describe("POST /api/auth/signup", () => {
     const res = await POST(
       new Request("http://localhost/api/auth/signup", {
         method: "POST",
-        headers: { "Content-Type": "application/json" },
+        headers: {
+          "Content-Type": "application/json",
+          "x-forwarded-for": "1.2.3.4",
+        },
         body: "not json",
       }),
     );
@@ -87,5 +116,20 @@ describe("POST /api/auth/signup", () => {
     expect(res.status).toBe(400);
     const body = await res.json();
     expect(body.message).toBe("アカウントの作成に失敗しました。");
+  });
+
+  test("レート制限超過時に429が返る", async () => {
+    mockCheck.mockRejectedValueOnce(new TooManyRequestsError(45_000));
+
+    const res = await postJson(validBody);
+    expect(res.status).toBe(429);
+    const body = await res.json();
+    expect(body.message).toContain("リクエストが多すぎます");
+    expect(mockCheck).toHaveBeenCalledWith("1.2.3.4");
+  });
+
+  test("正常リクエスト後にrecordFailureが呼ばれる", async () => {
+    await postJson(validBody);
+    expect(mockRecordFailure).toHaveBeenCalledWith("1.2.3.4");
   });
 });

--- a/app/api/auth/signup/route.ts
+++ b/app/api/auth/signup/route.ts
@@ -1,7 +1,12 @@
 import { NextResponse } from "next/server";
 import { buildServiceContainer } from "@/server/presentation/trpc/context";
+import { SIGNUP_RATE_LIMIT_CONFIG } from "@/server/infrastructure/auth/auth-config";
+import { TooManyRequestsError } from "@/server/domain/common/errors";
+import { getClientIp } from "@/server/infrastructure/http/client-ip";
+import { createPrismaRateLimiter } from "@/server/infrastructure/rate-limit/prisma-rate-limiter";
 
 const { signupService } = buildServiceContainer();
+const signupRateLimiter = createPrismaRateLimiter(SIGNUP_RATE_LIMIT_CONFIG);
 
 type SignupPayload = {
   email?: string;
@@ -11,6 +16,20 @@ type SignupPayload = {
 };
 
 export async function POST(request: Request) {
+  const clientIp = getClientIp(request);
+
+  try {
+    await signupRateLimiter.check(clientIp);
+  } catch (e) {
+    if (e instanceof TooManyRequestsError) {
+      return NextResponse.json(
+        { message: "リクエストが多すぎます。しばらくしてからお試しください。" },
+        { status: 429 },
+      );
+    }
+    throw e;
+  }
+
   const body = (await request.json().catch(() => null)) as SignupPayload | null;
   if (!body) {
     return NextResponse.json(
@@ -32,6 +51,8 @@ export async function POST(request: Request) {
     name,
     agreedToTerms,
   });
+
+  await signupRateLimiter.recordFailure(clientIp);
 
   if (!result.success) {
     const errorMessages = {

--- a/server/infrastructure/auth/auth-config.ts
+++ b/server/infrastructure/auth/auth-config.ts
@@ -6,3 +6,10 @@ export const LOGIN_RATE_LIMIT_CONFIG: Readonly<PrismaRateLimiterConfig> =
     windowMs: 60_000,
     category: "login",
   });
+
+export const SIGNUP_RATE_LIMIT_CONFIG: Readonly<PrismaRateLimiterConfig> =
+  Object.freeze({
+    maxAttempts: 10,
+    windowMs: 60_000,
+    category: "signup",
+  });


### PR DESCRIPTION
## Summary

- signup エンドポイント (`POST /api/auth/signup`) に IP ベースのレート制限を導入（同一 IP から 60 秒間に 10 リクエストまで）
- 既存の `PrismaRateLimiter` を再利用し、`SIGNUP_RATE_LIMIT_CONFIG` を `auth-config.ts` に追加
- テスト 2 件追加（429 レスポンス確認、recordFailure 呼び出し確認）

Closes #864

## Test plan

- [ ] `npx vitest run app/api/auth/signup/route.test.ts` で全 8 テストが合格
- [ ] ローカルで 11 回連続 POST → 11 回目で 429 が返ることを確認
- [ ] 429 レスポンスボディに「リクエストが多すぎます」が含まれることを確認

## Review points

- レート制限チェックはビジネスロジックの前に配置済み
- 429 レスポンスに内部情報（IP、残回数等）の漏洩なし
- `Retry-After` ヘッダーの追加は #870 でフォローアップ

🤖 Generated with [Claude Code](https://claude.com/claude-code)