### PR TITLE
test: CircleSessionCreateForm に required 属性テストを追加

### DIFF
--- a/app/(authenticated)/circles/[circleId]/sessions/new/circle-session-create-form.test.tsx
+++ b/app/(authenticated)/circles/[circleId]/sessions/new/circle-session-create-form.test.tsx
@@ -181,6 +181,14 @@ describe("CircleSessionCreateForm", () => {
     expect(screen.getByLabelText("終了日時")).toHaveValue("2025-08-20T18:00");
   });
 
+  it("タイトル・開始日時・終了日時に required 属性が付与されている", () => {
+    render(<CircleSessionCreateForm circleId={circleId} />);
+
+    expect(screen.getByLabelText("タイトル")).toBeRequired();
+    expect(screen.getByLabelText("開始日時")).toBeRequired();
+    expect(screen.getByLabelText("終了日時")).toBeRequired();
+  });
+
   it("空白のみのタイトルを入力すると customValidity が設定される", async () => {
     const user = userEvent.setup();
     render(<CircleSessionCreateForm circleId={circleId} />);


### PR DESCRIPTION
## Summary

- `CircleSessionCreateForm` にタイトル・開始日時・終了日時の `required` 属性テストを追加
- ブラウザ標準バリデーション移行（#898）の回帰防止

Closes #899

## Test plan

- [ ] `npx vitest run circle-session-create-form.test.tsx` で全14テストがパスすること

🤖 Generated with [Claude Code](https://claude.com/claude-code)