### PR TITLE
feat: メール送信時に List-Unsubscribe ヘッダーを設定 (RFC 8058)

### DIFF
--- a/app/api/unsubscribe/route.test.ts
+++ b/app/api/unsubscribe/route.test.ts
@@ -171,6 +171,29 @@ describe("POST /api/unsubscribe", () => {
     expect(mockDisableByToken).toHaveBeenCalledWith(token);
   });
 
+  test("URLクエリパラメータからトークンを読み取れる（RFC 8058 One-Click対応）", async () => {
+    mockDisableByToken.mockResolvedValue({
+      userId: "user-1",
+      emailEnabled: false,
+    });
+
+    const token = "dmFsaWQtdG9rZW4tZm9yLXRlc3Q";
+    const request = new Request(
+      `http://localhost/api/unsubscribe?token=${token}`,
+      {
+        method: "POST",
+        headers: { "Content-Type": "application/x-www-form-urlencoded" },
+        body: "List-Unsubscribe=One-Click",
+      },
+    );
+    const response = await POST(request);
+    const body = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(body.message).toBe("メール配信を停止しました。");
+    expect(mockDisableByToken).toHaveBeenCalledWith(token);
+  });
+
   test("サポート外のContent-Typeで 415 エラー", async () => {
     const request = new Request("http://localhost/api/unsubscribe", {
       method: "POST",

--- a/app/api/unsubscribe/route.ts
+++ b/app/api/unsubscribe/route.ts
@@ -47,6 +47,14 @@ export async function POST(request: Request) {
   }
 
   if (!token) {
+    const { searchParams } = new URL(request.url);
+    const queryToken = searchParams.get("token")?.trim() || null;
+    if (queryToken) {
+      token = queryToken;
+    }
+  }
+
+  if (!token) {
     return NextResponse.json(
       { message: "トークンが指定されていません。" },
       { status: 400 },

--- a/server/application/notification/notification-service.test.ts
+++ b/server/application/notification/notification-service.test.ts
@@ -213,6 +213,45 @@ describe("NotificationService", () => {
     );
   });
 
+  test("BASE_URL が設定されている場合、List-Unsubscribe ヘッダーが付与される", async () => {
+    vi.stubEnv("BASE_URL", "https://example.com");
+
+    vi.mocked(mockCircleRepository.listMembershipsByCircleId).mockResolvedValue(
+      [makeMembership("user-1"), makeMembership("user-2")],
+    );
+    vi.mocked(mockUserRepository.findByIds).mockResolvedValue([
+      makeUser("user-2", "user2@example.com"),
+    ]);
+
+    await service.notifySessionCreated(session, circleName, actorId);
+
+    expect(mockEmailSender.send).toHaveBeenCalledWith(
+      expect.objectContaining({
+        headers: {
+          "List-Unsubscribe":
+            "<https://example.com/api/unsubscribe?token=mock-token>",
+          "List-Unsubscribe-Post": "List-Unsubscribe=One-Click",
+        },
+      }),
+    );
+  });
+
+  test("BASE_URL が未設定の場合、headers が付与されない", async () => {
+    vi.stubEnv("BASE_URL", "");
+
+    vi.mocked(mockCircleRepository.listMembershipsByCircleId).mockResolvedValue(
+      [makeMembership("user-1"), makeMembership("user-2")],
+    );
+    vi.mocked(mockUserRepository.findByIds).mockResolvedValue([
+      makeUser("user-2", "user2@example.com"),
+    ]);
+
+    await service.notifySessionCreated(session, circleName, actorId);
+
+    const call = vi.mocked(mockEmailSender.send).mock.calls[0]?.[0];
+    expect(call).not.toHaveProperty("headers");
+  });
+
   test("BASE_URL が設定されている場合、メール本文に配信停止リンクが含まれる", async () => {
     vi.stubEnv("BASE_URL", "https://example.com");
 

--- a/server/application/notification/notification-service.ts
+++ b/server/application/notification/notification-service.ts
@@ -106,10 +106,22 @@ export const createNotificationService = (deps: NotificationServiceDeps) => {
             .filter((line) => line !== undefined)
             .join("\n");
 
+          const unsubscribeApiUrl = baseUrl
+            ? `${baseUrl}/api/unsubscribe?token=${unsubscribeToken}`
+            : null;
+
+          const headers: Record<string, string> = {};
+          if (unsubscribeApiUrl) {
+            headers["List-Unsubscribe"] = `<${unsubscribeApiUrl}>`;
+            headers["List-Unsubscribe-Post"] =
+              "List-Unsubscribe=One-Click";
+          }
+
           return deps.emailSender.send({
             to: [user.email!],
             subject: `[${circleName}] ${session.title}`,
             body,
+            ...(Object.keys(headers).length > 0 && { headers }),
           });
         }),
       );

--- a/server/domain/common/email-sender.ts
+++ b/server/domain/common/email-sender.ts
@@ -2,6 +2,7 @@ export type EmailMessage = {
   to: string[];
   subject: string;
   body: string;
+  headers?: Record<string, string>;
 };
 
 export type EmailSender = {

--- a/server/infrastructure/email/resend-email-sender.ts
+++ b/server/infrastructure/email/resend-email-sender.ts
@@ -11,6 +11,7 @@ export const createResendEmailSender = (apiKey: string): EmailSender => {
         to: message.to,
         subject: message.subject,
         text: message.body,
+        headers: message.headers,
       });
     },
   };


### PR DESCRIPTION
## Summary

Closes #944

- RFC 8058 準拠の `List-Unsubscribe` / `List-Unsubscribe-Post` ヘッダーをメール送信時に付与し、Gmail等でワンクリック配信停止ボタンを表示可能にする
- `POST /api/unsubscribe` でURLクエリパラメータからもトークンを読み取れるよう対応（メールクライアントからのOne-Clickフロー対応）
- `BASE_URL` 未設定時はヘッダーを付与しない安全なフォールバック

## Changes

| File | Description |
|------|-------------|
| `server/domain/common/email-sender.ts` | `EmailMessage` 型に `headers` フィールドを追加 |
| `server/application/notification/notification-service.ts` | トークン付き配信停止URLを `List-Unsubscribe` ヘッダーに設定 |
| `server/infrastructure/email/resend-email-sender.ts` | `headers` を Resend API に転送 |
| `app/api/unsubscribe/route.ts` | URLクエリパラメータからのトークン読み取りを追加 |

## Test plan

- [ ] `notification-service.test.ts`: 11テスト合格（List-Unsubscribeヘッダー付与テスト2件を含む）
- [ ] `route.test.ts`: 14テスト合格（URLクエリパラメータからのトークン読み取りテスト1件を含む）
- [ ] メール送信をトリガーし、受信メールのヘッダーに `List-Unsubscribe` と `List-Unsubscribe-Post` が含まれることを確認
- [ ] `curl -X POST -d "List-Unsubscribe=One-Click" "https://<BASE_URL>/api/unsubscribe?token=<token>"` でRFC 8058フローが動作することを確認

## Security notes

- トークンがURLクエリパラメータに含まれるが、RFC 8058の仕様上不可避。トークンの用途は配信停止のみで影響は限定的
- CSRF保護なしはRFC 8058準拠のため意図的（トークン自体が認可メカニズム）

## Follow-up

- #946: ボディとクエリパラメータ両方にトークンがある場合のテスト追加

🤖 Generated with [Claude Code](https://claude.com/claude-code)