### PR TITLE
refactor: 配信停止トークンバリデーションを共有関数に抽出 (#937)

### DIFF
--- a/app/api/unsubscribe/route.ts
+++ b/app/api/unsubscribe/route.ts
@@ -4,6 +4,7 @@ import {
   DomainError,
   type DomainErrorCode,
 } from "@/server/domain/common/errors";
+import { isValidUnsubscribeToken } from "@/server/domain/common/token-validation";
 
 const { notificationPreferenceService } = buildServiceContainer();
 
@@ -27,7 +28,7 @@ export async function GET(request: Request) {
     );
   }
 
-  if (!/^[A-Za-z0-9_-]+$/.test(token) || token.length < 20 || token.length > 256) {
+  if (!isValidUnsubscribeToken(token)) {
     return NextResponse.json(
       { message: "無効なトークンです。" },
       { status: 400 },

--- a/app/unsubscribe/page.tsx
+++ b/app/unsubscribe/page.tsx
@@ -1,6 +1,7 @@
 import Footer from "@/app/components/footer";
 import { buildServiceContainer } from "@/server/presentation/trpc/context";
 import { DomainError } from "@/server/domain/common/errors";
+import { isValidUnsubscribeToken } from "@/server/domain/common/token-validation";
 import Link from "next/link";
 
 type UnsubscribePageProps = {
@@ -14,11 +15,7 @@ type UnsubscribeResult =
 const { notificationPreferenceService } = buildServiceContainer();
 
 async function unsubscribe(token: string): Promise<UnsubscribeResult> {
-  if (
-    !/^[A-Za-z0-9_-]+$/.test(token) ||
-    token.length < 20 ||
-    token.length > 256
-  ) {
+  if (!isValidUnsubscribeToken(token)) {
     return { status: "error", message: "無効なトークンです。" };
   }
 

--- a/server/domain/common/token-validation.test.ts
+++ b/server/domain/common/token-validation.test.ts
@@ -1,0 +1,28 @@
+import { describe, expect, it } from "vitest";
+import { isValidUnsubscribeToken } from "./token-validation";
+
+describe("isValidUnsubscribeToken", () => {
+  it("有効なトークンを受け入れる", () => {
+    expect(isValidUnsubscribeToken("a".repeat(20))).toBe(true);
+    expect(isValidUnsubscribeToken("a".repeat(256))).toBe(true);
+    expect(isValidUnsubscribeToken("ABCdef012_-abcdefghij")).toBe(true);
+  });
+
+  it("空文字を拒否する", () => {
+    expect(isValidUnsubscribeToken("")).toBe(false);
+  });
+
+  it("短すぎるトークンを拒否する", () => {
+    expect(isValidUnsubscribeToken("a".repeat(19))).toBe(false);
+  });
+
+  it("長すぎるトークンを拒否する", () => {
+    expect(isValidUnsubscribeToken("a".repeat(257))).toBe(false);
+  });
+
+  it("許可されていない文字を含むトークンを拒否する", () => {
+    expect(isValidUnsubscribeToken("a".repeat(19) + "!")).toBe(false);
+    expect(isValidUnsubscribeToken("a".repeat(19) + " ")).toBe(false);
+    expect(isValidUnsubscribeToken("a".repeat(19) + ".")).toBe(false);
+  });
+});

--- a/server/domain/common/token-validation.ts
+++ b/server/domain/common/token-validation.ts
@@ -1,0 +1,8 @@
+const UNSUBSCRIBE_TOKEN_PATTERN = /^[A-Za-z0-9_-]+$/;
+const UNSUBSCRIBE_TOKEN_MIN_LENGTH = 20;
+const UNSUBSCRIBE_TOKEN_MAX_LENGTH = 256;
+
+export const isValidUnsubscribeToken = (token: string): boolean =>
+  UNSUBSCRIBE_TOKEN_PATTERN.test(token) &&
+  token.length >= UNSUBSCRIBE_TOKEN_MIN_LENGTH &&
+  token.length <= UNSUBSCRIBE_TOKEN_MAX_LENGTH;


### PR DESCRIPTION
## Summary

- `isValidUnsubscribeToken` 関数を `server/domain/common/token-validation.ts` に抽出
- `app/api/unsubscribe/route.ts` と `app/unsubscribe/page.tsx` の重複バリデーションロジックを統一
- 共有関数のユニットテストを追加

Closes #937

## Test plan

- [ ] `npx vitest run server/domain/common/token-validation.test.ts` でユニットテストが通ること
- [ ] 配信停止ページ・APIで無効トークンが正しく拒否されること
- [ ] 有効トークンで配信停止が正常に動作すること

🤖 Generated with [Claude Code](https://claude.com/claude-code)