### PR TITLE
fix: 配信停止エンドポイントをGETからPOSTに変更

### DIFF
--- a/app/api/unsubscribe/route.test.ts
+++ b/app/api/unsubscribe/route.test.ts
@@ -11,13 +11,40 @@ vi.mock("@/server/presentation/trpc/context", () => ({
   }),
 }));
 
-const { GET } = await import("@/app/api/unsubscribe/route");
+const { GET, POST } = await import("@/app/api/unsubscribe/route");
 
 beforeEach(() => {
   vi.clearAllMocks();
 });
 
 describe("GET /api/unsubscribe", () => {
+  test("トークン付きGETリクエストは /unsubscribe にリダイレクトする", async () => {
+    const token = "dmFsaWQtdG9rZW4tZm9yLXRlc3Q";
+    const request = new Request(
+      `http://localhost/api/unsubscribe?token=${token}`,
+    );
+    const response = await GET(request);
+
+    expect(response.status).toBe(302);
+    const location = response.headers.get("location");
+    expect(location).toContain("/unsubscribe");
+    expect(location).toContain(`token=${token}`);
+    expect(mockDisableByToken).not.toHaveBeenCalled();
+  });
+
+  test("トークンなしGETリクエストは /unsubscribe にリダイレクトする", async () => {
+    const request = new Request("http://localhost/api/unsubscribe");
+    const response = await GET(request);
+
+    expect(response.status).toBe(302);
+    const location = response.headers.get("location");
+    expect(location).toContain("/unsubscribe");
+    expect(location).not.toContain("token=");
+    expect(mockDisableByToken).not.toHaveBeenCalled();
+  });
+});
+
+describe("POST /api/unsubscribe", () => {
   test("有効なトークンで配信停止成功", async () => {
     mockDisableByToken.mockResolvedValue({
       userId: "user-1",
@@ -25,8 +52,12 @@ describe("GET /api/unsubscribe", () => {
     });
 
     const token = "dmFsaWQtdG9rZW4tZm9yLXRlc3Q";
-    const request = new Request(`http://localhost/api/unsubscribe?token=${token}`);
-    const response = await GET(request);
+    const request = new Request("http://localhost/api/unsubscribe", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ token }),
+    });
+    const response = await POST(request);
     const body = await response.json();
 
     expect(response.status).toBe(200);
@@ -38,8 +69,12 @@ describe("GET /api/unsubscribe", () => {
     mockDisableByToken.mockResolvedValue(null);
 
     const token = "aW52YWxpZC10b2tlbi1mb3ItdGVzdA";
-    const request = new Request(`http://localhost/api/unsubscribe?token=${token}`);
-    const response = await GET(request);
+    const request = new Request("http://localhost/api/unsubscribe", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ token }),
+    });
+    const response = await POST(request);
     const body = await response.json();
 
     expect(response.status).toBe(400);
@@ -47,8 +82,12 @@ describe("GET /api/unsubscribe", () => {
   });
 
   test("空白のみのトークンで 400 エラー", async () => {
-    const request = new Request("http://localhost/api/unsubscribe?token=%20%20");
-    const response = await GET(request);
+    const request = new Request("http://localhost/api/unsubscribe", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ token: "   " }),
+    });
+    const response = await POST(request);
     const body = await response.json();
 
     expect(response.status).toBe(400);
@@ -57,8 +96,12 @@ describe("GET /api/unsubscribe", () => {
   });
 
   test("不正な文字を含むトークンで 400 エラー", async () => {
-    const request = new Request("http://localhost/api/unsubscribe?token=invalid!%40%23%24%25token12345");
-    const response = await GET(request);
+    const request = new Request("http://localhost/api/unsubscribe", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ token: "invalid!@#$%token12345" }),
+    });
+    const response = await POST(request);
     const body = await response.json();
 
     expect(response.status).toBe(400);
@@ -67,8 +110,12 @@ describe("GET /api/unsubscribe", () => {
   });
 
   test("短すぎるトークンで 400 エラー", async () => {
-    const request = new Request("http://localhost/api/unsubscribe?token=abc123");
-    const response = await GET(request);
+    const request = new Request("http://localhost/api/unsubscribe", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ token: "abc123" }),
+    });
+    const response = await POST(request);
     const body = await response.json();
 
     expect(response.status).toBe(400);
