### PR TITLE
test: 論理削除の再参加シナリオのテストケースを追加

### DIFF
--- a/server/infrastructure/repository/authz/prisma-authz-repository.test.ts
+++ b/server/infrastructure/repository/authz/prisma-authz-repository.test.ts
@@ -125,4 +125,41 @@ describe("Prisma Authz リポジトリ", () => {
 
     expect(membership).toEqual({ kind: "none" });
   });
+
+  test("findCircleMembership は論理削除済みメンバーに none を返す", async () => {
+    // deletedAt: null 条件により論理削除済みレコードはヒットしない
+    mockedPrisma.circleMembership.findFirst.mockResolvedValueOnce(null);
+
+    const membership = await prismaAuthzRepository.findCircleMembership(
+      "user-1",
+      "circle-1",
+    );
+
+    expect(mockedPrisma.circleMembership.findFirst).toHaveBeenCalledWith({
+      where: { userId: "user-1", circleId: "circle-1", deletedAt: null },
+      select: { role: true },
+    });
+    expect(membership).toEqual({ kind: "none" });
+  });
+
+  test("findCircleSessionMembership は論理削除済みメンバーに none を返す", async () => {
+    mockedPrisma.circleSessionMembership.findFirst.mockResolvedValueOnce(null);
+
+    const membership = await prismaAuthzRepository.findCircleSessionMembership(
+      "user-1",
+      "session-1",
+    );
+
+    expect(mockedPrisma.circleSessionMembership.findFirst).toHaveBeenCalledWith(
+      {
+        where: {
+          userId: "user-1",
+          circleSessionId: "session-1",
+          deletedAt: null,
+        },
+        select: { role: true },
+      },
+    );
+    expect(membership).toEqual({ kind: "none" });
+  });
 });

--- a/server/infrastructure/repository/circle-session/prisma-circle-session-repository.test.ts
+++ b/server/infrastructure/repository/circle-session/prisma-circle-session-repository.test.ts
@@ -18,7 +18,7 @@ vi.mock("@/server/infrastructure/db", () => ({
 }));
 
 import type { CircleSession as PrismaCircleSession } from "@/generated/prisma/client";
-import { ConflictError } from "@/server/domain/common/errors";
+import { ConflictError, NotFoundError } from "@/server/domain/common/errors";
 import { circleId, circleSessionId, userId } from "@/server/domain/common/ids";
 import { createCircleSession } from "@/server/domain/models/circle-session/circle-session";
 import { prisma } from "@/server/infrastructure/db";
@@ -590,6 +590,108 @@ describe("Prisma CircleSession メンバーシップリポジトリ", () => {
         deletedAt,
       ),
     ).rejects.toThrow("CircleSessionMembership not found");
