### PR TITLE
refactor: 研究会作成ダイアログにブラウザ標準バリデーションを適用

### DIFF
--- a/app/components/circle-create-dialog.test.tsx
+++ b/app/components/circle-create-dialog.test.tsx
@@ -63,13 +63,11 @@ async function openDialog() {
 }
 
 describe("CircleCreateDialog", () => {
-  it("空入力で送信ボタンクリックしても mutate が呼ばれない", async () => {
-    const { user, dialog } = await openDialog();
+  it("研究会名の入力欄に required 属性が付与されている", async () => {
+    const { dialog } = await openDialog();
 
-    const submitButton = within(dialog).getByRole("button", { name: "作成" });
-    await user.click(submitButton);
-
-    expect(mutateSpyRef.current).not.toHaveBeenCalled();
+    const input = within(dialog).getByPlaceholderText("研究会名");
+    expect(input).toBeRequired();
   });
 
   it("有効な名前入力後に送信すると mutate が呼ばれる", async () => {
@@ -152,7 +150,7 @@ describe("CircleCreateDialog", () => {
     );
   });
 
-  it("空白のみの入力では送信ボタンクリックしても mutate が呼ばれない", async () => {
+  it("空白のみの入力では trim 後の空文字列で mutate が呼ばれる", async () => {
     const { user, dialog } = await openDialog();
 
     const input = within(dialog).getByPlaceholderText("研究会名");
@@ -161,7 +159,7 @@ describe("CircleCreateDialog", () => {
     const submitButton = within(dialog).getByRole("button", { name: "作成" });
     await user.click(submitButton);
 
-    expect(mutateSpyRef.current).not.toHaveBeenCalled();
+    expect(mutateSpyRef.current).toHaveBeenCalledWith({ name: "" });
   });
 
   it("前後の空白を除去して mutate が呼ばれる", async () => {

--- a/app/components/circle-create-dialog.tsx
+++ b/app/components/circle-create-dialog.tsx
@@ -34,9 +34,7 @@ export function CircleCreateDialog() {
   const handleSubmit = (event: FormEvent<HTMLFormElement>) => {
     event.preventDefault();
     const trimmed = name.trim();
-    if (!trimmed || createCircle.isPending) {
-      return;
-    }
+    if (createCircle.isPending) return;
     createCircle.mutate({ name: trimmed });
   };
 
@@ -91,7 +89,7 @@ export function CircleCreateDialog() {
             onChange={(event) => setName(event.target.value)}
             placeholder="研究会名"
             maxLength={CIRCLE_NAME_MAX_LENGTH}
-            aria-required="true"
+            required
             className="mt-2 bg-white"
           />
           <CharacterCounter


### PR DESCRIPTION
Closes #901

## Summary

- `aria-required="true"` を HTML 標準の `required` 属性に置き換え（暗黙的に `aria-required="true"` と同義）
- `handleSubmit` 内の `!trimmed` 空欄ガードを除去し、ブラウザ標準バリデーションとサーバー側バリデーションに委譲
- テストをブラウザ標準バリデーション方針に合わせて更新（全15テスト PASS）

## Test plan

- [ ] `npx vitest run app/components/circle-create-dialog.test.tsx` で全テスト PASS を確認
- [ ] ダイアログを開き、空のまま送信 → ブラウザ標準バリデーションポップアップが表示される
- [ ] 空白のみ入力して送信 → サーバーエラーが表示される
- [ ] 有効な名前で送信 → 研究会が作成され詳細ページに遷移する

## Notes

- verify で発見した既存課題（Zod スキーマに `.trim()` がない）は #903 として起票済み

🤖 Generated with [Claude Code](https://claude.com/claude-code)