@@ -77,9 +124,12 @@ describe("GET /api/unsubscribe", () => {
   });
 
   test("長すぎるトークンで 400 エラー", async () => {
-    const longToken = "a".repeat(257);
-    const request = new Request(`http://localhost/api/unsubscribe?token=${longToken}`);
-    const response = await GET(request);
+    const request = new Request("http://localhost/api/unsubscribe", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ token: "a".repeat(257) }),
+    });
+    const response = await POST(request);
     const body = await response.json();
 
     expect(response.status).toBe(400);
@@ -87,13 +137,51 @@ describe("GET /api/unsubscribe", () => {
     expect(mockDisableByToken).not.toHaveBeenCalled();
   });
 
-  test("token パラメータ未指定で 400 エラー", async () => {
-    const request = new Request("http://localhost/api/unsubscribe");
-    const response = await GET(request);
+  test("token フィールド未指定で 400 エラー", async () => {
+    const request = new Request("http://localhost/api/unsubscribe", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({}),
+    });
+    const response = await POST(request);
     const body = await response.json();
 
     expect(response.status).toBe(400);
     expect(body.message).toBe("トークンが指定されていません。");
+    expect(mockDisableByToken).not.toHaveBeenCalled();
+  });
+
+  test("application/x-www-form-urlencoded でトークンを送信できる", async () => {
+    mockDisableByToken.mockResolvedValue({
+      userId: "user-1",
+      emailEnabled: false,
+    });
+
+    const token = "dmFsaWQtdG9rZW4tZm9yLXRlc3Q";
+    const request = new Request("http://localhost/api/unsubscribe", {
+      method: "POST",
+      headers: { "Content-Type": "application/x-www-form-urlencoded" },
+      body: `token=${token}`,
+    });
+    const response = await POST(request);
+    const body = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(body.message).toBe("メール配信を停止しました。");
+    expect(mockDisableByToken).toHaveBeenCalledWith(token);
+  });
+
+  test("サポート外のContent-Typeで 415 エラー", async () => {
+    const request = new Request("http://localhost/api/unsubscribe", {
+      method: "POST",
+      headers: { "Content-Type": "text/plain" },
+      body: "token=test",
+    });
+    const response = await POST(request);
+    const body = await response.json();
+
+    expect(response.status).toBe(415);
+    expect(body.message).toBe("Unsupported Content-Type");
     expect(mockDisableByToken).not.toHaveBeenCalled();
   });
 
@@ -102,10 +190,12 @@ describe("GET /api/unsubscribe", () => {
       new BadRequestError("トークンの形式が不正です。"),
     );
 
-    const request = new Request(
-      "http://localhost/api/unsubscribe?token=bWFsZm9ybWVkLXRva2VuLXRlc3Q",
-    );
-    const response = await GET(request);
+    const request = new Request("http://localhost/api/unsubscribe", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ token: "bWFsZm9ybWVkLXRva2VuLXRlc3Q" }),
+    });
+    const response = await POST(request);
     const body = await response.json();
 
     expect(response.status).toBe(400);
