### PR TITLE
feat: セッション作成通知メールにセッション詳細リンクを追加

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -19,5 +19,9 @@ GOOGLE_CLIENT_SECRET="your-google-client-secret"
 # 省略時は NoopEmailSender にフォールバック（メール送信なし）
 # RESEND_API_KEY="re_xxxxxxxxxxxxx"
 
+# アプリケーションのベースURL（メール通知内のリンクに使用）
+# 省略時はメール本文にリンクが含まれない
+# BASE_URL="https://your-domain.com"
+
 # Vercel Cron Job 認証（Vercel環境変数で設定）
 # CRON_SECRET="your-cron-secret-here"

--- a/server/application/notification/notification-service.test.ts
+++ b/server/application/notification/notification-service.test.ts
@@ -115,4 +115,44 @@ describe("NotificationService", () => {
 
     expect(mockEmailSender.send).not.toHaveBeenCalled();
   });
+
+  test("BASE_URL が設定されている場合、メール本文にセッション詳細リンクが含まれる", async () => {
+    vi.stubEnv("BASE_URL", "https://example.com");
+
+    vi.mocked(mockCircleRepository.listMembershipsByCircleId).mockResolvedValue(
+      [makeMembership("user-1"), makeMembership("user-2")],
+    );
+    vi.mocked(mockUserRepository.findByIds).mockResolvedValue([
+      makeUser("user-2", "user2@example.com"),
+    ]);
+
+    await service.notifySessionCreated(session, circleName, actorId);
+
+    expect(mockEmailSender.send).toHaveBeenCalledWith(
+      expect.objectContaining({
+        body: expect.stringContaining(
+          "詳細はこちら: https://example.com/circle-sessions/session-1",
+        ),
+      }),
+    );
+  });
+
+  test("BASE_URL が未設定の場合、メール本文にリンクが含まれない", async () => {
+    vi.stubEnv("BASE_URL", "");
+
+    vi.mocked(mockCircleRepository.listMembershipsByCircleId).mockResolvedValue(
+      [makeMembership("user-1"), makeMembership("user-2")],
+    );
+    vi.mocked(mockUserRepository.findByIds).mockResolvedValue([
+      makeUser("user-2", "user2@example.com"),
+    ]);
+
+    await service.notifySessionCreated(session, circleName, actorId);
+
+    expect(mockEmailSender.send).toHaveBeenCalledWith(
+      expect.objectContaining({
+        body: expect.stringContaining("SKKT でご確認ください。"),
+      }),
+    );
+  });
 });

--- a/server/application/notification/notification-service.ts
+++ b/server/application/notification/notification-service.ts
@@ -57,6 +57,15 @@ export const createNotificationService = (deps: NotificationServiceDeps) => {
         ? `場所: ${session.location}\n`
         : "";
 
+      const baseUrl = process.env.BASE_URL;
+      const sessionUrl = baseUrl
+        ? `${baseUrl}/circle-sessions/${session.id}`
+        : null;
+
+      const footer = sessionUrl
+        ? `詳細はこちら: ${sessionUrl}`
+        : "SKKT でご確認ください。";
+
       const body = [
         `${circleName} に新しいセッションが作成されました。`,
         "",
@@ -64,7 +73,7 @@ export const createNotificationService = (deps: NotificationServiceDeps) => {
         `日時: ${startDate} ${startTime} - ${endTime}`,
         locationLine.trimEnd(),
         "",
-        "SKKT でご確認ください。",
+        footer,
       ]
         .filter((line) => line !== undefined)
         .join("\n");


### PR DESCRIPTION
## Summary

- `BASE_URL` 環境変数が設定されている場合、セッション作成通知メールにセッション詳細ページへのリンクを追加
- 未設定時は従来の「SKKT でご確認ください。」フォールバックを維持
- `.env.example` に `BASE_URL` の設定例を追加

Closes #908

## 変更ファイル

- `server/application/notification/notification-service.ts` — リンク生成ロジック追加
- `server/application/notification/notification-service.test.ts` — BASE_URL あり/なし両ケースのテスト追加
- `.env.example` — BASE_URL 設定例を追加

## Test plan

- [x] `npx vitest run server/application/notification/notification-service.test.ts` — 全6テスト PASS
- [ ] `BASE_URL` を設定してセッション作成 → メールにリンクが含まれることを確認
- [ ] `BASE_URL` 未設定でセッション作成 → 従来のメッセージが表示されることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)