### PR TITLE
feat: メール通知オプトアウトのフロントエンドUI (#916)

### DIFF
--- a/app/(authenticated)/account/notification-form.tsx
+++ b/app/(authenticated)/account/notification-form.tsx
@@ -1,0 +1,50 @@
+"use client";
+
+import { Switch } from "@/components/ui/switch";
+import { trpc } from "@/lib/trpc/client";
+import { useState } from "react";
+import { toast } from "sonner";
+
+export function NotificationForm({
+  initialEmailEnabled,
+}: {
+  initialEmailEnabled: boolean;
+}) {
+  const utils = trpc.useUtils();
+  const [emailEnabled, setEmailEnabled] = useState(initialEmailEnabled);
+
+  const updatePreference = trpc.notificationPreferences.update.useMutation({
+    onSuccess: async () => {
+      toast.success("通知設定を更新しました");
+      await utils.notificationPreferences.get.invalidate();
+    },
+    onError: (error) => {
+      setEmailEnabled((prev) => !prev);
+      toast.error(error.message);
+    },
+  });
+
+  const handleToggle = (checked: boolean) => {
+    setEmailEnabled(checked);
+    updatePreference.mutate({ emailEnabled: checked });
+  };
+
+  return (
+    <div className="flex items-center justify-between gap-4">
+      <div className="flex flex-col gap-1">
+        <span className="text-sm font-medium text-(--brand-ink)">
+          メール通知を受け取る
+        </span>
+        <span className="text-xs text-(--brand-ink-muted)">
+          オフにすると、セッション案内などのメール通知が届かなくなります
+        </span>
+      </div>
+      <Switch
+        checked={emailEnabled}
+        onCheckedChange={handleToggle}
+        disabled={updatePreference.isPending}
+        aria-label="メール通知の設定"
+      />
+    </div>
+  );
+}

--- a/app/(authenticated)/account/page.tsx
+++ b/app/(authenticated)/account/page.tsx
@@ -1,3 +1,4 @@
+import { NotificationForm } from "@/app/(authenticated)/account/notification-form";
 import { PasswordForm } from "@/app/(authenticated)/account/password-form";
 import { ProfileFormInner } from "@/app/(authenticated)/account/profile-form";
 import { VisibilityForm } from "@/app/(authenticated)/account/visibility-form";
@@ -38,6 +39,19 @@ export default async function AccountPage() {
           プライバシー
         </h2>
         <VisibilityForm initialVisibility={viewModel.profileVisibility} />
+      </section>
+
+      <section
+        aria-labelledby="section-notification"
+        className="rounded-2xl border border-border/60 bg-white/85 p-6 shadow-sm"
+      >
+        <h2
+          id="section-notification"
+          className="mb-4 text-lg font-semibold text-(--brand-ink)"
+        >
+          通知
+        </h2>
+        <NotificationForm initialEmailEnabled={viewModel.emailEnabled} />
       </section>
 
       {viewModel.hasPassword && (

--- a/app/unsubscribe/page.tsx
+++ b/app/unsubscribe/page.tsx
@@ -1,0 +1,98 @@
+import Footer from "@/app/components/footer";
+import Link from "next/link";
+
+type UnsubscribePageProps = {
+  searchParams: Promise<{ token?: string }>;
+};
+
+type UnsubscribeResult =
+  | { status: "success" }
+  | { status: "error"; message: string };
+
+async function unsubscribe(token: string): Promise<UnsubscribeResult> {
+  const baseUrl = process.env.NEXTAUTH_URL ?? "http://localhost:3000";
+  const res = await fetch(
+    `${baseUrl}/api/unsubscribe?token=${encodeURIComponent(token)}`,
+    { cache: "no-store" },
+  );
+
+  if (res.ok) {
+    return { status: "success" };
+  }
+
+  const body = await res.json().catch(() => null);
+  return {
+    status: "error",
+    message: body?.message ?? "配信停止の処理中にエラーが発生しました。",
+  };
+}
+
+export default async function UnsubscribePage({
+  searchParams,
+}: UnsubscribePageProps) {
+  const { token } = await searchParams;
+
+  const result: UnsubscribeResult | null = token
+    ? await unsubscribe(token)
+    : null;
+
+  return (
+    <div className="flex min-h-svh flex-col">
+      <main className="flex flex-1 items-center justify-center px-4">
+        <div className="w-full max-w-md rounded-2xl border border-border/60 bg-white/85 p-8 shadow-sm">
+          {!token && (
+            <>
+              <h1 className="mb-4 text-xl font-bold text-(--brand-ink)">
+                配信停止
+              </h1>
+              <p className="text-sm text-(--brand-ink-muted)">
+                無効なリンクです。メールに記載されたリンクからアクセスしてください。
+              </p>
+            </>
+          )}
+
+          {result?.status === "success" && (
+            <>
+              <h1 className="mb-4 text-xl font-bold text-(--brand-ink)">
+                配信停止完了
+              </h1>
+              <p className="mb-6 text-sm text-(--brand-ink-muted)">
+                メール配信を停止しました。今後、通知メールは届きません。
+              </p>
+              <p className="text-sm text-(--brand-ink-muted)">
+                設定を変更したい場合は、
+                <Link
+                  href="/account"
+                  className="text-(--brand-moss) underline hover:opacity-80"
+                >
+                  ログインしてアカウント設定
+                </Link>
+                から変更できます。
+              </p>
+            </>
+          )}
+
+          {result?.status === "error" && (
+            <>
+              <h1 className="mb-4 text-xl font-bold text-(--brand-ink)">
+                配信停止
+              </h1>
+              <p className="mb-6 text-sm text-red-600">{result.message}</p>
+              <p className="text-sm text-(--brand-ink-muted)">
+                問題が解決しない場合は、
+                <Link
+                  href="/account"
+                  className="text-(--brand-moss) underline hover:opacity-80"
+                >
+                  ログインしてアカウント設定
+                </Link>
+                からメール通知を無効にしてください。
+              </p>
+            </>
+          )}
+        </div>
+      </main>
+      <Footer />
+    </div>
+  );
+}

--- a/server/presentation/providers/account-provider.ts
+++ b/server/presentation/providers/account-provider.ts
@@ -6,12 +6,16 @@ export async function getAccountViewModel(): Promise<AccountViewModel> {
   const ctx = await createContext();
   const caller = appRouter.createCaller(ctx);
 
-  const me = await caller.users.me();
+  const [me, notificationPref] = await Promise.all([
+    caller.users.me(),
+    caller.notificationPreferences.get(),
+  ]);
 
   return {
     name: me.name ?? "",
     email: me.email ?? "",
     hasPassword: me.hasPassword,
     profileVisibility: me.profileVisibility,
+    emailEnabled: notificationPref.emailEnabled,
   };
 }

--- a/server/presentation/view-models/account.ts
+++ b/server/presentation/view-models/account.ts
@@ -5,4 +5,5 @@ export type AccountViewModel = {
   email: string;
   hasPassword: boolean;
   profileVisibility: ProfileVisibilityDto;
+  emailEnabled: boolean;
 };


### PR DESCRIPTION
## Summary

Closes #916

- アカウント設定ページにメール通知ON/OFFトグル（`NotificationForm`）を追加
- 認証不要の配信停止ページ `/unsubscribe?token=xxx` を追加（トークンなし・無効トークン・成功の各状態を表示）
- `AccountViewModel` に `emailEnabled` フィールドを追加し、`account-provider` で通知設定を並列取得

依存: #915（バックエンド側の通知オプトアウト機能）

## Test plan

- [ ] ログイン → アカウント設定 → 通知セクションのSwitchをON/OFFし、トースト通知が表示され設定が保存されること
- [ ] `/unsubscribe` にアクセスし、「無効なリンクです」メッセージが表示されること
- [ ] `/unsubscribe?token=<valid>` にアクセスし、「配信停止完了」画面が表示されること
- [ ] `/unsubscribe?token=invalid` にアクセスし、エラーメッセージが表示されること
- [ ] 完了画面の「ログインしてアカウント設定」リンクが `/account` に遷移すること

## Known limitations

- 配信停止ページがServer Componentから自身のAPI routeにHTTP fetchしている（→ #935 で対応予定）

🤖 Generated with [Claude Code](https://claude.com/claude-code)