### PR TITLE
fix: 配信停止APIルートにエラーハンドリングを追加

### DIFF
--- a/app/api/unsubscribe/route.test.ts
+++ b/app/api/unsubscribe/route.test.ts
@@ -1,4 +1,5 @@
 import { describe, test, expect, vi, beforeEach } from "vitest";
+import { BadRequestError } from "@/server/domain/common/errors";
 
 const mockDisableByToken = vi.fn();
 
@@ -51,5 +52,33 @@ describe("GET /api/unsubscribe", () => {
     expect(response.status).toBe(400);
     expect(body.message).toBe("トークンが指定されていません。");
     expect(mockDisableByToken).not.toHaveBeenCalled();
+  });
+
+  test("DomainError がスローされた場合、対応するHTTPステータスとメッセージを返す", async () => {
+    mockDisableByToken.mockRejectedValue(
+      new BadRequestError("トークンの形式が不正です。"),
+    );
+
+    const request = new Request(
+      "http://localhost/api/unsubscribe?token=malformed-token",
+    );
+    const response = await GET(request);
+    const body = await response.json();
+
+    expect(response.status).toBe(400);
+    expect(body.message).toBe("トークンの形式が不正です。");
+  });
+
+  test("未知のエラーがスローされた場合、500レスポンスと汎用メッセージを返す", async () => {
+    mockDisableByToken.mockRejectedValue(new Error("unexpected DB error"));
+
+    const request = new Request(
+      "http://localhost/api/unsubscribe?token=some-token",
+    );
+    const response = await GET(request);
+    const body = await response.json();
+
+    expect(response.status).toBe(500);
+    expect(body.message).toBe("Internal server error");
   });
 });

--- a/app/api/unsubscribe/route.ts
+++ b/app/api/unsubscribe/route.ts
@@ -1,7 +1,20 @@
 import { NextResponse } from "next/server";
 import { buildServiceContainer } from "@/server/presentation/trpc/context";
+import {
+  DomainError,
+  type DomainErrorCode,
+} from "@/server/domain/common/errors";
 
 const { notificationPreferenceService } = buildServiceContainer();
+
+const domainErrorToHttpStatus: Record<DomainErrorCode, number> = {
+  BAD_REQUEST: 400,
+  UNAUTHORIZED: 401,
+  FORBIDDEN: 403,
+  NOT_FOUND: 404,
+  CONFLICT: 409,
+  TOO_MANY_REQUESTS: 429,
+};
 
 export async function GET(request: Request) {
   const { searchParams } = new URL(request.url);
@@ -14,16 +27,31 @@ export async function GET(request: Request) {
     );
   }
 
-  const result = await notificationPreferenceService.disableByToken(token);
-  if (!result) {
+  try {
+    const result = await notificationPreferenceService.disableByToken(token);
+    if (!result) {
+      return NextResponse.json(
+        { message: "無効なトークンです。" },
+        { status: 400 },
+      );
+    }
+
     return NextResponse.json(
-      { message: "無効なトークンです。" },
-      { status: 400 },
+      { message: "メール配信を停止しました。" },
+      { headers: { "Cache-Control": "no-store" } },
+    );
+  } catch (error) {
+    if (error instanceof DomainError) {
+      return NextResponse.json(
+        { message: error.message },
+        { status: domainErrorToHttpStatus[error.code] },
+      );
+    }
+
+    console.error("Unhandled error in unsubscribe handler:", error);
+    return NextResponse.json(
+      { message: "Internal server error" },
+      { status: 500 },
     );
   }
-
-  return NextResponse.json(
-    { message: "メール配信を停止しました。" },
-    { headers: { "Cache-Control": "no-store" } },
-  );
 }


### PR DESCRIPTION
## Summary

- `app/api/unsubscribe/route.ts` の GET ハンドラーに try/catch を追加
- `DomainError` は `DomainErrorCode` に対応する HTTP ステータスコードにマッピング
- 未知のエラーは `console.error` でログ出力し、500 + 汎用メッセージを返す
- エラーケースのテスト2件を追加（DomainError / 未知のエラー）

Closes #927

## Test plan

- [x] `npx vitest run app/api/unsubscribe/route.test.ts` — 5テスト全てパス
- [ ] CI が通ることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)