### PR TITLE
refactor: RateLimiter の recordFailure を recordAttempt にリネーム

### DIFF
--- a/app/api/auth/signup/route.test.ts
+++ b/app/api/auth/signup/route.test.ts
@@ -23,7 +23,7 @@ vi.mock("@/server/presentation/trpc/context", () => ({
 vi.mock("@/server/infrastructure/rate-limit/prisma-rate-limiter", () => ({
   createPrismaRateLimiter: () => ({
     check: mockCheck,
-    recordFailure: mockRecordFailure,
+    recordAttempt: mockRecordFailure,
   }),
 }));
 
@@ -128,7 +128,7 @@ describe("POST /api/auth/signup", () => {
     expect(mockCheck).toHaveBeenCalledWith("1.2.3.4");
   });
 
-  test("正常リクエスト後にrecordFailureが呼ばれる", async () => {
+  test("正常リクエスト後にrecordAttemptが呼ばれる", async () => {
     await postJson(validBody);
     expect(mockRecordFailure).toHaveBeenCalledWith("1.2.3.4");
   });

--- a/app/api/auth/signup/route.ts
+++ b/app/api/auth/signup/route.ts
@@ -52,7 +52,7 @@ export async function POST(request: Request) {
     agreedToTerms,
   });
 
-  await signupRateLimiter.recordFailure(clientIp);
+  await signupRateLimiter.recordAttempt(clientIp);
 
   if (!result.success) {
     const errorMessages = {

--- a/server/application/user/user-service.test.ts
+++ b/server/application/user/user-service.test.ts
@@ -27,7 +27,7 @@ const passwordHasher: PasswordHasher = {
 
 const changePasswordRateLimiter: RateLimiter = {
   check: vi.fn(),
-  recordFailure: vi.fn(),
+  recordAttempt: vi.fn(),
   reset: vi.fn(),
 };
 
@@ -263,14 +263,14 @@ describe("changePassword", () => {
     expect(stored?.passwordHash).toBe("hashed:oldpass");
   });
 
-  test("パスワード不一致時に recordFailure が呼ばれる", async () => {
+  test("パスワード不一致時に recordAttempt が呼ばれる", async () => {
     addTestUser("hashed:correct");
 
     await expect(
       service.changePassword(actorId, { currentPassword: "wrong", newPassword: "newpass12", clientIp: "1.2.3.4" }),
     ).rejects.toThrow("Current password is incorrect");
 
-    expect(changePasswordRateLimiter.recordFailure).toHaveBeenCalledWith(
+    expect(changePasswordRateLimiter.recordAttempt).toHaveBeenCalledWith(
       `${actorId}:1.2.3.4`,
     );
   });

--- a/server/application/user/user-service.ts
+++ b/server/application/user/user-service.ts
@@ -95,7 +95,7 @@ export const createUserService = (deps: UserServiceDeps) => ({
 
     const valid = deps.passwordHasher.verify(currentPassword, passwordHash);
     if (!valid) {
-      await deps.changePasswordRateLimiter.recordFailure(rateLimitKey);
+      await deps.changePasswordRateLimiter.recordAttempt(rateLimitKey);
       throw new BadRequestError("Current password is incorrect");
     }
 

--- a/server/domain/common/rate-limiter.ts
+++ b/server/domain/common/rate-limiter.ts
@@ -1,8 +1,8 @@
 export type RateLimiter = {
   /** レート制限チェック。超過時は TooManyRequestsError をスロー */
   check(key: string): Promise<void>;
-  /** 失敗を記録 */
-  recordFailure(key: string): Promise<void>;
+  /** 試行を記録 */
+  recordAttempt(key: string): Promise<void>;
   /** カウンターをリセット（成功時） */
   reset(key: string): Promise<void>;
 };

--- a/server/infrastructure/auth/nextauth-handler.test.ts
+++ b/server/infrastructure/auth/nextauth-handler.test.ts
@@ -57,7 +57,7 @@ const createMockRateLimiter = (
   overrides: Partial<RateLimiter> = {},
 ): RateLimiter => ({
   check: vi.fn(),
-  recordFailure: vi.fn(),
+  recordAttempt: vi.fn(),
   reset: vi.fn(),
   ...overrides,
 });
@@ -424,7 +424,7 @@ describe("authorize コールバック（レート制限）", () => {
     expect(mockRepo.findByEmail).not.toHaveBeenCalled();
   });
 
-  test("ユーザーが見つからない場合は recordFailure を呼ぶ", async () => {
+  test("ユーザーが見つからない場合は recordAttempt を呼ぶ", async () => {
     const mockRepo = createMockUserRepository({
       findByEmail: vi.fn().mockResolvedValue(null),
     });
@@ -437,12 +437,12 @@ describe("authorize コールバック（レート制限）", () => {
     });
 
     expect(result).toBeNull();
-    expect(mockRateLimiter.recordFailure).toHaveBeenCalledWith(
+    expect(mockRateLimiter.recordAttempt).toHaveBeenCalledWith(
       "test@example.com:1.2.3.4",
     );
   });
 
-  test("パスワード不一致時は recordFailure を呼ぶ", async () => {
+  test("パスワード不一致時は recordAttempt を呼ぶ", async () => {
     const mockRepo = createMockUserRepository({
       findByEmail: vi
         .fn()
@@ -459,7 +459,7 @@ describe("authorize コールバック（レート制限）", () => {
     });
 
     expect(result).toBeNull();
-    expect(mockRateLimiter.recordFailure).toHaveBeenCalledWith(
+    expect(mockRateLimiter.recordAttempt).toHaveBeenCalledWith(
       "test@example.com:1.2.3.4",
     );
   });
@@ -490,7 +490,7 @@ describe("authorize コールバック（レート制限）", () => {
       image: undefined,
     });
     expect(mockRateLimiter.reset).toHaveBeenCalledWith("test@example.com:1.2.3.4");
-    expect(mockRateLimiter.recordFailure).not.toHaveBeenCalled();
+    expect(mockRateLimiter.recordAttempt).not.toHaveBeenCalled();
   });
 
   test("check() が TooManyRequestsError 以外をスローした場合はそのまま再スローする", async () => {
@@ -507,7 +507,7 @@ describe("authorize コールバック（レート制限）", () => {
     ).rejects.toThrow("unexpected failure");
   });
 
-  test("パスワードハッシュが無い場合は recordFailure を呼ぶ", async () => {
+  test("パスワードハッシュが無い場合は recordAttempt を呼ぶ", async () => {
     const mockRepo = createMockUserRepository({
       findByEmail: vi
         .fn()
@@ -523,7 +523,7 @@ describe("authorize コールバック（レート制限）", () => {
     });
 
     expect(result).toBeNull();
-    expect(mockRateLimiter.recordFailure).toHaveBeenCalledWith(
+    expect(mockRateLimiter.recordAttempt).toHaveBeenCalledWith(
       "test@example.com:1.2.3.4",
     );
   });
@@ -549,7 +549,7 @@ describe("authorize コールバック（レート制限）", () => {
     expect(mockRepo.findByEmail).not.toHaveBeenCalled();
   });
 
-  test("認証失敗時はIPのみのレート制限にも recordFailure を呼ぶ", async () => {
+  test("認証失敗時はIPのみのレート制限にも recordAttempt を呼ぶ", async () => {
     const mockRepo = createMockUserRepository({
       findByEmail: vi.fn().mockResolvedValue(null),
     });
@@ -562,8 +562,8 @@ describe("authorize コールバック（レート制限）", () => {
       password: "password",
     });
 
-    expect(mockIpRateLimiter.recordFailure).toHaveBeenCalledWith("1.2.3.4");
-    expect(mockRateLimiter.recordFailure).toHaveBeenCalledWith("test@example.com:1.2.3.4");
+    expect(mockIpRateLimiter.recordAttempt).toHaveBeenCalledWith("1.2.3.4");
+    expect(mockRateLimiter.recordAttempt).toHaveBeenCalledWith("test@example.com:1.2.3.4");
   });
 
   test("認証成功時はIPのみのレート制限にも reset を呼ぶ", async () => {

--- a/server/infrastructure/auth/nextauth-handler.ts
+++ b/server/infrastructure/auth/nextauth-handler.ts
@@ -64,8 +64,8 @@ export const createAuthOptions = (deps: AuthDeps): AuthOptions => ({
           if (isDebug) {
             console.warn("[auth] credentials user not found", { email });
           }
-          await deps.loginRateLimiter.recordFailure(rateLimitKey);
-          await deps.loginIpRateLimiter.recordFailure(clientIp);
+          await deps.loginRateLimiter.recordAttempt(rateLimitKey);
+          await deps.loginIpRateLimiter.recordAttempt(clientIp);
           return null;
         }
         const passwordHash = await deps.userRepository.findPasswordHashById(
@@ -78,16 +78,16 @@ export const createAuthOptions = (deps: AuthDeps): AuthOptions => ({
               email,
             });
           }
-          await deps.loginRateLimiter.recordFailure(rateLimitKey);
-          await deps.loginIpRateLimiter.recordFailure(clientIp);
+          await deps.loginRateLimiter.recordAttempt(rateLimitKey);
+          await deps.loginIpRateLimiter.recordAttempt(clientIp);
           return null;
         }
         if (!verifyPassword(password, passwordHash)) {
           if (isDebug) {
             console.warn("[auth] credentials password mismatch", { email });
           }
-          await deps.loginRateLimiter.recordFailure(rateLimitKey);
-          await deps.loginIpRateLimiter.recordFailure(clientIp);
+          await deps.loginRateLimiter.recordAttempt(rateLimitKey);
+          await deps.loginIpRateLimiter.recordAttempt(clientIp);
           return null;
         }
         await deps.loginRateLimiter.reset(rateLimitKey);

--- a/server/infrastructure/rate-limit/in-memory-rate-limiter.test.ts
+++ b/server/infrastructure/rate-limit/in-memory-rate-limiter.test.ts
@@ -15,24 +15,24 @@ describe("InMemoryRateLimiter", () => {
 
   test("制限内ならcheckはスローしない", async () => {
     const limiter = createInMemoryRateLimiter(config);
-    await limiter.recordFailure("key");
-    await limiter.recordFailure("key");
+    await limiter.recordAttempt("key");
+    await limiter.recordAttempt("key");
     await expect(limiter.check("key")).resolves.toBeUndefined();
   });
 
   test("maxAttempts到達でTooManyRequestsErrorをスロー", async () => {
     const limiter = createInMemoryRateLimiter(config);
-    await limiter.recordFailure("key");
-    await limiter.recordFailure("key");
-    await limiter.recordFailure("key");
+    await limiter.recordAttempt("key");
+    await limiter.recordAttempt("key");
+    await limiter.recordAttempt("key");
     await expect(limiter.check("key")).rejects.toThrow(TooManyRequestsError);
   });
 
   test("ウィンドウ経過後にカウンターがリセットされる", async () => {
     const limiter = createInMemoryRateLimiter(config);
-    await limiter.recordFailure("key");
-    await limiter.recordFailure("key");
-    await limiter.recordFailure("key");
+    await limiter.recordAttempt("key");
+    await limiter.recordAttempt("key");
+    await limiter.recordAttempt("key");
 
     vi.advanceTimersByTime(60_000);
 
@@ -41,9 +41,9 @@ describe("InMemoryRateLimiter", () => {
 
   test("resetでカウンターがクリアされる", async () => {
     const limiter = createInMemoryRateLimiter(config);
-    await limiter.recordFailure("key");
-    await limiter.recordFailure("key");
-    await limiter.recordFailure("key");
+    await limiter.recordAttempt("key");
+    await limiter.recordAttempt("key");
+    await limiter.recordAttempt("key");
 
     await limiter.reset("key");
 
@@ -52,11 +52,11 @@ describe("InMemoryRateLimiter", () => {
 
   test("TooManyRequestsErrorにretryAfterMsが含まれる", async () => {
     const limiter = createInMemoryRateLimiter(config);
-    await limiter.recordFailure("key");
+    await limiter.recordAttempt("key");
 
     vi.advanceTimersByTime(5_000); // 5秒経過
-    await limiter.recordFailure("key");
-    await limiter.recordFailure("key");
+    await limiter.recordAttempt("key");
+    await limiter.recordAttempt("key");
 
     try {
       await limiter.check("key");
@@ -72,9 +72,9 @@ describe("InMemoryRateLimiter", () => {
 
   test("キーごとに独立してカウントする", async () => {
     const limiter = createInMemoryRateLimiter(config);
-    await limiter.recordFailure("key-a");
-    await limiter.recordFailure("key-a");
-    await limiter.recordFailure("key-a");
+    await limiter.recordAttempt("key-a");
+    await limiter.recordAttempt("key-a");
+    await limiter.recordAttempt("key-a");
 
     await expect(limiter.check("key-a")).rejects.toThrow(TooManyRequestsError);
     await expect(limiter.check("key-b")).resolves.toBeUndefined();

--- a/server/infrastructure/rate-limit/in-memory-rate-limiter.ts
+++ b/server/infrastructure/rate-limit/in-memory-rate-limiter.ts
@@ -33,7 +33,7 @@ export const createInMemoryRateLimiter = (
       }
     },
 
-    async recordFailure(key) {
+    async recordAttempt(key) {
       const now = Date.now();
       const recent = prune(key, now);
       recent.push(now);

--- a/server/infrastructure/rate-limit/noop-rate-limiter.ts
+++ b/server/infrastructure/rate-limit/noop-rate-limiter.ts
@@ -6,6 +6,6 @@ import type { RateLimiter } from "@/server/domain/common/rate-limiter";
  */
 export const noopRateLimiter: RateLimiter = {
   async check() {},
-  async recordFailure() {},
+  async recordAttempt() {},
   async reset() {},
 };

--- a/server/infrastructure/rate-limit/prisma-rate-limiter.test.ts
+++ b/server/infrastructure/rate-limit/prisma-rate-limiter.test.ts
@@ -115,11 +115,11 @@ describe("PrismaRateLimiter", () => {
     vi.spyOn(Math, "random").mockRestore();
   });
 
-  test("recordFailureはレコードを作成する", async () => {
+  test("recordAttemptはレコードを作成する", async () => {
     mockedPrisma.rateLimitAttempt.create.mockResolvedValueOnce({} as never);
 
     const limiter = createPrismaRateLimiter(config);
-    await limiter.recordFailure("user-1");
+    await limiter.recordAttempt("user-1");
 
     expect(mockedPrisma.rateLimitAttempt.create).toHaveBeenCalledWith({
       data: {
@@ -166,7 +166,7 @@ describe("PrismaRateLimiter", () => {
       consoleErrorSpy.mockRestore();
     });
 
-    test("recordFailureはDBエラー時に例外をスローしない（fail-open）", async () => {
+    test("recordAttemptはDBエラー時に例外をスローしない（fail-open）", async () => {
       const consoleErrorSpy = vi
         .spyOn(console, "error")
         .mockImplementation(() => {});
@@ -175,10 +175,10 @@ describe("PrismaRateLimiter", () => {
       );
 
       const limiter = createPrismaRateLimiter(config);
-      await expect(limiter.recordFailure("user-1")).resolves.toBeUndefined();
+      await expect(limiter.recordAttempt("user-1")).resolves.toBeUndefined();
 
       expect(consoleErrorSpy).toHaveBeenCalledWith(
-        "[rate-limit] DB error during recordFailure:",
+        "[rate-limit] DB error during recordAttempt:",
         expect.any(Error),
       );
       consoleErrorSpy.mockRestore();

--- a/server/infrastructure/rate-limit/prisma-rate-limiter.ts
+++ b/server/infrastructure/rate-limit/prisma-rate-limiter.ts
@@ -70,7 +70,7 @@ export const createPrismaRateLimiter = (
       }
     },
 
-    async recordFailure(key) {
+    async recordAttempt(key) {
       try {
         await prisma.rateLimitAttempt.create({
           data: {
@@ -79,7 +79,7 @@ export const createPrismaRateLimiter = (
           },
         });
       } catch (error) {
-        console.error("[rate-limit] DB error during recordFailure:", error);
+        console.error("[rate-limit] DB error during recordAttempt:", error);
       }
     },
 

--- a/server/infrastructure/service-container.test.ts
+++ b/server/infrastructure/service-container.test.ts
@@ -32,7 +32,7 @@ describe("Service container", () => {
       passwordHasher: { hash: vi.fn(), verify: vi.fn() },
       changePasswordRateLimiter: {
         check: vi.fn(),
-        recordFailure: vi.fn(),
+        recordAttempt: vi.fn(),
         reset: vi.fn(),
       },
       holidayProvider: {

--- a/server/presentation/providers/__tests__/helpers/create-mock-deps.ts
+++ b/server/presentation/providers/__tests__/helpers/create-mock-deps.ts
@@ -102,7 +102,7 @@ export const createMockDeps = (): MockDeps => ({
   },
   changePasswordRateLimiter: {
     check: vi.fn().mockResolvedValue(undefined),
-    recordFailure: vi.fn().mockResolvedValue(undefined),
+    recordAttempt: vi.fn().mockResolvedValue(undefined),
     reset: vi.fn().mockResolvedValue(undefined),
   },
   holidayProvider: {

--- a/server/presentation/trpc/__tests__/context-wiring.test.ts
+++ b/server/presentation/trpc/__tests__/context-wiring.test.ts
@@ -56,7 +56,7 @@ vi.mock("@/server/infrastructure/holiday/japanese-holiday-provider", () => ({
 vi.mock("@/server/infrastructure/rate-limit/prisma-rate-limiter", () => ({
   createPrismaRateLimiter: vi.fn(() => ({
     check: vi.fn(),
-    recordFailure: vi.fn(),
+    recordAttempt: vi.fn(),
     reset: vi.fn(),
   })),
 }));


### PR DESCRIPTION
## Summary

- `RateLimiter` インターフェースの `recordFailure` を `recordAttempt` にリネーム
- 全実装（PrismaRateLimiter, InMemoryRateLimiter, NoopRateLimiter）を更新
- 呼び出し箇所（signup, login, changePassword）を更新
- 全テストファイルを更新

Closes #871

## Test plan

- [ ] `npx vitest run` で全テストがパスすることを確認
- [ ] `npx tsc --noEmit` で型エラーがないことを確認
- [ ] `recordFailure` がコードベースに残っていないことを grep で確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)