### PR TITLE
refactor: キーボード操作時の view 空オブジェクトキャストを除去 (#885)

### DIFF
--- a/components/calendar/session-calendar-keyboard.test.tsx
+++ b/components/calendar/session-calendar-keyboard.test.tsx
@@ -6,14 +6,33 @@
  * mirrors the structure FullCalendar produces and re-import only the
  * component to exercise the keyboard-support effect.
  */
+import React from "react";
 import { cleanup, render } from "@testing-library/react";
 import type { DateClickArg } from "@fullcalendar/interaction";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 // ── Stub FullCalendar so the component can mount without the real library ──
 
+const mockView = {
+  type: "dayGridMonth",
+  title: "January 2025",
+  calendar: {},
+  currentStart: new Date("2025-01-01"),
+  currentEnd: new Date("2025-02-01"),
+  activeStart: new Date("2024-12-29"),
+  activeEnd: new Date("2025-02-02"),
+};
+
 vi.mock("@fullcalendar/react", () => ({
-  default: () => null,
+  default: React.forwardRef(function MockFullCalendar(
+    _props: Record<string, unknown>,
+    ref: React.Ref<unknown>,
+  ) {
+    React.useImperativeHandle(ref, () => ({
+      getApi: () => ({ view: mockView }),
+    }));
+    return null;
+  }),
 }));
 vi.mock("@fullcalendar/daygrid", () => ({ default: {} }));
 vi.mock("@fullcalendar/interaction", () => ({ default: {} }));
@@ -269,6 +288,7 @@ describe("SessionCalendar keyboard navigation", () => {
       expect(arg.jsEvent.type).toBe("click");
       expect(arg.jsEvent.clientX).toBe(0);
       expect(arg.jsEvent.button).toBe(0);
+      expect(arg.view).toHaveProperty("type", "dayGridMonth");
     });
   });
 
@@ -302,6 +322,7 @@ describe("SessionCalendar keyboard navigation", () => {
       const arg = onDateClick.mock.calls[0][0];
       expect(arg.jsEvent).toBeInstanceOf(MouseEvent);
       expect(arg.jsEvent.type).toBe("click");
+      expect(arg.view).toHaveProperty("type", "dayGridMonth");
     });
   });
 

--- a/components/calendar/session-calendar.tsx
+++ b/components/calendar/session-calendar.tsx
@@ -250,15 +250,15 @@ export function SessionCalendar({
             case " ": {
               e.preventDefault();
               const dateStr = cell.getAttribute("data-date");
-              if (dateStr && onDateClickRef.current) {
+              const view = calendarRef.current?.getApi().view;
+              if (dateStr && view && onDateClickRef.current) {
                 onDateClickRef.current({
                   date: new Date(dateStr),
                   dateStr,
                   allDay: true,
                   dayEl: cell,
                   jsEvent: new MouseEvent("click"),
-                  view: calendarRef.current?.getApi().view ??
-                    ({} as DateClickArg["view"]),
+                  view,
                 });
               }
               break;


### PR DESCRIPTION
## Summary

- `session-calendar.tsx`: キーボード操作（Enter/Space）時の `{} as DateClickArg["view"]` フォールバックを除去し、`calendarRef` から `view` が取得できない場合は早期リターンするよう変更
- `session-calendar-keyboard.test.tsx`: FullCalendar モックを `forwardRef` + `useImperativeHandle` パターンに改善し、`calendarRef.getApi().view` が有効な値を返すようにテストを強化

Closes #885

## Test plan

- [ ] `pnpm vitest components/calendar/session-calendar-keyboard.test.tsx` 全16テストパス
- [ ] カレンダー画面で Tab → Enter/Space による日付選択が正常動作

🤖 Generated with [Claude Code](https://claude.com/claude-code)