### PR TITLE
test: 配信停止API成功レスポンスのCache-Controlヘッダーテストを追加

### DIFF
--- a/app/api/unsubscribe/route.test.ts
+++ b/app/api/unsubscribe/route.test.ts
@@ -61,6 +61,7 @@ describe("POST /api/unsubscribe", () => {
     const body = await response.json();
 
     expect(response.status).toBe(200);
+    expect(response.headers.get("Cache-Control")).toBe("no-store");
     expect(body.message).toBe("メール配信を停止しました。");
     expect(mockDisableByToken).toHaveBeenCalledWith(token);
   });
@@ -167,6 +168,7 @@ describe("POST /api/unsubscribe", () => {
     const body = await response.json();
 
     expect(response.status).toBe(200);
+    expect(response.headers.get("Cache-Control")).toBe("no-store");
     expect(body.message).toBe("メール配信を停止しました。");
     expect(mockDisableByToken).toHaveBeenCalledWith(token);
   });
@@ -190,6 +192,7 @@ describe("POST /api/unsubscribe", () => {
     const body = await response.json();
 
     expect(response.status).toBe(200);
+    expect(response.headers.get("Cache-Control")).toBe("no-store");
     expect(body.message).toBe("メール配信を停止しました。");
     expect(mockDisableByToken).toHaveBeenCalledWith(token);
   });
@@ -214,6 +217,7 @@ describe("POST /api/unsubscribe", () => {
     const body = await response.json();
 
     expect(response.status).toBe(200);
+    expect(response.headers.get("Cache-Control")).toBe("no-store");
     expect(body.message).toBe("メール配信を停止しました。");
     expect(mockDisableByToken).toHaveBeenCalledWith(bodyToken);
   });


### PR DESCRIPTION
## Summary

- 配信停止API (`POST /api/unsubscribe`) の成功レスポンス4ケース全てに `Cache-Control: no-store` ヘッダーのアサーションを追加
- 状態変更を伴うレスポンスのキャッシュ防止ヘッダーに対するリグレッション検知を可能にした

Closes #928

## Test plan

- [x] `npx vitest run app/api/unsubscribe/route.test.ts` で15テスト全てパス
- [ ] CI が通ることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)