### PR TITLE
test: validateContactFormUrl のユニットテストを追加 (#838)

### DIFF
--- a/app/(authenticated)/help/page.tsx
+++ b/app/(authenticated)/help/page.tsx
@@ -1,3 +1,4 @@
+import { validateContactFormUrl } from "@/lib/url";
 import { ExternalLink } from "lucide-react";
 
 type PermissionRow = {
@@ -99,13 +100,9 @@ function renderPermissionCell(value: string, noteId?: string) {
   }
 }
 
-const GOOGLE_FORMS_URL_PATTERN = /^https:\/\/docs\.google\.com\/forms\//;
-
-const rawContactFormUrl = process.env.NEXT_PUBLIC_CONTACT_FORM_URL;
-const contactFormUrl =
-  rawContactFormUrl && GOOGLE_FORMS_URL_PATTERN.test(rawContactFormUrl)
-    ? rawContactFormUrl
-    : undefined;
+const contactFormUrl = validateContactFormUrl(
+  process.env.NEXT_PUBLIC_CONTACT_FORM_URL,
+);
 
 export default function HelpPage() {
   return (

--- a/lib/url.test.ts
+++ b/lib/url.test.ts
@@ -1,5 +1,5 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
-import { sanitizeCallbackUrl } from "./url";
+import { sanitizeCallbackUrl, validateContactFormUrl } from "./url";
 
 describe("sanitizeCallbackUrl", () => {
   it("returns /home for undefined", () => {
@@ -132,5 +132,49 @@ describe("sanitizeCallbackUrl", () => {
         "/home",
       );
     });
+  });
+});
+
+describe("validateContactFormUrl", () => {
+  it("正しい Google Forms URL はそのまま返す", () => {
+    expect(
+      validateContactFormUrl(
+        "https://docs.google.com/forms/d/e/xxx/viewform",
+      ),
+    ).toBe("https://docs.google.com/forms/d/e/xxx/viewform");
+  });
+
+  it("パスなしの Google Forms URL はそのまま返す", () => {
+    expect(
+      validateContactFormUrl("https://docs.google.com/forms/"),
+    ).toBe("https://docs.google.com/forms/");
+  });
+
+  it("サブパス付きの Google Forms URL はそのまま返す", () => {
+    expect(
+      validateContactFormUrl(
+        "https://docs.google.com/forms/d/e/1FAIpQLSfxxx/viewform?usp=sf_link",
+      ),
+    ).toBe(
+      "https://docs.google.com/forms/d/e/1FAIpQLSfxxx/viewform?usp=sf_link",
+    );
+  });
+
+  it("javascript: URI は undefined を返す", () => {
+    expect(validateContactFormUrl("javascript:alert(1)")).toBeUndefined();
+  });
+
+  it("異なるドメインの URL は undefined を返す", () => {
+    expect(
+      validateContactFormUrl("https://evil.com/forms/"),
+    ).toBeUndefined();
+  });
+
+  it("undefined は undefined を返す", () => {
+    expect(validateContactFormUrl(undefined)).toBeUndefined();
+  });
+
+  it("空文字は undefined を返す", () => {
+    expect(validateContactFormUrl("")).toBeUndefined();
   });
 });

--- a/lib/url.ts
+++ b/lib/url.ts
@@ -54,3 +54,11 @@ export function sanitizeCallbackUrl(url: string | undefined): string {
 
   return DEFAULT_CALLBACK;
 }
+
+const GOOGLE_FORMS_URL_PATTERN = /^https:\/\/docs\.google\.com\/forms\//;
+
+export function validateContactFormUrl(
+  raw: string | undefined,
+): string | undefined {
+  return raw && GOOGLE_FORMS_URL_PATTERN.test(raw) ? raw : undefined;
+}


### PR DESCRIPTION
## Summary

- `app/(authenticated)/help/page.tsx` にインラインで記述されていた Google Forms URL バリデーションロジックを `lib/url.ts` の `validateContactFormUrl` 関数として抽出
- 7つのテストケースで正常系・異常系を網羅的に検証（正しいURL、javascript: URI、異ドメイン、undefined、空文字）

## Test plan

- [x] `npx vitest run lib/url.test.ts` — 34テスト全件パス
- [ ] `NEXT_PUBLIC_CONTACT_FORM_URL` に正しい Google Forms URL を設定し、ヘルプページにリンクが表示されることを確認
- [ ] 環境変数を未設定・空文字・不正URLに変更し、リンクが非表示になることを確認

## Related

- Closes #838
- Follow-up: #891 (セキュリティエッジケースのテスト追加)

🤖 Generated with [Claude Code](https://claude.com/claude-code)