### PR TITLE
fix: sanitizeCallbackUrl に percent-encoded パストラバーサル検出を追加

### DIFF
--- a/lib/url.test.ts
+++ b/lib/url.test.ts
@@ -108,6 +108,24 @@ describe("sanitizeCallbackUrl", () => {
     });
   });
 
+  describe("percent-encoded path traversal", () => {
+    it("rejects percent-encoded path traversal", () => {
+      expect(sanitizeCallbackUrl("/%2f..%2f..%2fetc%2fpasswd")).toBe("/home");
+    });
+
+    it("rejects percent-encoded path traversal with uppercase encoding", () => {
+      expect(sanitizeCallbackUrl("/%2F..")).toBe("/home");
+    });
+
+    it("rejects double-encoded path traversal", () => {
+      expect(sanitizeCallbackUrl("/%252f..")).toBe("/home");
+    });
+
+    it("rejects malformed percent-encoding", () => {
+      expect(sanitizeCallbackUrl("/%ZZ%invalid/..")).toBe("/home");
+    });
+  });
+
   describe("full URL handling on server (no window)", () => {
     it("falls back to /home for full URL when window is undefined", () => {
       expect(sanitizeCallbackUrl("http://localhost:3000/invite/abc")).toBe(

--- a/lib/url.ts
+++ b/lib/url.ts
@@ -1,12 +1,37 @@
 const DEFAULT_CALLBACK = "/home";
 
+/** Fully decode a URI string, handling double-encoding. Returns null on malformed input. */
+function fullyDecode(value: string): string | null {
+  const MAX_ITERATIONS = 10;
+  try {
+    let decoded = decodeURIComponent(value);
+    // Handle double-encoded sequences (e.g. %252f -> %2f -> /)
+    for (let i = 0; i < MAX_ITERATIONS; i++) {
+      const next = decodeURIComponent(decoded);
+      if (next === decoded) return decoded;
+      decoded = next;
+    }
+    return null;
+  } catch {
+    return null;
+  }
+}
+
+function hasPathTraversal(value: string): boolean {
+  return value.includes("/..");
+}
+
 export function sanitizeCallbackUrl(url: string | undefined): string {
   if (!url) return DEFAULT_CALLBACK;
   // Strip control characters and backslashes that URL parsers may interpret differently.
   // Without this, "/\n/evil.com" bypasses startsWith checks, and "/\evil.com" can be
   // treated as a protocol-relative URL by some user agents.
   const cleaned = url.replace(/[\t\n\r\\]/g, "");
-  if (cleaned.startsWith("/") && !cleaned.startsWith("//") && !cleaned.includes("/..")) return cleaned;
+  if (cleaned.startsWith("/") && !cleaned.startsWith("//") && !hasPathTraversal(cleaned)) {
+    const decoded = fullyDecode(cleaned);
+    if (decoded === null || hasPathTraversal(decoded)) return DEFAULT_CALLBACK;
+    return cleaned;
+  }
 
   // Handle full URLs: extract path from same-origin URLs (e.g. NextAuth result.url)
   try {
@@ -17,7 +42,11 @@ export function sanitizeCallbackUrl(url: string | undefined): string {
     ) {
       const path = parsed.pathname + parsed.search + parsed.hash;
       // Re-apply validation on extracted path
-      if (path.startsWith("/") && !path.startsWith("//") && !path.includes("/..")) return path;
+      if (path.startsWith("/") && !path.startsWith("//") && !hasPathTraversal(path)) {
+        const decoded = fullyDecode(path);
+        if (decoded === null || hasPathTraversal(decoded)) return DEFAULT_CALLBACK;
+        return path;
+      }
     }
   } catch {
     // Invalid URL — fall through to default


### PR DESCRIPTION
## Summary

- `sanitizeCallbackUrl` で percent-encoded パストラバーサル（`%2f..`, `%252f..` 等）を検出・拒否するよう強化
- `fullyDecode` ヘルパーで二重エンコードにも対応（最大10回反復デコード）
- malformed percent-encoding は安全側に倒してデフォルトURLへフォールバック

Closes #881

## Test plan

- [x] `npx vitest run lib/url.test.ts` で全27テスト合格（既存23 + 新規4）
- [ ] 既存のコールバックURL動作に影響がないことを確認
- [ ] CI パス確認

## Verification

新規テストケース:
- `/%2f..%2f..%2fetc%2fpasswd` → `/home`（拒否）
- `/%2F..` → `/home`（大文字エンコード拒否）
- `/%252f..` → `/home`（二重エンコード拒否）
- `/%ZZ%invalid/..` → `/home`（不正エンコード拒否）

🤖 Generated with [Claude Code](https://claude.com/claude-code)