### PR TITLE
refactor: waitUntil フィールド名を runInBackground に統一

### DIFF
--- a/server/application/circle-session/circle-session-service.ts
+++ b/server/application/circle-session/circle-session-service.ts
@@ -31,7 +31,7 @@ export type CircleSessionServiceDeps = {
   circleSessionRepository: CircleSessionRepository;
   accessService: AccessService;
   notificationService?: NotificationService;
-  waitUntil?: BackgroundTaskRunner;
+  runInBackground?: BackgroundTaskRunner;
   unitOfWork?: UnitOfWork;
 };
 
@@ -39,7 +39,7 @@ export const createCircleSessionService = (deps: CircleSessionServiceDeps) => {
   const uow: UnitOfWork =
     deps.unitOfWork ?? (async (op) => op(deps as unknown as Repositories));
   const runInBackground: BackgroundTaskRunner =
-    deps.waitUntil ?? ((p) => { void p; });
+    deps.runInBackground ?? ((p) => { void p; });
 
   return {
     async createCircleSession(params: {

--- a/server/infrastructure/service-container.ts
+++ b/server/infrastructure/service-container.ts
@@ -55,7 +55,7 @@ export type ServiceContainerDeps = {
   changePasswordRateLimiter: RateLimiter;
   holidayProvider: HolidayProvider;
   emailSender: EmailSender;
-  waitUntil?: BackgroundTaskRunner;
+  runInBackground?: BackgroundTaskRunner;
   unitOfWork?: UnitOfWork;
 };
 
@@ -87,7 +87,7 @@ export const createServiceContainer = (
       circleSessionRepository: deps.circleSessionRepository,
       accessService,
       notificationService,
-      waitUntil: deps.waitUntil,
+      runInBackground: deps.runInBackground,
       unitOfWork: deps.unitOfWork,
     }),
     circleSessionMembershipService: createCircleSessionMembershipService({

--- a/server/presentation/providers/__tests__/helpers/create-mock-deps.ts
+++ b/server/presentation/providers/__tests__/helpers/create-mock-deps.ts
@@ -33,7 +33,7 @@ export type MockDeps = {
   changePasswordRateLimiter: Mocked<RateLimiter>;
   holidayProvider: Mocked<HolidayProvider>;
   emailSender: Mocked<EmailSender>;
-  waitUntil: BackgroundTaskRunner;
+  runInBackground: BackgroundTaskRunner;
 };
 
 export const createMockDeps = (): MockDeps => ({
@@ -116,7 +116,7 @@ export const createMockDeps = (): MockDeps => ({
   emailSender: {
     send: vi.fn().mockResolvedValue(undefined),
   },
-  waitUntil: (p) => { void p; },
+  runInBackground: (p) => { void p; },
 });
 
 export const toServiceContainerDeps = (

--- a/server/presentation/trpc/context.ts
+++ b/server/presentation/trpc/context.ts
@@ -48,7 +48,7 @@ export const buildServiceContainer = (): ServiceContainer =>
     changePasswordRateLimiter,
     holidayProvider: japaneseHolidayProvider,
     emailSender,
-    waitUntil: (promise) => after(promise),
+    runInBackground: (promise) => after(promise),
     unitOfWork: prismaUnitOfWork,
   });
 


### PR DESCRIPTION
## Summary

- `waitUntil` フィールド名を `runInBackground` にリネームし、ドメイン層・アプリケーション層から Next.js 固有の語彙を除去

Closes #912

## Changed files

- `server/application/circle-session/circle-session-service.ts` — `CircleSessionServiceDeps.waitUntil` → `runInBackground`
- `server/infrastructure/service-container.ts` — `ServiceContainerDeps.waitUntil` → `runInBackground`
- `server/presentation/trpc/context.ts` — `buildServiceContainer` 内の呼び出し箇所
- `server/presentation/providers/__tests__/helpers/create-mock-deps.ts` — `MockDeps.waitUntil` → `runInBackground`

## Verification

- [ ] `npx tsc --noEmit` で型エラーなし
- [ ] 既存テストがパス（`vitest run`）
- [ ] grep で `waitUntil` が依存フィールド名として残っていないこと

🤖 Generated with [Claude Code](https://claude.com/claude-code)