### PR TITLE
feat: メール通知に waitUntil を適用してバックグラウンド送信を保証

### DIFF
--- a/server/application/circle-session/circle-session-service.ts
+++ b/server/application/circle-session/circle-session-service.ts
@@ -11,6 +11,7 @@ import type { CircleRepository } from "@/server/domain/models/circle/circle-repo
 import type { CircleSessionRepository } from "@/server/domain/models/circle-session/circle-session-repository";
 import type { createAccessService } from "@/server/application/authz/access-service";
 import type { createNotificationService } from "@/server/application/notification/notification-service";
+import type { BackgroundTaskRunner } from "@/server/domain/common/background-task";
 import type {
   Repositories,
   UnitOfWork,
@@ -30,12 +31,15 @@ export type CircleSessionServiceDeps = {
   circleSessionRepository: CircleSessionRepository;
   accessService: AccessService;
   notificationService?: NotificationService;
+  waitUntil?: BackgroundTaskRunner;
   unitOfWork?: UnitOfWork;
 };
 
 export const createCircleSessionService = (deps: CircleSessionServiceDeps) => {
   const uow: UnitOfWork =
     deps.unitOfWork ?? (async (op) => op(deps as unknown as Repositories));
+  const runInBackground: BackgroundTaskRunner =
+    deps.waitUntil ?? ((p) => { void p; });
 
   return {
     async createCircleSession(params: {
@@ -80,15 +84,19 @@ export const createCircleSessionService = (deps: CircleSessionServiceDeps) => {
         );
       });
 
-      void deps.notificationService
-        ?.notifySessionCreated(session, circle.name, params.actorId)
-        .catch((err) =>
-          console.error("Failed to send session notification:", {
-            sessionId: session.id,
-            circleId: session.circleId,
-            message: err instanceof Error ? err.message : "Unknown error",
-          }),
+      if (deps.notificationService) {
+        runInBackground(
+          deps.notificationService
+            .notifySessionCreated(session, circle.name, params.actorId)
+            .catch((err) =>
+              console.error("Failed to send session notification:", {
+                sessionId: session.id,
+                circleId: session.circleId,
+                message: err instanceof Error ? err.message : "Unknown error",
+              }),
+            ),
         );
+      }
 
       return session;
     },

--- a/server/domain/common/background-task.ts
+++ b/server/domain/common/background-task.ts
@@ -1,0 +1,1 @@
+export type BackgroundTaskRunner = (promise: Promise<unknown>) => void;

--- a/server/infrastructure/service-container.ts
+++ b/server/infrastructure/service-container.ts
@@ -22,6 +22,7 @@ import type { CircleInviteLinkRepository } from "@/server/domain/models/circle-i
 import type { PasswordHasher } from "@/server/domain/common/password-hasher";
 import type { HolidayProvider } from "@/server/domain/common/holiday-provider";
 import type { RoundRobinScheduleRepository } from "@/server/domain/models/round-robin-schedule/round-robin-schedule-repository";
+import type { BackgroundTaskRunner } from "@/server/domain/common/background-task";
 
 export type ServiceContainer = {
   circleService: ReturnType<typeof createCircleService>;
@@ -54,6 +55,7 @@ export type ServiceContainerDeps = {
   changePasswordRateLimiter: RateLimiter;
   holidayProvider: HolidayProvider;
   emailSender: EmailSender;
+  waitUntil?: BackgroundTaskRunner;
   unitOfWork?: UnitOfWork;
 };
 
@@ -85,6 +87,7 @@ export const createServiceContainer = (
       circleSessionRepository: deps.circleSessionRepository,
       accessService,
       notificationService,
+      waitUntil: deps.waitUntil,
       unitOfWork: deps.unitOfWork,
     }),
     circleSessionMembershipService: createCircleSessionMembershipService({

--- a/server/presentation/providers/__tests__/helpers/create-mock-deps.ts
+++ b/server/presentation/providers/__tests__/helpers/create-mock-deps.ts
@@ -11,6 +11,7 @@ import type { PasswordHasher } from "@/server/domain/common/password-hasher";
 import type { RateLimiter } from "@/server/domain/common/rate-limiter";
 import type { HolidayProvider } from "@/server/domain/common/holiday-provider";
 import type { EmailSender } from "@/server/domain/common/email-sender";
+import type { BackgroundTaskRunner } from "@/server/domain/common/background-task";
 import type { UserId } from "@/server/domain/common/ids";
 import type { Mock } from "vitest";
 
@@ -32,6 +33,7 @@ export type MockDeps = {
   changePasswordRateLimiter: Mocked<RateLimiter>;
   holidayProvider: Mocked<HolidayProvider>;
   emailSender: Mocked<EmailSender>;
+  waitUntil: BackgroundTaskRunner;
 };
 
 export const createMockDeps = (): MockDeps => ({
@@ -114,6 +116,7 @@ export const createMockDeps = (): MockDeps => ({
   emailSender: {
     send: vi.fn().mockResolvedValue(undefined),
   },
+  waitUntil: (p) => { void p; },
 });
 
 export const toServiceContainerDeps = (

--- a/server/presentation/trpc/context.ts
+++ b/server/presentation/trpc/context.ts
@@ -1,3 +1,4 @@
+import { after } from "next/server";
 import { createGetSession } from "@/server/application/auth/session";
 import { createServiceContainer } from "@/server/infrastructure/service-container";
 import type { ServiceContainer } from "@/server/infrastructure/service-container";
@@ -47,6 +48,7 @@ export const buildServiceContainer = (): ServiceContainer =>
     changePasswordRateLimiter,
     holidayProvider: japaneseHolidayProvider,
     emailSender,
+    waitUntil: (promise) => after(promise),
     unitOfWork: prismaUnitOfWork,
   });
 


### PR DESCRIPTION
## Summary

- Vercel serverless 環境でレスポンス送信後にメール通知の Promise が打ち切られる問題を解決
- `BackgroundTaskRunner` 型を domain 層に追加し、`next/server` の `after()` を DI 経由で接続
- `void` による fire-and-forget を `waitUntil` 経由のバックグラウンドタスク登録に変更

Closes #909

## Changed Files

| File | Change |
|------|--------|
| `server/domain/common/background-task.ts` | 新規: `BackgroundTaskRunner` 型定義 |
| `server/application/circle-session/circle-session-service.ts` | `waitUntil` 依存を注入し通知を登録 |
| `server/infrastructure/service-container.ts` | `waitUntil` を deps に追加 |
| `server/presentation/trpc/context.ts` | `after()` を `waitUntil` として接続 |
| `server/presentation/providers/__tests__/helpers/create-mock-deps.ts` | テスト用フォールバック追加 |

## Test plan

- [x] `circle-session-service.test.ts`: 16 tests passed
- [x] `context-wiring.test.ts`: 2 tests passed
- [x] Provider tests: 14 tests passed
- [x] TypeScript type check: passed
- [ ] デプロイ後、セッション作成でメール通知が確実に届くことを確認

## Follow-up

- #912: `waitUntil` フィールド名をドメイン語彙に変更する

🤖 Generated with [Claude Code](https://claude.com/claude-code)