### PR TITLE
refactor: 配信停止ページでself-fetchを除去しサービス層を直接呼び出す

### DIFF
--- a/app/unsubscribe/page.tsx
+++ b/app/unsubscribe/page.tsx
@@ -1,4 +1,6 @@
 import Footer from "@/app/components/footer";
+import { buildServiceContainer } from "@/server/presentation/trpc/context";
+import { DomainError } from "@/server/domain/common/errors";
 import Link from "next/link";
 
 type UnsubscribePageProps = {
@@ -9,22 +11,34 @@ type UnsubscribeResult =
   | { status: "success" }
   | { status: "error"; message: string };
 
-async function unsubscribe(token: string): Promise<UnsubscribeResult> {
-  const baseUrl = process.env.NEXTAUTH_URL ?? "http://localhost:3000";
-  const res = await fetch(
-    `${baseUrl}/api/unsubscribe?token=${encodeURIComponent(token)}`,
-    { cache: "no-store" },
-  );
+const { notificationPreferenceService } = buildServiceContainer();
 
-  if (res.ok) {
-    return { status: "success" };
+async function unsubscribe(token: string): Promise<UnsubscribeResult> {
+  if (
+    !/^[A-Za-z0-9_-]+$/.test(token) ||
+    token.length < 20 ||
+    token.length > 256
+  ) {
+    return { status: "error", message: "無効なトークンです。" };
   }
 
-  const body = await res.json().catch(() => null);
-  return {
-    status: "error",
-    message: body?.message ?? "配信停止の処理中にエラーが発生しました。",
-  };
+  try {
+    const result =
+      await notificationPreferenceService.disableByToken(token);
+    if (!result) {
+      return { status: "error", message: "無効なトークンです。" };
+    }
+    return { status: "success" };
+  } catch (error) {
+    if (error instanceof DomainError) {
+      return { status: "error", message: error.message };
+    }
+    console.error("Unhandled error in unsubscribe page:", error);
+    return {
+      status: "error",
+      message: "配信停止の処理中にエラーが発生しました。",
+    };
+  }
 }
 
 export default async function UnsubscribePage({


### PR DESCRIPTION
## Summary

- 配信停止ページ (`app/unsubscribe/page.tsx`) のServer Componentで、自身のAPI routeへのHTTP self-fetchを `notificationPreferenceService.disableByToken()` の直接呼び出しに置換
- `NEXTAUTH_URL` 環境変数への依存を排除
- トークンバリデーション（フォーマット・長さチェック）をページ側にも追加

Closes #935

## Verification steps

1. `npx tsc --noEmit` で型エラーなしを確認
2. `/unsubscribe` にトークンなしでアクセス → 「無効なリンクです」メッセージ
3. `/unsubscribe?token=abc` → 「無効なトークンです」エラー
4. `/unsubscribe?token=<script>alert(1)</script>` → 「無効なトークンです」エラー
5. 有効トークンでアクセス → 「配信停止完了」メッセージ
6. API route (`/api/unsubscribe`) は `List-Unsubscribe` ヘッダー用に引き続き動作

## Review points

- トークンバリデーションがAPI routeと重複（→ #937 で共有関数に抽出予定）
- `DomainError.message` の直接転送（→ #938 で修正予定）
- ページのテストカバレッジ（→ #939 で追加予定）

🤖 Generated with [Claude Code](https://claude.com/claude-code)