### PR TITLE
fix: 配信停止APIルートに空白トークンのバリデーションを追加

### DIFF
--- a/app/api/unsubscribe/route.test.ts
+++ b/app/api/unsubscribe/route.test.ts
@@ -44,6 +44,16 @@ describe("GET /api/unsubscribe", () => {
     expect(body.message).toBe("無効なトークンです。");
   });
 
+  test("空白のみのトークンで 400 エラー", async () => {
+    const request = new Request("http://localhost/api/unsubscribe?token=%20%20");
+    const response = await GET(request);
+    const body = await response.json();
+
+    expect(response.status).toBe(400);
+    expect(body.message).toBe("トークンが指定されていません。");
+    expect(mockDisableByToken).not.toHaveBeenCalled();
+  });
+
   test("token パラメータ未指定で 400 エラー", async () => {
     const request = new Request("http://localhost/api/unsubscribe");
     const response = await GET(request);

--- a/app/api/unsubscribe/route.ts
+++ b/app/api/unsubscribe/route.ts
@@ -18,7 +18,7 @@ const domainErrorToHttpStatus: Record<DomainErrorCode, number> = {
 
 export async function GET(request: Request) {
   const { searchParams } = new URL(request.url);
-  const token = searchParams.get("token");
+  const token = searchParams.get("token")?.trim() || null;
 
   if (!token) {
     return NextResponse.json(


### PR DESCRIPTION
## Summary

- 空白のみのトークン（例: `?token=%20%20`）が入力バリデーションを通過していた問題を修正
- `searchParams.get("token")` の結果に `.trim() || null` を適用し、空白のみの値を早期に弾くように変更
- 対応するテストケースを追加

Closes #926

## Test plan

- [ ] `npx vitest run app/api/unsubscribe/route.test.ts` で全6テスト PASS を確認
- [ ] 空白トークン `?token=%20%20` で 400 エラーが返ることを確認
- [ ] 正常なトークンで配信停止が動作することを確認

## Verification

verify.md の結果:
- **safety**: 変更自体は安全。新たな脆弱性なし
- **implementation**: 最小限で正しい実装
- フォローアップ issue #931, #932 を作成済み

🤖 Generated with [Claude Code](https://claude.com/claude-code)