### PR TITLE
fix: sanitizeCallbackUrl のハードニング (#687)

### DIFF
--- a/lib/url.test.ts
+++ b/lib/url.test.ts
@@ -56,6 +56,14 @@ describe("sanitizeCallbackUrl", () => {
     expect(sanitizeCallbackUrl("/\r/evil.com")).toBe("/home");
   });
 
+  it("rejects path traversal", () => {
+    expect(sanitizeCallbackUrl("/../../../etc/passwd")).toBe("/home");
+  });
+
+  it("strips backslashes before validation", () => {
+    expect(sanitizeCallbackUrl("/\\evil.com")).toBe("/evil.com");
+  });
+
   describe("full URL handling", () => {
     const ORIGIN = "http://localhost:3000";
 

--- a/lib/url.ts
+++ b/lib/url.ts
@@ -2,10 +2,11 @@ const DEFAULT_CALLBACK = "/home";
 
 export function sanitizeCallbackUrl(url: string | undefined): string {
   if (!url) return DEFAULT_CALLBACK;
-  // Strip control characters that URL parsers silently remove (tab, newline, CR).
-  // Without this, "/\n/evil.com" passes the startsWith checks but resolves to "//evil.com".
-  const cleaned = url.replace(/[\t\n\r]/g, "");
-  if (cleaned.startsWith("/") && !cleaned.startsWith("//")) return cleaned;
+  // Strip control characters and backslashes that URL parsers may interpret differently.
+  // Without this, "/\n/evil.com" bypasses startsWith checks, and "/\evil.com" can be
+  // treated as a protocol-relative URL by some user agents.
+  const cleaned = url.replace(/[\t\n\r\\]/g, "");
+  if (cleaned.startsWith("/") && !cleaned.startsWith("//") && !cleaned.includes("/..")) return cleaned;
 
   // Handle full URLs: extract path from same-origin URLs (e.g. NextAuth result.url)
   try {
@@ -16,7 +17,7 @@ export function sanitizeCallbackUrl(url: string | undefined): string {
     ) {
       const path = parsed.pathname + parsed.search + parsed.hash;
       // Re-apply validation on extracted path
-      if (path.startsWith("/") && !path.startsWith("//")) return path;
+      if (path.startsWith("/") && !path.startsWith("//") && !path.includes("/..")) return path;
     }
   } catch {
     // Invalid URL — fall through to default


### PR DESCRIPTION
## Summary

- `sanitizeCallbackUrl` にパストラバーサル (`/../..`) とバックスラッシュ (`/\evil.com`) の拒否を追加
- 制御文字ストリップの正規表現にバックスラッシュを追加、`/..` を含むパスをデフォルトにフォールバック
- テストケース2件追加（計23件）

Closes #687

## Test plan

- [ ] `npx vitest run lib/url.test.ts` で全23テストがPASS
- [ ] パストラバーサル: `sanitizeCallbackUrl("/../../../etc/passwd")` → `"/home"`
- [ ] バックスラッシュ: `sanitizeCallbackUrl("/\\evil.com")` → `"/evil.com"`
- [ ] 既存テストのリグレッションなし

## Remaining limitations

- Percent-encoded path traversal (`/%2f..`) は文字列リテラルチェックではブロックされない（#881 で追跡）
- 実害なし: NextAuth same-origin enforcement + client-side routing による多層防御

🤖 Generated with [Claude Code](https://claude.com/claude-code)