### PR TITLE
refactor: 開催回編集ダイアログにブラウザ標準バリデーションを適用

### DIFF
--- a/app/(authenticated)/circle-sessions/components/circle-session-edit-dialog.test.tsx
+++ b/app/(authenticated)/circle-sessions/components/circle-session-edit-dialog.test.tsx
@@ -159,7 +159,7 @@ describe("CircleSessionEditDialog", () => {
       expect(refreshMock).toHaveBeenCalled();
     });
 
-    it("タイトルが空白のみの場合、保存ボタンが無効になる", async () => {
+    it("タイトルが空白のみの場合、customValidity が設定される", async () => {
       const user = await openEditDialog();
 
       const dialog = await screen.findByRole("dialog");
@@ -167,10 +167,25 @@ describe("CircleSessionEditDialog", () => {
       await user.clear(titleInput);
       await user.type(titleInput, "   ");
 
-      const submitButton = within(dialog).getByRole("button", {
-        name: "保存",
-      });
-      expect(submitButton).toBeDisabled();
+      expect(
+        (titleInput as HTMLInputElement).validationMessage,
+      ).toBe("タイトルを入力してください");
+    });
+
+    it("空白のみから有効なタイトルに変更すると customValidity がクリアされる", async () => {
+      const user = await openEditDialog();
+
+      const dialog = await screen.findByRole("dialog");
+      const titleInput = within(dialog).getByLabelText("タイトル");
+      await user.clear(titleInput);
+      await user.type(titleInput, "   ");
+      expect(
+        (titleInput as HTMLInputElement).validationMessage,
+      ).toBe("タイトルを入力してください");
+
+      await user.clear(titleInput);
+      await user.type(titleInput, "テスト");
+      expect((titleInput as HTMLInputElement).validationMessage).toBe("");
     });
   });
 

--- a/app/(authenticated)/circle-sessions/components/circle-session-edit-dialog.tsx
+++ b/app/(authenticated)/circle-sessions/components/circle-session-edit-dialog.tsx
@@ -12,6 +12,7 @@ import {
 } from "@/components/ui/dialog";
 import { Input } from "@/components/ui/input";
 import { Textarea } from "@/components/ui/textarea";
+import { trimWithFullwidth } from "@/lib/string";
 import { trpc } from "@/lib/trpc/client";
 import {
   CIRCLE_SESSION_NOTE_MAX_LENGTH,
@@ -19,7 +20,7 @@ import {
 } from "@/server/domain/models/circle-session/circle-session";
 import { Pencil } from "lucide-react";
 import { useRouter } from "next/navigation";
-import type { FormEvent } from "react";
+import type { ChangeEvent, FormEvent } from "react";
 import { useState } from "react";
 
 type CircleSessionEditDialogProps = {
@@ -54,15 +55,22 @@ export function CircleSessionEditDialog({
     },
   });
 
-  const trimmedTitle = title.trim();
-  const canSubmit = trimmedTitle.length > 0 && !updateSession.isPending;
+  const handleTitleChange = (e: ChangeEvent<HTMLInputElement>) => {
+    const value = e.target.value;
+    setTitle(value);
+    e.target.setCustomValidity(
+      trimWithFullwidth(value) === ""
+        ? "タイトルを入力してください"
+        : "",
+    );
+  };
 
   const handleSubmit = (event: FormEvent<HTMLFormElement>) => {
     event.preventDefault();
-    if (!canSubmit) return;
+    if (updateSession.isPending) return;
     updateSession.mutate({
       circleSessionId,
-      title: trimmedTitle,
+      title: trimWithFullwidth(title),
       startsAt: new Date(startsAt),
       endsAt: new Date(endsAt),
       location: location.trim() || null,
@@ -115,9 +123,9 @@ export function CircleSessionEditDialog({
             <Input
               id="edit-title"
               value={title}
-              onChange={(e) => setTitle(e.target.value)}
+              onChange={handleTitleChange}
               maxLength={CIRCLE_SESSION_TITLE_MAX_LENGTH}
-              aria-required="true"
+              required
               className="bg-white"
             />
           </div>
@@ -135,7 +143,7 @@ export function CircleSessionEditDialog({
                 type="datetime-local"
                 value={startsAt}
                 onChange={(e) => setStartsAt(e.target.value)}
-                aria-required="true"
+                required
                 className="bg-white"
               />
             </div>
@@ -151,7 +159,7 @@ export function CircleSessionEditDialog({
                 type="datetime-local"
                 value={endsAt}
                 onChange={(e) => setEndsAt(e.target.value)}
-                aria-required="true"
+                required
                 className="bg-white"
               />
             </div>
@@ -208,7 +216,7 @@ export function CircleSessionEditDialog({
             <Button
               type="submit"
               className="bg-(--brand-moss) text-white hover:bg-(--brand-moss)/90"
-              disabled={!canSubmit}
+              disabled={updateSession.isPending}
             >
               {updateSession.isPending ? "保存中..." : "保存"}
             </Button>


### PR DESCRIPTION
## Summary

Closes #210

- `aria-required="true"` → `required` に移行し、ブラウザ標準バリデーションを活用
- `setCustomValidity` で全角スペースのみのタイトルをカスタムバリデーション
- `canSubmit` の手動チェックを削除し `disabled={isPending}` に簡素化
- `trimWithFullwidth` を使用して作成フォームとトリム処理を統一

## Test plan

- [ ] `npx vitest run app/\(authenticated\)/circle-sessions/components/circle-session-edit-dialog.test.tsx` — 全9テスト PASS
- [ ] 編集ダイアログでタイトルを空白のみにして保存 → バリデーションメッセージ表示
- [ ] 全角スペースのみ入力 → 「タイトルを入力してください」表示
- [ ] 有効なタイトルに変更 → バリデーションクリア、保存可能
- [ ] 開始/終了日時を空にして送信 → ブラウザ標準の必須バリデーション動作

🤖 Generated with [Claude Code](https://claude.com/claude-code)