### PR TITLE
feat: SessionCalendar の shadcn/ui デザインシステム統合

### DIFF
--- a/components/calendar/session-calendar.css
+++ b/components/calendar/session-calendar.css
@@ -1,0 +1,191 @@
+/*
+ * FullCalendar v6 style overrides for shadcn/ui design system integration.
+ * Uses CSS variables from globals.css (--background, --foreground, --border, etc.)
+ * and brand colors (--brand-moss, --brand-sky, --brand-holiday, etc.).
+ *
+ * Scoped under .session-calendar to avoid leaking into other components.
+ */
+
+/* ── Container ── */
+.session-calendar .fc {
+  --fc-border-color: var(--border);
+  --fc-page-bg-color: transparent;
+  --fc-neutral-bg-color: var(--muted);
+  --fc-today-bg-color: color-mix(in oklch, var(--brand-gold) 12%, transparent);
+  --fc-event-bg-color: var(--brand-moss);
+  --fc-event-border-color: var(--brand-moss);
+  --fc-event-text-color: white;
+
+  font-family: inherit;
+  font-size: 0.875rem;
+  border: 1px solid var(--border);
+  border-radius: var(--radius);
+  background: var(--card);
+  overflow: hidden;
+}
+
+/* ── Toolbar (month navigation) ── */
+.session-calendar .fc .fc-toolbar {
+  padding: 0.75rem 1rem;
+  margin-bottom: 0;
+  background: var(--muted);
+  border-bottom: 1px solid var(--border);
+}
+
+.session-calendar .fc .fc-toolbar-title {
+  font-size: 1rem;
+  font-weight: 600;
+  color: var(--foreground);
+}
+
+.session-calendar .fc .fc-button {
+  background: var(--background);
+  border: 1px solid var(--border);
+  color: var(--foreground);
+  border-radius: var(--radius);
+  padding: 0.25rem 0.5rem;
+  font-size: 0.875rem;
+  font-weight: 500;
+  box-shadow: none;
+  transition: background-color 0.15s, border-color 0.15s;
+}
+
+.session-calendar .fc .fc-button:hover {
+  background: var(--accent);
+  border-color: var(--border);
+}
+
+.session-calendar .fc .fc-button:active,
+.session-calendar .fc .fc-button.fc-button-active {
+  background: var(--accent);
+  border-color: var(--border);
+  box-shadow: none;
+}
+
+.session-calendar .fc .fc-button:focus-visible {
+  outline: 2px solid var(--ring);
+  outline-offset: 2px;
+  box-shadow: none;
+}
+
+.session-calendar .fc .fc-button:disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
+}
+
+/* ── Column header (weekday labels) ── */
+.session-calendar .fc .fc-col-header {
+  background: var(--muted);
+}
+
+.session-calendar .fc .fc-col-header-cell {
+  padding: 0.5rem 0;
+  font-weight: 500;
+  font-size: 0.75rem;
+  color: var(--muted-foreground);
+  border-color: var(--border);
+  text-transform: uppercase;
+}
+
+/* Saturday / Sunday / Holiday header colors */
+.session-calendar .fc .fc-day-sat.fc-col-header-cell {
+  color: var(--brand-sky);
+}
+
+.session-calendar .fc .fc-day-sun.fc-col-header-cell {
+  color: var(--brand-holiday);
+}
+
+/* ── Day cells ── */
+.session-calendar .fc .fc-daygrid-day {
+  border-color: var(--border);
+  transition: background-color 0.15s;
+}
+
+.session-calendar .fc .fc-daygrid-day-number {
+  padding: 0.25rem 0.5rem;
+  font-size: 0.8125rem;
+  color: var(--foreground);
+}
+
+/* Saturday / Sunday / Holiday day number colors */
+.session-calendar .fc .fc-day-sat .fc-daygrid-day-number {
+  color: var(--brand-sky);
+}
+
+.session-calendar .fc .fc-day-sun .fc-daygrid-day-number {
+  color: var(--brand-holiday);
+}
+
+.session-calendar .fc .fc-day-holiday .fc-daygrid-day-number {
+  color: var(--brand-holiday);
+}
+
+/* Today highlight */
+.session-calendar .fc .fc-day-today {
+  background: var(--fc-today-bg-color);
+}
+
+/* Other-month days */
+.session-calendar .fc .fc-day-other .fc-daygrid-day-number {
+  opacity: 0.4;
+}
+
+/* ── Clickable day cells ── */
+.session-calendar .fc .fc-day-clickable {
+  cursor: pointer;
+}
+
+.session-calendar .fc .fc-day-clickable:hover {
+  background: color-mix(in oklch, var(--brand-moss) 10%, transparent);
+}
+
+/* ── Focus ring for keyboard navigation ── */
+.session-calendar .fc .fc-daygrid-day:focus-visible {
+  outline: 2px solid var(--ring);
+  outline-offset: -2px;
+  z-index: 1;
+}
+
+/* ── Events ── */
+.session-calendar .fc .fc-event {
+  border-radius: calc(var(--radius) - 4px);
+  padding: 0.0625rem 0.375rem;
+  font-size: 0.75rem;
+  font-weight: 500;
+  line-height: 1.5;
+  border: none;
+  cursor: default;
+}
+
+.session-calendar .fc .fc-event:focus-visible {
+  outline: 2px solid var(--ring);
+  outline-offset: 1px;
+  box-shadow: none;
+}
+
+.session-calendar .fc .fc-daygrid-event-dot {
+  display: none;
+}
+
+/* ── Scrollbar inside day grid ── */
+.session-calendar .fc .fc-scroller {
+  overflow: hidden !important;
+}
+
+/* ── Remove default FullCalendar theme borders on table ── */
+.session-calendar .fc .fc-scrollgrid {
+  border: none;
+}
+
+.session-calendar .fc .fc-scrollgrid td:last-of-type {
+  border-right: none;
+}
+
+.session-calendar .fc .fc-scrollgrid-section > td {
+  border-bottom: none;
+}
+
+.session-calendar .fc tr:last-child td {
+  border-bottom: none;
+}