+  });
+
+  test("再参加後に listMembershipsByUserId がアクティブなメンバーシップのみ返す", async () => {
+    mockedPrisma.circleSessionMembership.findMany.mockResolvedValueOnce([
+      {
+        id: "membership-3",
+        userId: "user-1",
+        circleSessionId: "session-1",
+        role: "CircleSessionMember",
+        createdAt: new Date("2025-06-02T00:00:00Z"),
+        deletedAt: null,
+      },
+    ]);
+
+    const result = await prismaCircleSessionRepository.listMembershipsByUserId(
+      userId("user-1"),
+    );
+
+    expect(mockedPrisma.circleSessionMembership.findMany).toHaveBeenCalledWith({
+      where: { userId: "user-1", deletedAt: null },
+      select: {
+        circleSessionId: true,
+        userId: true,
+        role: true,
+        createdAt: true,
+        deletedAt: true,
+      },
+    });
+    expect(result).toEqual([
+      {
+        circleSessionId: circleSessionId("session-1"),
+        userId: userId("user-1"),
+        role: "CircleSessionMember",
+        createdAt: new Date("2025-06-02T00:00:00Z"),
+        deletedAt: null,
+      },
+    ]);
+  });
+
+  test("再参加時のロールが正しく設定される", async () => {
+    await prismaCircleSessionRepository.addMembership(
+      circleSessionId("session-1"),
+      userId("user-1"),
+      "CircleSessionMember",
+    );
+
+    expect(mockedPrisma.circleSessionMembership.create).toHaveBeenCalledWith({
+      data: {
+        circleSessionId: "session-1",
+        userId: "user-1",
+        role: "CircleSessionMember",
+      },
+    });
+  });
+
+  test("論理削除済みメンバーへの removeMembership が NotFoundError をスローする", async () => {
+    mockedPrisma.circleSessionMembership.updateMany.mockResolvedValueOnce({
+      count: 0,
+    });
+
+    await expect(
+      prismaCircleSessionRepository.removeMembership(
+        circleSessionId("session-1"),
+        userId("user-1"),
+        new Date("2025-07-01T00:00:00Z"),
+      ),
+    ).rejects.toThrow(NotFoundError);
+  });
+
+  test("論理削除済みメンバーの deletedAt が後続の removeMembership で上書きされない", async () => {
+    const firstDeletedAt = new Date("2025-06-01T00:00:00Z");
+    mockedPrisma.circleSessionMembership.updateMany.mockResolvedValueOnce({
+      count: 1,
+    });
+    await prismaCircleSessionRepository.removeMembership(
+      circleSessionId("session-1"),
+      userId("user-1"),
+      firstDeletedAt,
+    );
+
+    mockedPrisma.circleSessionMembership.updateMany.mockResolvedValueOnce({
+      count: 0,
+    });
+
+    await expect(
+      prismaCircleSessionRepository.removeMembership(
+        circleSessionId("session-1"),
+        userId("user-1"),
+        new Date("2025-07-01T00:00:00Z"),
+      ),
+    ).rejects.toThrow(NotFoundError);
+
+    expect(
+      mockedPrisma.circleSessionMembership.updateMany,
+    ).toHaveBeenLastCalledWith({
+      where: {
+        circleSessionId: "session-1",
+        userId: "user-1",
+        deletedAt: null,
+      },
+      data: { deletedAt: new Date("2025-07-01T00:00:00Z") },
+    });
   });
 
   test("removeMembership はメンバーシップを論理削除する", async () => {

--- a/server/infrastructure/repository/circle/prisma-circle-repository.test.ts
+++ b/server/infrastructure/repository/circle/prisma-circle-repository.test.ts
@@ -17,7 +17,7 @@ vi.mock("@/server/infrastructure/db", () => ({
 }));
 
 import type { Circle as PrismaCircle } from "@/generated/prisma/client";
-import { ConflictError } from "@/server/domain/common/errors";
+import { ConflictError, NotFoundError } from "@/server/domain/common/errors";
 import { circleId, userId } from "@/server/domain/common/ids";
 import { createCircle } from "@/server/domain/models/circle/circle";
 import { prisma } from "@/server/infrastructure/db";
@@ -418,6 +418,112 @@ describe("Prisma Circle メンバーシップリポジトリ", () => {
         deletedAt,
       ),
     ).rejects.toThrow("CircleMembership not found");
+  });
+
+  test("再参加後に listMembershipsByUserId がアクティブなメンバーシップのみ返す", async () => {
+    mockedPrisma.circleMembership.findMany.mockResolvedValueOnce([
+      {
+        id: "membership-3",
+        userId: "user-1",
+        circleId: "circle-1",
+        role: "CircleMember",
+        createdAt: new Date("2025-06-02T00:00:00Z"),
+        deletedAt: null,
+      },
+    ]);
+
+    const result = await prismaCircleRepository.listMembershipsByUserId(
+      userId("user-1"),
+    );
+
+    expect(mockedPrisma.circleMembership.findMany).toHaveBeenCalledWith({
+      where: { userId: "user-1", deletedAt: null },
+      orderBy: { createdAt: "desc" },
+      select: {
+        circleId: true,
+        userId: true,
+        role: true,
+        createdAt: true,
+        deletedAt: true,
+      },
+    });
+    expect(result).toEqual([
+      {
+        circleId: circleId("circle-1"),
+        userId: userId("user-1"),
+        role: "CircleMember",
+        createdAt: new Date("2025-06-02T00:00:00Z"),
+        deletedAt: null,
+      },
+    ]);
+  });
+
+  test("再参加時のロールが正しく設定される", async () => {
+    // 論理削除後に CircleMember ロールで再参加
+    await prismaCircleRepository.addMembership(
+      circleId("circle-1"),
+      userId("user-1"),
+      "CircleMember",
+    );
+
+    expect(mockedPrisma.circleMembership.create).toHaveBeenCalledWith({
+      data: {
+        circleId: "circle-1",
+        userId: "user-1",
+        role: "CircleMember",
+      },
+    });
+  });
+
+  test("論理削除済みメンバーへの removeMembership が NotFoundError をスローする", async () => {
+    // deletedAt: null のレコードが存在しないため count: 0
+    mockedPrisma.circleMembership.updateMany.mockResolvedValueOnce({
+      count: 0,
+    });
+
+    await expect(
+      prismaCircleRepository.removeMembership(
+        circleId("circle-1"),
+        userId("user-1"),
+        new Date("2025-07-01T00:00:00Z"),
+      ),
+    ).rejects.toThrow(NotFoundError);
+  });
+
+  test("論理削除済みメンバーの deletedAt が後続の removeMembership で上書きされない", async () => {
+    const firstDeletedAt = new Date("2025-06-01T00:00:00Z");
+    mockedPrisma.circleMembership.updateMany.mockResolvedValueOnce({
+      count: 1,
+    });
+    await prismaCircleRepository.removeMembership(
+      circleId("circle-1"),
+      userId("user-1"),
+      firstDeletedAt,
+    );
+
+    // 2回目の削除は deletedAt: null のレコードが存在しないため count: 0
+    mockedPrisma.circleMembership.updateMany.mockResolvedValueOnce({
+      count: 0,
+    });
+
+    await expect(
+      prismaCircleRepository.removeMembership(
+        circleId("circle-1"),
+        userId("user-1"),
+        new Date("2025-07-01T00:00:00Z"),
+      ),
+    ).rejects.toThrow(NotFoundError);
+
+    // updateMany は where: { deletedAt: null } で呼ばれるため、
+    // 既に論理削除済みのレコードの deletedAt は上書きされない
+    expect(mockedPrisma.circleMembership.updateMany).toHaveBeenLastCalledWith({
+      where: {
+        circleId: "circle-1",
+        userId: "user-1",
+        deletedAt: null,
+      },
+      data: { deletedAt: new Date("2025-07-01T00:00:00Z") },
+    });
   });
 
   test("removeMembership は研究会メンバーシップを論理削除する", async () => {


### PR DESCRIPTION
## Summary

Closes #423

- Circle / CircleSession メンバーシップの論理削除→再参加シナリオのエッジケーステストを追加
- Authz リポジトリで論理削除済みメンバーが `none` と判定されることを検証
- 既存テスト全56件 PASS を確認済み

## 変更ファイル

- `server/infrastructure/repository/authz/prisma-authz-repository.test.ts` (+37行)
- `server/infrastructure/repository/circle-session/prisma-circle-session-repository.test.ts` (+104行)
- `server/infrastructure/repository/circle/prisma-circle-repository.test.ts` (+108行)

## Test plan

- [ ] `npx vitest run server/infrastructure/repository/circle/prisma-circle-repository.test.ts` PASS
- [ ] `npx vitest run server/infrastructure/repository/circle-session/prisma-circle-session-repository.test.ts` PASS
- [ ] `npx vitest run server/infrastructure/repository/authz/prisma-authz-repository.test.ts` PASS

🤖 Generated with [Claude Code](https://claude.com/claude-code)