### PR TITLE
refactor: 配信停止APIルートのクリーンアーキテクチャ準拠 (#918)

### DIFF
--- a/app/api/unsubscribe/route.ts
+++ b/app/api/unsubscribe/route.ts
@@ -1,11 +1,6 @@
 import { NextResponse } from "next/server";
-import { createUnsubscribeTokenService } from "@/server/domain/services/unsubscribe-token";
 import { buildServiceContainer } from "@/server/presentation/trpc/context";
-import { userId } from "@/server/domain/common/ids";
 
-const unsubscribeTokenService = createUnsubscribeTokenService(
-  process.env.UNSUBSCRIBE_SECRET || "default-unsubscribe-secret",
-);
 const { notificationPreferenceService } = buildServiceContainer();
 
 export async function GET(request: Request) {
@@ -19,18 +14,13 @@ export async function GET(request: Request) {
     );
   }
 
-  const extractedUserId = unsubscribeTokenService.verify(token);
-  if (!extractedUserId) {
+  const result = await notificationPreferenceService.disableByToken(token);
+  if (!result) {
     return NextResponse.json(
       { message: "無効なトークンです。" },
       { status: 400 },
     );
   }
-
-  await notificationPreferenceService.updatePreference(
-    userId(extractedUserId),
-    false,
-  );
 
   return NextResponse.json(
     { message: "メール配信を停止しました。" },

--- a/server/application/notification/notification-preference-service.ts
+++ b/server/application/notification/notification-preference-service.ts
@@ -1,9 +1,11 @@
-import type { UserId } from "@/server/domain/common/ids";
+import { userId, type UserId } from "@/server/domain/common/ids";
 import type { NotificationPreference } from "@/server/domain/models/notification-preference/notification-preference";
 import type { NotificationPreferenceRepository } from "@/server/domain/models/notification-preference/notification-preference-repository";
+import type { UnsubscribeTokenService } from "@/server/domain/services/unsubscribe-token";
 
 export type NotificationPreferenceServiceDeps = {
   notificationPreferenceRepository: NotificationPreferenceRepository;
+  unsubscribeTokenService: UnsubscribeTokenService;
 };
 
 export const createNotificationPreferenceService = (
@@ -23,6 +25,12 @@ export const createNotificationPreferenceService = (
       const pref: NotificationPreference = { userId, emailEnabled };
       await deps.notificationPreferenceRepository.save(pref);
       return pref;
+    },
+
+    async disableByToken(token: string): Promise<NotificationPreference | null> {
+      const extractedUserId = deps.unsubscribeTokenService.verify(token);
+      if (!extractedUserId) return null;
+      return this.updatePreference(userId(extractedUserId), false);
     },
   };
 };

--- a/server/infrastructure/service-container.ts
+++ b/server/infrastructure/service-container.ts
@@ -83,6 +83,7 @@ export const createServiceContainer = (
   });
   const notificationPreferenceService = createNotificationPreferenceService({
     notificationPreferenceRepository: deps.notificationPreferenceRepository,
+    unsubscribeTokenService: deps.unsubscribeTokenService,
   });
   return {
     circleService: createCircleService({


### PR DESCRIPTION
## Summary

- `NotificationPreferenceService` に `disableByToken(token: string)` メソッドを追加し、トークン検証と配信停止をサービス層で完結
- `app/api/unsubscribe/route.ts` から `createUnsubscribeTokenService` と `userId` の直接インポートを除去
- `UNSUBSCRIBE_SECRET` のアクセスをサービスコンテナ経由に統一

Closes #918

## Test plan

- [ ] `GET /api/unsubscribe?token=<valid>` で配信停止が正常に動作すること
- [ ] 無効なトークンで 400 エラーが返ること
- [ ] トークン未指定で 400 エラーが返ること

🤖 Generated with [Claude Code](https://claude.com/claude-code)