### PR TITLE
refactor: キーボード操作の view/jsEvent キャストを改善 (#149)

### DIFF
--- a/components/calendar/session-calendar-keyboard.test.tsx
+++ b/components/calendar/session-calendar-keyboard.test.tsx
@@ -262,16 +262,17 @@ describe("SessionCalendar keyboard navigation", () => {
       press(cells[10], "Enter");
 
       expect(onDateClick).toHaveBeenCalledOnce();
-      expect(onDateClick).toHaveBeenCalledWith(
-        expect.objectContaining({
-          dateStr: "2025-01-11",
-          allDay: true,
-        }),
-      );
+      const arg = onDateClick.mock.calls[0][0];
+      expect(arg.dateStr).toBe("2025-01-11");
+      expect(arg.allDay).toBe(true);
+      expect(arg.jsEvent).toBeInstanceOf(MouseEvent);
+      expect(arg.jsEvent.type).toBe("click");
+      expect(arg.jsEvent.clientX).toBe(0);
+      expect(arg.jsEvent.button).toBe(0);
     });
   });
 
-  it("Space triggers onDateClick", () => {
+  it("Space triggers onDateClick with valid jsEvent", () => {
     const onDateClick = vi.fn();
 
     document.body.innerHTML = "";
@@ -298,6 +299,9 @@ describe("SessionCalendar keyboard navigation", () => {
       press(cells[10], " ");
 
       expect(onDateClick).toHaveBeenCalledOnce();
+      const arg = onDateClick.mock.calls[0][0];
+      expect(arg.jsEvent).toBeInstanceOf(MouseEvent);
+      expect(arg.jsEvent.type).toBe("click");
     });
   });
 

--- a/components/calendar/session-calendar.tsx
+++ b/components/calendar/session-calendar.tsx
@@ -115,6 +115,7 @@ export function SessionCalendar({
   holidayDates,
 }: SessionCalendarProps) {
   const containerRef = useRef<HTMLDivElement>(null);
+  const calendarRef = useRef<FullCalendar>(null);
   const onDateClickRef = useRef(onDateClick);
   useEffect(() => {
     onDateClickRef.current = onDateClick;
@@ -255,8 +256,9 @@ export function SessionCalendar({
                   dateStr,
                   allDay: true,
                   dayEl: cell,
-                  jsEvent: e as unknown as MouseEvent,
-                  view: {} as DateClickArg["view"],
+                  jsEvent: new MouseEvent("click"),
+                  view: calendarRef.current?.getApi().view ??
+                    ({} as DateClickArg["view"]),
                 });
               }
               break;
@@ -284,6 +286,7 @@ export function SessionCalendar({
       className="session-calendar"
     >
       <FullCalendar
+        ref={calendarRef}
         plugins={FC_PLUGINS}
         initialView="dayGridMonth"
         locale="ja"


### PR DESCRIPTION
## Summary

Closes #149

- `jsEvent`: `KeyboardEvent` → `MouseEvent` の `as unknown as` 二重キャストを `new MouseEvent("click")` に置換。`clientX`, `button` 等が有効な値を持つようになった
- `view`: 空オブジェクトキャストの代わりに `calendarRef` 経由で実際の FullCalendar view を取得
- テストを更新し、`jsEvent` が有効な `MouseEvent` インスタンスであることを検証

## Remaining Limitations

- `calendarRef.current` が `null` の場合のフォールバック（空オブジェクト）は残存 → #885 で対応予定

## Follow-up Issues

- #885: view フォールバック（空オブジェクトキャスト）の除去
- #886: キーボードテストのセットアップコード重複解消

## Test plan

- [ ] `npx vitest run components/calendar/session-calendar-keyboard.test.tsx` — 全16テスト Pass
- [ ] カレンダー画面でキーボード操作（Enter/Space）による日付選択が正常動作
- [ ] マウスクリックによる日付選択が引き続き正常動作

🤖 Generated with [Claude Code](https://claude.com/claude-code)