@@ -115,10 +205,12 @@ describe("GET /api/unsubscribe", () => {
   test("未知のエラーがスローされた場合、500レスポンスと汎用メッセージを返す", async () => {
     mockDisableByToken.mockRejectedValue(new Error("unexpected DB error"));
 
-    const request = new Request(
-      "http://localhost/api/unsubscribe?token=c29tZS10b2tlbi1mb3ItdGVzdA",
-    );
-    const response = await GET(request);
+    const request = new Request("http://localhost/api/unsubscribe", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ token: "c29tZS10b2tlbi1mb3ItdGVzdA" }),
+    });
+    const response = await POST(request);
     const body = await response.json();
 
     expect(response.status).toBe(500);

--- a/app/api/unsubscribe/route.ts
+++ b/app/api/unsubscribe/route.ts
@@ -21,6 +21,31 @@ export async function GET(request: Request) {
   const { searchParams } = new URL(request.url);
   const token = searchParams.get("token")?.trim() || null;
 
+  const redirectUrl = new URL("/unsubscribe", request.url);
+  if (token) {
+    redirectUrl.searchParams.set("token", token);
+  }
+  return NextResponse.redirect(redirectUrl, 302);
+}
+
+export async function POST(request: Request) {
+  let token: string | null = null;
+
+  const contentType = request.headers.get("content-type") || "";
+  if (contentType.includes("application/json")) {
+    const body = await request.json();
+    token = typeof body.token === "string" ? body.token.trim() || null : null;
+  } else if (contentType.includes("application/x-www-form-urlencoded")) {
+    const formData = await request.formData();
+    const raw = formData.get("token");
+    token = typeof raw === "string" ? raw.trim() || null : null;
+  } else {
+    return NextResponse.json(
+      { message: "Unsupported Content-Type" },
+      { status: 415 },
+    );
+  }
+
   if (!token) {
     return NextResponse.json(
       { message: "トークンが指定されていません。" },

--- a/app/unsubscribe/page.tsx
+++ b/app/unsubscribe/page.tsx
@@ -1,51 +1,18 @@
 import Footer from "@/app/components/footer";
-import { buildServiceContainer } from "@/server/presentation/trpc/context";
-import { BadRequestError } from "@/server/domain/common/errors";
 import { isValidUnsubscribeToken } from "@/server/domain/common/token-validation";
 import Link from "next/link";
+import { UnsubscribeForm } from "./unsubscribe-form";
 
 type UnsubscribePageProps = {
   searchParams: Promise<{ token?: string }>;
 };
-
-type UnsubscribeResult =
-  | { status: "success" }
-  | { status: "error"; message: string };
-
-const { notificationPreferenceService } = buildServiceContainer();
-
-async function unsubscribe(token: string): Promise<UnsubscribeResult> {
-  if (!isValidUnsubscribeToken(token)) {
-    return { status: "error", message: "無効なトークンです。" };
-  }
-
-  try {
-    const result =
-      await notificationPreferenceService.disableByToken(token);
-    if (!result) {
-      return { status: "error", message: "無効なトークンです。" };
-    }
-    return { status: "success" };
-  } catch (error) {
-    if (error instanceof BadRequestError) {
-      return { status: "error", message: error.message };
-    }
-    console.error("Unhandled error in unsubscribe page:", error);
-    return {
-      status: "error",
-      message: "配信停止の処理中にエラーが発生しました。",
-    };
-  }
-}
 
 export default async function UnsubscribePage({
   searchParams,
 }: UnsubscribePageProps) {
   const { token } = await searchParams;
 
-  const result: UnsubscribeResult | null = token
-    ? await unsubscribe(token)
-    : null;
+  const hasValidToken = !!token && isValidUnsubscribeToken(token);
 
   return (
     <div className="flex min-h-svh flex-col">
@@ -62,33 +29,14 @@ export default async function UnsubscribePage({
             </>
           )}
 
-          {result?.status === "success" && (
-            <>
-              <h1 className="mb-4 text-xl font-bold text-(--brand-ink)">
-                配信停止完了
-              </h1>
-              <p className="mb-6 text-sm text-(--brand-ink-muted)">
-                メール配信を停止しました。今後、通知メールは届きません。
-              </p>
-              <p className="text-sm text-(--brand-ink-muted)">
-                設定を変更したい場合は、
-                <Link
-                  href="/account"
-                  className="text-(--brand-moss) underline hover:opacity-80"
-                >
-                  ログインしてアカウント設定
-                </Link>
-                から変更できます。
-              </p>
-            </>
-          )}
-
-          {result?.status === "error" && (
+          {token && !hasValidToken && (
             <>
               <h1 className="mb-4 text-xl font-bold text-(--brand-ink)">
                 配信停止
               </h1>
-              <p className="mb-6 text-sm text-red-600">{result.message}</p>
+              <p className="mb-6 text-sm text-red-600">
+                無効なトークンです。
+              </p>
               <p className="text-sm text-(--brand-ink-muted)">
                 問題が解決しない場合は、
                 <Link
@@ -101,6 +49,8 @@ export default async function UnsubscribePage({
               </p>
             </>
           )}
+
+          {hasValidToken && <UnsubscribeForm token={token} />}
         </div>
       </main>
       <Footer />

--- a/app/unsubscribe/unsubscribe-form.tsx
+++ b/app/unsubscribe/unsubscribe-form.tsx
@@ -1,0 +1,100 @@
+"use client";
+
+import { useState } from "react";
+import Link from "next/link";
+
+type Props = {
+  token: string;
+};
+
+type State = "idle" | "loading" | "success" | "error";
+
+export function UnsubscribeForm({ token }: Props) {
+  const [state, setState] = useState<State>("idle");
+  const [errorMessage, setErrorMessage] = useState("");
+
+  async function handleSubmit() {
+    setState("loading");
+    try {
+      const response = await fetch("/api/unsubscribe", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ token }),
+      });
+      const data = await response.json();
+
+      if (response.ok) {
+        setState("success");
+      } else {
+        setState("error");
+        setErrorMessage(data.message || "配信停止の処理中にエラーが発生しました。");
+      }
+    } catch {
+      setState("error");
+      setErrorMessage("配信停止の処理中にエラーが発生しました。");
+    }
+  }
+
+  if (state === "success") {
+    return (
+      <>
+        <h1 className="mb-4 text-xl font-bold text-(--brand-ink)">
+          配信停止完了
+        </h1>
+        <p className="mb-6 text-sm text-(--brand-ink-muted)">
+          メール配信を停止しました。今後、通知メールは届きません。
+        </p>
+        <p className="text-sm text-(--brand-ink-muted)">
+          設定を変更したい場合は、
+          <Link
+            href="/account"
+            className="text-(--brand-moss) underline hover:opacity-80"
+          >
+            ログインしてアカウント設定
+          </Link>
+          から変更できます。
+        </p>
+      </>
+    );
+  }
+
+  if (state === "error") {
+    return (
+      <>
+        <h1 className="mb-4 text-xl font-bold text-(--brand-ink)">
+          配信停止
+        </h1>
+        <p className="mb-6 text-sm text-red-600">{errorMessage}</p>
+        <p className="text-sm text-(--brand-ink-muted)">
+          問題が解決しない場合は、
+          <Link
+            href="/account"
+            className="text-(--brand-moss) underline hover:opacity-80"
+          >
+            ログインしてアカウント設定
+          </Link>
+          からメール通知を無効にしてください。
+        </p>
+      </>
+    );
+  }
+
+  return (
+    <>
+      <h1 className="mb-4 text-xl font-bold text-(--brand-ink)">
+        配信停止
+      </h1>
+      <p className="mb-6 text-sm text-(--brand-ink-muted)">
+        メール通知の配信を停止しますか？
+      </p>
+      <button
+        type="button"
+        onClick={handleSubmit}
+        disabled={state === "loading"}
+        className="w-full rounded-lg bg-(--brand-moss) px-4 py-2.5 text-sm font-medium text-white hover:opacity-90 disabled:opacity-50"
+      >
+        {state === "loading" ? "処理中..." : "配信を停止する"}
+      </button>
+    </>
+  );
+}

--- a/server/application/notification/notification-service.test.ts
+++ b/server/application/notification/notification-service.test.ts
@@ -228,7 +228,7 @@ describe("NotificationService", () => {
     expect(mockEmailSender.send).toHaveBeenCalledWith(
       expect.objectContaining({
         body: expect.stringContaining(
-          "メール配信を停止する: https://example.com/api/unsubscribe?token=mock-token",
+          "メール配信を停止する: https://example.com/unsubscribe?token=mock-token",
         ),
       }),
     );

--- a/server/application/notification/notification-service.ts
+++ b/server/application/notification/notification-service.ts
@@ -87,7 +87,7 @@ export const createNotificationService = (deps: NotificationServiceDeps) => {
             String(user.id),
           );
           const unsubscribeUrl = baseUrl
-            ? `${baseUrl}/api/unsubscribe?token=${unsubscribeToken}`
+            ? `${baseUrl}/unsubscribe?token=${unsubscribeToken}`
             : null;
           const unsubscribeFooter = unsubscribeUrl
             ? `\n---\nメール配信を停止する: ${unsubscribeUrl}`


### PR DESCRIPTION
## Summary

Closes #931

配信停止エンドポイントがGETで状態変更を行っていた問題を修正。RFC 8058に準拠し、GET/POSTを適切に分離。

- **GET /api/unsubscribe**: `/unsubscribe` ページへ302リダイレクト（状態変更なし）
- **POST /api/unsubscribe**: JSON / form-urlencoded で配信停止を実行
- **UnsubscribeForm**: 確認ボタン付きのクライアントコンポーネントを新規追加
- **メールリンク**: `/api/unsubscribe?token=xxx` → `/unsubscribe?token=xxx` に変更

## Test plan

- [ ] `vitest app/api/unsubscribe/route.test.ts` が全件パス
- [ ] `vitest server/application/notification/notification-service.test.ts` が全件パス
- [ ] GET /api/unsubscribe?token=xxx がリダイレクトし、状態変更しないことを確認
- [ ] /unsubscribe?token=xxx でボタンクリック後に配信停止されることを確認
- [ ] メールプリフェッチ（GETリクエスト）で意図しない配信停止が発生しないことを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)