### PR TITLE
refactor: emailEnabled デフォルト値ロジックの一元化

### DIFF
--- a/server/application/notification/notification-preference-service.ts
+++ b/server/application/notification/notification-preference-service.ts
@@ -1,5 +1,8 @@
 import { userId, type UserId } from "@/server/domain/common/ids";
-import type { NotificationPreference } from "@/server/domain/models/notification-preference/notification-preference";
+import {
+  createDefaultPreference,
+  type NotificationPreference,
+} from "@/server/domain/models/notification-preference/notification-preference";
 import type { NotificationPreferenceRepository } from "@/server/domain/models/notification-preference/notification-preference-repository";
 import type { UnsubscribeTokenService } from "@/server/domain/services/unsubscribe-token";
 
@@ -15,7 +18,7 @@ export const createNotificationPreferenceService = (
     async getPreference(userId: UserId): Promise<NotificationPreference> {
       const pref =
         await deps.notificationPreferenceRepository.findByUserId(userId);
-      return pref ?? { userId, emailEnabled: true };
+      return pref ?? createDefaultPreference(userId);
     },
 
     async updatePreference(

--- a/server/application/notification/notification-service.ts
+++ b/server/application/notification/notification-service.ts
@@ -40,7 +40,9 @@ export const createNotificationService = (deps: NotificationServiceDeps) => {
       const usersWithEmail = users.filter((u) => u.email !== null);
       if (usersWithEmail.length === 0) return;
 
-      // Check notification preferences — users without a record default to emailEnabled: true
+      // Check notification preferences — users without a record are not in this
+      // array, so they remain in the eligible list (default: enabled).
+      // See: createDefaultPreference() in notification-preference.ts
       const prefs =
         await deps.notificationPreferenceRepository.findByUserIds(
           usersWithEmail.map((u) => u.id),

--- a/server/domain/models/notification-preference/notification-preference.ts
+++ b/server/domain/models/notification-preference/notification-preference.ts
@@ -4,3 +4,12 @@ export type NotificationPreference = {
   userId: UserId;
   emailEnabled: boolean;
 };
+
+const DEFAULT_EMAIL_ENABLED = true;
+
+export const createDefaultPreference = (
+  userId: UserId,
+): NotificationPreference => ({
+  userId,
+  emailEnabled: DEFAULT_EMAIL_ENABLED,
+});


### PR DESCRIPTION
## Summary

- ドメイン層に `createDefaultPreference(userId)` ファクトリ関数を追加し、`emailEnabled: true` デフォルト値の定義を一元化
- `NotificationPreferenceService.getPreference()` のインラインリテラルをファクトリ関数に置換
- `NotificationService` のフィルタリングロジックのコメントを改善（暗黙的前提の明示化）

Closes #920

## Test plan

- [x] 既存テスト全パス（1187 tests, 振る舞い変更なし）
- [ ] `createDefaultPreference` が正しいデフォルト値を返すことを確認
- [ ] `getPreference()` でレコード未存在時にファクトリ関数経由のデフォルトが返ることを確認

## Review points

- Prisma スキーマの `@default(true)` との二重定義は構造上避けられない（DB層 vs ドメイン層）
- `DEFAULT_EMAIL_ENABLED` 定数は外部エクスポートせず、ファクトリ関数のみを公開API とした

🤖 Generated with [Claude Code](https://claude.com/claude-code)