### PR TITLE
feat: 配信停止ページに Referrer-Policy ヘッダーを追加

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -35,6 +35,15 @@ const nextConfig: NextConfig = {
           },
         ],
       },
+      {
+        source: "/unsubscribe",
+        headers: [
+          {
+            key: "Referrer-Policy",
+            value: "no-referrer",
+          },
+        ],
+      },
     ];
   },
 };


### PR DESCRIPTION
## Summary

- `/unsubscribe` ページに `Referrer-Policy: no-referrer` ヘッダーを設定
- URLクエリパラメータの配信停止トークンが Referer ヘッダー経由で外部サイトに漏洩するのを防止

Closes #943

## Test plan

- [ ] `next dev` でローカルサーバーを起動し `/unsubscribe?token=test123` にアクセス
- [ ] DevTools の Network タブでレスポンスヘッダーに `Referrer-Policy: no-referrer` が設定されていることを確認
- [ ] 他のページ（例: `/`）では `Referrer-Policy: strict-origin-when-cross-origin` のままであることを確認
- [ ] デプロイ後に `curl -I https://<domain>/unsubscribe` でヘッダーを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)