### PR TITLE
fix: ログインエンドポイントのタイミングサイドチャネルを解消する

### DIFF
--- a/server/infrastructure/auth/nextauth-handler.test.ts
+++ b/server/infrastructure/auth/nextauth-handler.test.ts
@@ -22,6 +22,7 @@ vi.mock("next-auth/providers/credentials", () => ({
 }));
 vi.mock("next-auth/providers/google", () => ({ default: googleMock }));
 vi.mock("@/server/infrastructure/auth/password", () => ({
+  DUMMY_HASH: "scrypt$dummysalt$dummykey",
   verifyPassword: verifyPasswordMock,
 }));
 
@@ -518,6 +519,60 @@ describe("authorize コールバック（レート制限）", () => {
     expect(result).toBeNull();
     expect(mockRateLimiter.recordFailure).toHaveBeenCalledWith(
       "test@example.com:1.2.3.4",
+    );
+  });
+});
+
+describe("authorize コールバック（タイミングサイドチャネル防止）", () => {
+  const extractAuthorize = (
+    mockRepo: UserRepository,
+    mockRateLimiter: RateLimiter,
+  ) => {
+    credentialsMock.mockClear();
+    createAuthOptions({
+      userRepository: mockRepo,
+      loginRateLimiter: mockRateLimiter,
+      getClientIp: mockGetClientIp,
+    });
+    return credentialsMock.mock.calls[0][0].authorize as (
+      credentials: { email: string; password: string } | undefined,
+    ) => Promise<{ id: string; email: string } | null>;
+  };
+
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
+  test("ユーザー不存在時にダミーハッシュで verifyPassword を実行する", async () => {
+    const mockRepo = createMockUserRepository({
+      findByEmail: vi.fn().mockResolvedValue(null),
+    });
+    const mockRateLimiter = createMockRateLimiter();
+    const authorize = extractAuthorize(mockRepo, mockRateLimiter);
+
+    await authorize({ email: "unknown@example.com", password: "password" });
+
+    expect(verifyPasswordMock).toHaveBeenCalledWith(
+      "password",
+      "scrypt$dummysalt$dummykey",
+    );
+  });
+
+  test("パスワードハッシュ不存在時にダミーハッシュで verifyPassword を実行する", async () => {
+    const mockRepo = createMockUserRepository({
+      findByEmail: vi
+        .fn()
+        .mockResolvedValue({ id: "user-1", email: "test@example.com" }),
+      findPasswordHashById: vi.fn().mockResolvedValue(null),
+    });
+    const mockRateLimiter = createMockRateLimiter();
+    const authorize = extractAuthorize(mockRepo, mockRateLimiter);
+
+    await authorize({ email: "test@example.com", password: "password" });
+
+    expect(verifyPasswordMock).toHaveBeenCalledWith(
+      "password",
+      "scrypt$dummysalt$dummykey",
     );
   });
 });

--- a/server/infrastructure/auth/nextauth-handler.ts
+++ b/server/infrastructure/auth/nextauth-handler.ts
@@ -1,6 +1,9 @@
 // PrismaAdapter が NextAuth のアダプタ要件として prisma を直接必要とするため、この import のみリポジトリ抽象化の対象外
 import { prisma } from "@/server/infrastructure/db";
-import { verifyPassword } from "@/server/infrastructure/auth/password";
+import {
+  DUMMY_HASH,
+  verifyPassword,
+} from "@/server/infrastructure/auth/password";
 import { userId } from "@/server/domain/common/ids";
 import { USER_NAME_MAX_LENGTH } from "@/server/domain/models/user/user";
 import type { RateLimiter } from "@/server/domain/common/rate-limiter";
@@ -54,6 +57,7 @@ export const createAuthOptions = (deps: AuthDeps): AuthOptions => ({
 
         const user = await deps.userRepository.findByEmail(email);
         if (!user) {
+          verifyPassword(password, DUMMY_HASH);
           if (isDebug) {
             console.warn("[auth] credentials user not found", { email });
           }
@@ -64,6 +68,7 @@ export const createAuthOptions = (deps: AuthDeps): AuthOptions => ({
           user.id,
         );
         if (!passwordHash) {
+          verifyPassword(password, DUMMY_HASH);
           if (isDebug) {
             console.warn("[auth] credentials user missing password hash", {
               email,

--- a/server/infrastructure/auth/password.ts
+++ b/server/infrastructure/auth/password.ts
@@ -14,6 +14,8 @@ export const hashPassword = (password: string): string => {
   ].join("$");
 };
 
+export const DUMMY_HASH = hashPassword("dummy");
+
 export const verifyPassword = (
   password: string,
   hashedValue: string,


### PR DESCRIPTION
## Summary

- ユーザー不存在時・パスワードハッシュ不存在時に `verifyPassword(password, DUMMY_HASH)` を実行し、scrypt の処理時間を均一化
- `DUMMY_HASH` は `hashPassword("dummy")` でモジュールロード時に動的生成（scrypt パラメータが実ハッシュと常に同一）
- 新規テスト2件追加（既存27テスト全パス）

Closes #873

## Test plan

- [ ] `npx vitest run server/infrastructure/auth/nextauth-handler.test.ts` で全27テストがパスすること
- [ ] ユーザー不存在時にダミーハッシュで `verifyPassword` が実行されること（テストで検証済み）
- [ ] パスワードハッシュ不存在時にダミーハッシュで `verifyPassword` が実行されること（テストで検証済み）
- [ ] 正常ログイン・認証失敗の既存フローが壊れていないこと

🤖 Generated with [Claude Code](https://claude.com/claude-code)