### PR TITLE
feat: email フィールドに .email() バリデーターを追加 (#553)

### DIFF
--- a/server/presentation/dto/user.test.ts
+++ b/server/presentation/dto/user.test.ts
@@ -38,4 +38,31 @@ describe("updateProfileInputSchema", () => {
 
     expect(result.success).toBe(false);
   });
+
+  test("不正な形式のメールアドレスはバリデーション失敗", () => {
+    const result = updateProfileInputSchema.safeParse({
+      name: "テスト",
+      email: "invalid-email",
+    });
+
+    expect(result.success).toBe(false);
+  });
+
+  test("メールアドレスがnullの場合はバリデーション成功", () => {
+    const result = updateProfileInputSchema.safeParse({
+      name: "テスト",
+      email: null,
+    });
+
+    expect(result.success).toBe(true);
+  });
+
+  test("空白のみのメールアドレスはバリデーション失敗", () => {
+    const result = updateProfileInputSchema.safeParse({
+      name: "テスト",
+      email: "   ",
+    });
+
+    expect(result.success).toBe(false);
+  });
 });

--- a/server/presentation/dto/user.ts
+++ b/server/presentation/dto/user.ts
@@ -50,7 +50,7 @@ export const updateProfileInputSchema = z.object({
       message: `名前は${String(USER_NAME_MAX_LENGTH)}文字以内で入力してください`,
     })
     .nullable(),
-  email: z.string().trim().min(1).max(USER_EMAIL_MAX_LENGTH).nullable(),
+  email: z.string().trim().min(1).email().max(USER_EMAIL_MAX_LENGTH).nullable(),
 });
 
 export type UpdateProfileInput = z.infer<typeof updateProfileInputSchema>;


### PR DESCRIPTION
## Summary

- `updateProfileInputSchema` の email フィールドに Zod の `.email()` バリデーターを追加し、メールアドレスの形式チェックを実施
- 不正形式・null・空白のみのケースをカバーするテストを追加

Closes #553

## Test plan

- [x] `npx vitest run server/presentation/dto/user.test.ts` — 全7テスト通過
- [ ] プロフィール編集画面で不正なメールアドレスを入力し、バリデーションエラーが表示されることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)