### PR TITLE
test: NotificationPreferenceService と配信停止APIルートのテストを追加

### DIFF
--- a/app/api/unsubscribe/route.test.ts
+++ b/app/api/unsubscribe/route.test.ts
@@ -1,0 +1,55 @@
+import { describe, test, expect, vi, beforeEach } from "vitest";
+
+const mockDisableByToken = vi.fn();
+
+vi.mock("@/server/presentation/trpc/context", () => ({
+  buildServiceContainer: () => ({
+    notificationPreferenceService: {
+      disableByToken: mockDisableByToken,
+    },
+  }),
+}));
+
+const { GET } = await import("@/app/api/unsubscribe/route");
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+describe("GET /api/unsubscribe", () => {
+  test("有効なトークンで配信停止成功", async () => {
+    mockDisableByToken.mockResolvedValue({
+      userId: "user-1",
+      emailEnabled: false,
+    });
+
+    const request = new Request("http://localhost/api/unsubscribe?token=valid-token");
+    const response = await GET(request);
+    const body = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(body.message).toBe("メール配信を停止しました。");
+    expect(mockDisableByToken).toHaveBeenCalledWith("valid-token");
+  });
+
+  test("無効なトークンで 400 エラー", async () => {
+    mockDisableByToken.mockResolvedValue(null);
+
+    const request = new Request("http://localhost/api/unsubscribe?token=invalid-token");
+    const response = await GET(request);
+    const body = await response.json();
+
+    expect(response.status).toBe(400);
+    expect(body.message).toBe("無効なトークンです。");
+  });
+
+  test("token パラメータ未指定で 400 エラー", async () => {
+    const request = new Request("http://localhost/api/unsubscribe");
+    const response = await GET(request);
+    const body = await response.json();
+
+    expect(response.status).toBe(400);
+    expect(body.message).toBe("トークンが指定されていません。");
+    expect(mockDisableByToken).not.toHaveBeenCalled();
+  });
+});

--- a/server/application/notification/notification-preference-service.test.ts
+++ b/server/application/notification/notification-preference-service.test.ts
@@ -1,0 +1,84 @@
+import { describe, test, expect, vi, beforeEach } from "vitest";
+import { createNotificationPreferenceService } from "@/server/application/notification/notification-preference-service";
+import { userId } from "@/server/domain/common/ids";
+import type { NotificationPreferenceRepository } from "@/server/domain/models/notification-preference/notification-preference-repository";
+import type { UnsubscribeTokenService } from "@/server/domain/services/unsubscribe-token";
+
+const mockNotificationPreferenceRepository = {
+  findByUserId: vi.fn(),
+  findByUserIds: vi.fn(),
+  save: vi.fn(),
+} as unknown as NotificationPreferenceRepository;
+
+const mockUnsubscribeTokenService: UnsubscribeTokenService = {
+  generate: vi.fn(),
+  verify: vi.fn(),
+};
+
+const service = createNotificationPreferenceService({
+  notificationPreferenceRepository: mockNotificationPreferenceRepository,
+  unsubscribeTokenService: mockUnsubscribeTokenService,
+});
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+describe("NotificationPreferenceService", () => {
+  describe("getPreference", () => {
+    test("レコード未存在時に emailEnabled: true のデフォルトを返す", async () => {
+      vi.mocked(mockNotificationPreferenceRepository.findByUserId).mockResolvedValue(null);
+
+      const result = await service.getPreference(userId("user-1"));
+
+      expect(result).toEqual({ userId: userId("user-1"), emailEnabled: true });
+    });
+
+    test("レコード存在時にそのまま返す", async () => {
+      const existing = { userId: userId("user-1"), emailEnabled: false };
+      vi.mocked(mockNotificationPreferenceRepository.findByUserId).mockResolvedValue(existing);
+
+      const result = await service.getPreference(userId("user-1"));
+
+      expect(result).toEqual({ userId: userId("user-1"), emailEnabled: false });
+    });
+  });
+
+  describe("updatePreference", () => {
+    test("リポジトリに保存し、保存した設定を返す", async () => {
+      vi.mocked(mockNotificationPreferenceRepository.save).mockResolvedValue(undefined);
+
+      const result = await service.updatePreference(userId("user-1"), false);
+
+      expect(mockNotificationPreferenceRepository.save).toHaveBeenCalledWith({
+        userId: userId("user-1"),
+        emailEnabled: false,
+      });
+      expect(result).toEqual({ userId: userId("user-1"), emailEnabled: false });
+    });
+  });
+
+  describe("disableByToken", () => {
+    test("有効なトークンの場合、emailEnabled: false で保存して返す", async () => {
+      vi.mocked(mockUnsubscribeTokenService.verify).mockReturnValue("user-1");
+      vi.mocked(mockNotificationPreferenceRepository.save).mockResolvedValue(undefined);
+
+      const result = await service.disableByToken("valid-token");
+
+      expect(result).toEqual({ userId: userId("user-1"), emailEnabled: false });
+      expect(mockNotificationPreferenceRepository.save).toHaveBeenCalledWith({
+        userId: userId("user-1"),
+        emailEnabled: false,
+      });
+    });
+
+    test("無効なトークンの場合、null を返す", async () => {
+      vi.mocked(mockUnsubscribeTokenService.verify).mockReturnValue(null);
+
+      const result = await service.disableByToken("invalid-token");
+
+      expect(result).toBeNull();
+      expect(mockNotificationPreferenceRepository.save).not.toHaveBeenCalled();
+    });
+  });
+});


### PR DESCRIPTION
## Summary

Closes #919

- `NotificationPreferenceService` のユニットテスト（5ケース）を追加
- `GET /api/unsubscribe` APIルートのテスト（3ケース）を追加

## Changes

| File | Description |
|------|-------------|
| `server/application/notification/notification-preference-service.test.ts` | getPreference (デフォルト/既存), updatePreference, disableByToken (有効/無効トークン) |
| `app/api/unsubscribe/route.test.ts` | 成功, 無効トークン400, トークン未指定400 |

## Test Plan

- [x] `npx vitest run server/application/notification/notification-preference-service.test.ts` -> 5 tests pass
- [x] `npx vitest run app/api/unsubscribe/route.test.ts` -> 3 tests pass

## Verification

```bash
npx vitest run server/application/notification/notification-preference-service.test.ts app/api/unsubscribe/route.test.ts
```

## Review Points

- サービス層テスト: リポジトリ層をモック境界としている（CLAUDE.mdガイドラインに準拠）
- APIルートテスト: `buildServiceContainer` をモジュールモック（route.tsのモジュールスコープ初期化の制約による実用的判断）
- レビューで検出した改善点は #926, #927, #928 として別issueで管理

🤖 Generated with [Claude Code](https://claude.com/claude-code)