### PR TITLE
feat: 研究会メール通知on/offトグルUI（ダミー実装） (#955)

### DIFF
--- a/app/(authenticated)/circles/components/circle-notification-toggle.tsx
+++ b/app/(authenticated)/circles/components/circle-notification-toggle.tsx
@@ -1,0 +1,27 @@
+"use client";
+
+import { Switch } from "@/components/ui/switch";
+import { useState } from "react";
+
+export function CircleNotificationToggle() {
+  // TODO: バックエンドAPI連携時にローカルステートからtRPC mutationに置き換える
+  const [enabled, setEnabled] = useState(true);
+
+  return (
+    <div className="flex items-center justify-between gap-4">
+      <div className="flex flex-col gap-1">
+        <span className="text-sm font-medium text-(--brand-ink)">
+          セッション作成時のメール通知
+        </span>
+        <span className="text-xs text-(--brand-ink-muted)">
+          新しいセッションが作成されたとき、メンバーにメール通知を送信します
+        </span>
+      </div>
+      <Switch
+        checked={enabled}
+        onCheckedChange={setEnabled}
+        aria-label="セッション作成時のメール通知"
+      />
+    </div>
+  );
+}

--- a/app/(authenticated)/circles/components/circle-overview-view.test.tsx
+++ b/app/(authenticated)/circles/components/circle-overview-view.test.tsx
@@ -68,6 +68,15 @@ vi.mock(
 );
 
 vi.mock(
+  "@/app/(authenticated)/circles/components/circle-notification-toggle",
+  () => ({
+    CircleNotificationToggle: () => (
+      <div data-testid="notification-toggle">通知トグル</div>
+    ),
+  }),
+);
+
+vi.mock(
   "@/app/(authenticated)/circles/components/transfer-circle-ownership-dialog",
   () => ({
     TransferCircleOwnershipDialog: () => (
@@ -96,6 +105,7 @@ function buildOverview(
     canDeleteCircle: false,
     canRenameCircle: false,
     canTransferOwnership: false,
+    canEditNotificationSetting: false,
     viewerUserId: null,
     ...overrides,
   };
@@ -292,6 +302,30 @@ describe("CircleOverviewView ロールベース表示制御", () => {
 
     expect(screen.getByText("オーナー")).toBeInTheDocument();
     expect(screen.queryByTestId("role-edit-user-2")).not.toBeInTheDocument();
+  });
+});
+
+describe("CircleOverviewView 通知設定トグル", () => {
+  it("canEditNotificationSetting が true の場合、通知トグルが表示される", () => {
+    render(
+      <CircleOverviewView
+        overview={buildOverview({ canEditNotificationSetting: true })}
+      />,
+    );
+
+    expect(screen.getByTestId("notification-toggle")).toBeInTheDocument();
+  });
+
+  it("canEditNotificationSetting が false の場合、通知トグルが表示されない", () => {
+    render(
+      <CircleOverviewView
+        overview={buildOverview({ canEditNotificationSetting: false })}
+      />,
+    );
+
+    expect(
+      screen.queryByTestId("notification-toggle"),
+    ).not.toBeInTheDocument();
   });
 });
 

--- a/app/(authenticated)/circles/components/circle-overview-view.tsx
+++ b/app/(authenticated)/circles/components/circle-overview-view.tsx
@@ -1,4 +1,5 @@
 import { CircleDeleteButton } from "@/app/(authenticated)/circles/components/circle-delete-button";
+import { CircleNotificationToggle } from "@/app/(authenticated)/circles/components/circle-notification-toggle";
 import { CircleOverviewCalendar } from "@/app/(authenticated)/circles/components/circle-overview-calendar";
 import { CircleRenameDialog } from "@/app/(authenticated)/circles/components/circle-rename-dialog";
 import { CircleWithdrawButton } from "@/app/(authenticated)/circles/components/circle-withdraw-button";
@@ -225,6 +226,15 @@ export function CircleOverviewView({
           </div>
         </div>
       </section>
+
+      {overview.canEditNotificationSetting ? (
+        <section className="rounded-2xl border border-border/60 bg-white/90 p-6 shadow-sm">
+          <p className="mb-4 text-sm font-semibold text-(--brand-ink)">
+            通知設定
+          </p>
+          <CircleNotificationToggle />
+        </section>
+      ) : null}
 
       {overview.canTransferOwnership && overview.viewerUserId ? (
         <section className="rounded-2xl border border-border/60 bg-white/90 p-6 shadow-sm">

--- a/server/presentation/providers/circle-overview-provider.test.ts
+++ b/server/presentation/providers/circle-overview-provider.test.ts
@@ -145,6 +145,83 @@ describe("getCircleOverviewViewModel", () => {
     ]);
   });
 
+  describe("canEditNotificationSetting", () => {
+    test("viewerがownerの場合、trueになる", async () => {
+      const memberships = [
+        makeCircleMembership("viewer-1", CircleRole.CircleOwner),
+      ];
+      mockDeps.circleRepository.listMembershipsByCircleId.mockResolvedValue(
+        memberships,
+      );
+      mockDeps.userRepository.findByIds.mockResolvedValue([
+        makeUser("viewer-1", "オーナー"),
+      ]);
+      mockDeps.authzRepository.findCircleMembership.mockResolvedValue({
+        kind: "member" as const,
+        role: CircleRole.CircleOwner,
+      });
+
+      const result = await getCircleOverviewViewModel("circle-1");
+      expect(result.canEditNotificationSetting).toBe(true);
+    });
+
+    test("viewerがmanagerの場合、trueになる", async () => {
+      const memberships = [
+        makeCircleMembership("viewer-1", CircleRole.CircleManager),
+        makeCircleMembership("u-owner", CircleRole.CircleOwner),
+      ];
+      mockDeps.circleRepository.listMembershipsByCircleId.mockResolvedValue(
+        memberships,
+      );
+      mockDeps.userRepository.findByIds.mockResolvedValue([
+        makeUser("viewer-1", "マネージャー"),
+        makeUser("u-owner", "オーナー"),
+      ]);
+      mockDeps.authzRepository.findCircleMembership.mockImplementation(
+        async (uid: string) => {
+          const roles: Record<string, CircleRole> = {
+            "viewer-1": CircleRole.CircleManager,
+            "u-owner": CircleRole.CircleOwner,
+          };
+          const role = roles[uid];
+          if (role) return { kind: "member" as const, role };
+          return { kind: "none" as const };
+        },
+      );
+
+      const result = await getCircleOverviewViewModel("circle-1");
+      expect(result.canEditNotificationSetting).toBe(true);
+    });
+
+    test("viewerがmemberの場合、falseになる", async () => {
+      const memberships = [
+        makeCircleMembership("viewer-1", CircleRole.CircleMember),
+        makeCircleMembership("u-owner", CircleRole.CircleOwner),
+      ];
+      mockDeps.circleRepository.listMembershipsByCircleId.mockResolvedValue(
+        memberships,
+      );
+      mockDeps.userRepository.findByIds.mockResolvedValue([
+        makeUser("viewer-1", "メンバー"),
+        makeUser("u-owner", "オーナー"),
+      ]);
+      mockDeps.authzRepository.findCircleMembership.mockImplementation(
+        async (uid: string) => {
+          const roles: Record<string, CircleRole> = {
+            "viewer-1": CircleRole.CircleMember,
+            "u-owner": CircleRole.CircleOwner,
+          };
+          const role = roles[uid];
+          if (role) return { kind: "member" as const, role };
+          return { kind: "none" as const };
+        },
+      );
+
+      const result = await getCircleOverviewViewModel("circle-1");
+      expect(result.canEditNotificationSetting).toBe(false);
+    });
+  });
+
   describe("認可エラー", () => {
     test("研究会メンバーでないユーザーが研究会詳細を取得するとFORBIDDENエラーになる", async () => {
       // authzRepository.findCircleMembership はデフォルト { kind: "none" } のまま

--- a/server/presentation/providers/circle-overview-provider.ts
+++ b/server/presentation/providers/circle-overview-provider.ts
@@ -154,6 +154,8 @@ export async function getCircleOverviewViewModel(
     canDeleteCircle,
     canRenameCircle,
     canTransferOwnership,
+    canEditNotificationSetting:
+      viewerRole === "owner" || viewerRole === "manager",
     viewerUserId: viewerId,
   };
 

--- a/server/presentation/view-models/circle-overview.ts
+++ b/server/presentation/view-models/circle-overview.ts
@@ -33,5 +33,6 @@ export type CircleOverviewViewModel = {
   canDeleteCircle: boolean;
   canRenameCircle: boolean;
   canTransferOwnership: boolean;
+  canEditNotificationSetting: boolean;
   viewerUserId: string | null;
 };


### PR DESCRIPTION
## Summary

- 研究会概要ページに「セッション作成時のメール通知」on/offトグルUIを追加
- CircleOwner / CircleManager のみトグルを表示（`canEditNotificationSetting` フラグで制御）
- バックエンドAPI未実装のため、ローカルステートによるダミー動作（TODOコメント付記）

Closes #955

## Test plan

- [x] `circle-overview-provider.test.ts`: owner→true, manager→true, member→false の3パターン
- [x] `circle-overview-view.test.tsx`: canEditNotificationSetting true/false での表示/非表示
- [ ] 手動確認: owner/managerでトグル表示、memberで非表示
- [ ] 手動確認: トグル操作でUI切り替え、リロードでデフォルト(ON)に戻る

## レビューポイント

- `CircleNotificationToggle` はダミー実装。バックエンドAPI実装issue（後続）で `useState` → tRPC mutation に差し替え予定
- 認可判定はサーバーサイド（provider）で算出済み。クライアント側での改竄不可

🤖 Generated with [Claude Code](https://claude.com/claude-code)