### PR TITLE
fix: 配信停止ページのDomainErrorメッセージ直接転送を修正

### DIFF
--- a/app/unsubscribe/page.tsx
+++ b/app/unsubscribe/page.tsx
@@ -1,6 +1,6 @@
 import Footer from "@/app/components/footer";
 import { buildServiceContainer } from "@/server/presentation/trpc/context";
-import { DomainError } from "@/server/domain/common/errors";
+import { BadRequestError } from "@/server/domain/common/errors";
 import { isValidUnsubscribeToken } from "@/server/domain/common/token-validation";
 import Link from "next/link";
 
@@ -27,7 +27,7 @@ async function unsubscribe(token: string): Promise<UnsubscribeResult> {
     }
     return { status: "success" };
   } catch (error) {
-    if (error instanceof DomainError) {
+    if (error instanceof BadRequestError) {
       return { status: "error", message: error.message };
     }
     console.error("Unhandled error in unsubscribe page:", error);


### PR DESCRIPTION
## Summary

- `DomainError` 全体のキャッチを `BadRequestError` のみに限定し、内部エラーメッセージのユーザー露出リスクを排除
- `ForbiddenError` 等の内部エラーは汎用メッセージにフォールバック

Closes #938

## Test plan

- [ ] 有効なトークンでアクセス → 「配信停止完了」が表示される
- [ ] 無効/期限切れトークンでアクセス → 「無効または期限切れのトークンです」が表示される
- [ ] トークンパラメータなしでアクセス → 「無効なリンクです」が表示される
- [ ] 不正な文字列トークンでアクセス → 「無効なトークンです。」が表示される
- [ ] 内部エラーメッセージがユーザーに露出しないことを確認
- [ ] `npx tsc --noEmit` パス

🤖 Generated with [Claude Code](https://claude.com/claude-code)