--- a/components/calendar/session-calendar.tsx
+++ b/components/calendar/session-calendar.tsx
@@ -17,6 +17,7 @@ import {
 } from "@/components/ui/tooltip";
 import { formatTooltipDateTime } from "@/lib/date-utils";
 import { trpc } from "@/lib/trpc/client";
+import "./session-calendar.css";
 
 const FC_PLUGINS = [dayGridPlugin, interactionPlugin];
 
@@ -280,7 +281,7 @@ export function SessionCalendar({
       ref={containerRef}
       role="region"
       aria-label="開催カレンダー"
-      className="[&_.fc-daygrid-day:focus-visible]:ring-2 [&_.fc-daygrid-day:focus-visible]:ring-ring [&_.fc-daygrid-day:focus-visible]:ring-offset-1 [&_.fc-daygrid-day:focus-visible]:outline-none [&_.fc-day-clickable]:cursor-pointer [&_.fc-day-clickable:hover]:bg-(--brand-moss)/10 [&_.fc-day-sat_.fc-daygrid-day-number]:text-(--brand-sky) [&_.fc-day-sat.fc-col-header-cell]:text-(--brand-sky) [&_.fc-day-sun_.fc-daygrid-day-number]:text-(--brand-holiday) [&_.fc-day-sun.fc-col-header-cell]:text-(--brand-holiday) [&_.fc-day-holiday_.fc-daygrid-day-number]:text-(--brand-holiday)"
+      className="session-calendar"
     >
       <FullCalendar
         plugins={FC_PLUGINS}


### PR DESCRIPTION
## Summary

Closes #74

- FullCalendar のインライン Tailwind クラスをスコープ付き CSS ファイル (`session-calendar.css`) に抽出
- shadcn/ui の CSS 変数（`--border`, `--muted`, `--foreground` 等）とブランドカラー（moss, gold, sky, holiday）でスタイルオーバーライドを実装
- ダークモードは CSS 変数経由で自動適用

## 変更ファイル

| ファイル | 変更内容 |
|---|---|
| `components/calendar/session-calendar.css` | 新規: FullCalendar スタイルオーバーライド（192行） |
| `components/calendar/session-calendar.tsx` | インラインクラスを `session-calendar` に置換、CSS import 追加 |

## 検証手順

1. `pnpm dev` で開発サーバーを起動
2. カレンダーが表示されるページを開く
3. 以下を確認:
   - [ ] コンテナ・ツールバー・ボタンが shadcn/ui テーマと一貫している
   - [ ] 土曜（sky）、日曜・祝日（holiday）の色分けが正しい
   - [ ] 今日の日付が gold でハイライトされている
   - [ ] ダークモード切替で正しく表示される
   - [ ] クリッカブル日セルのホバー・フォーカスが動作する

## レビューポイント

- CSS 変数の命名と shadcn/ui テーマ変数との整合性
- `color-mix(in oklch, ...)` のブラウザ対応（Can I Use: 96%+）

🤖 Generated with [Claude Code](https://claude.com/claude-code)