### PR TITLE
feat: 研究会のセッション作成時メール通知on/offバックエンド実装

### DIFF
--- a/app/(authenticated)/circles/components/circle-notification-toggle.tsx
+++ b/app/(authenticated)/circles/components/circle-notification-toggle.tsx
@@ -1,11 +1,38 @@
 "use client";
 
 import { Switch } from "@/components/ui/switch";
-import { useState } from "react";
+import { trpc } from "@/lib/trpc/client";
+import { useCallback, useState } from "react";
 
-export function CircleNotificationToggle() {
-  // TODO: バックエンドAPI連携時にローカルステートからtRPC mutationに置き換える
-  const [enabled, setEnabled] = useState(true);
+type CircleNotificationToggleProps = {
+  circleId: string;
+  initialEnabled: boolean;
+};
+
+export function CircleNotificationToggle({
+  circleId,
+  initialEnabled,
+}: CircleNotificationToggleProps) {
+  const [enabled, setEnabled] = useState(initialEnabled);
+
+  const mutation =
+    trpc.circles.updateSessionEmailNotification.useMutation();
+
+  const handleChange = useCallback(
+    (checked: boolean) => {
+      const previous = enabled;
+      setEnabled(checked);
+      mutation.mutate(
+        { circleId, enabled: checked },
+        {
+          onError: () => {
+            setEnabled(previous);
+          },
+        },
+      );
+    },
+    [circleId, enabled, mutation],
+  );
 
   return (
     <div className="flex items-center justify-between gap-4">
@@ -19,7 +46,8 @@ export function CircleNotificationToggle() {
       </div>
       <Switch
         checked={enabled}
-        onCheckedChange={setEnabled}
+        onCheckedChange={handleChange}
+        disabled={mutation.isPending}
         aria-label="セッション作成時のメール通知"
       />
     </div>

--- a/app/(authenticated)/circles/components/circle-overview-view.test.tsx
+++ b/app/(authenticated)/circles/components/circle-overview-view.test.tsx
@@ -106,6 +106,7 @@ function buildOverview(
     canRenameCircle: false,
     canTransferOwnership: false,
     canEditNotificationSetting: false,
+    sessionEmailNotificationEnabled: true,
     viewerUserId: null,
     ...overrides,
   };

--- a/app/(authenticated)/circles/components/circle-overview-view.tsx
+++ b/app/(authenticated)/circles/components/circle-overview-view.tsx
@@ -232,7 +232,10 @@ export function CircleOverviewView({
           <p className="mb-4 text-sm font-semibold text-(--brand-ink)">
             通知設定
           </p>
-          <CircleNotificationToggle />
+          <CircleNotificationToggle
+            circleId={overview.circleId}
+            initialEnabled={overview.sessionEmailNotificationEnabled}
+          />
         </section>
       ) : null}
 

--- a/prisma/migrations/20260307143311_add_session_email_notification_enabled_to_circle/migration.sql
+++ b/prisma/migrations/20260307143311_add_session_email_notification_enabled_to_circle/migration.sql
@@ -1,0 +1,2 @@
+-- AlterTable
+ALTER TABLE "Circle" ADD COLUMN     "sessionEmailNotificationEnabled" BOOLEAN NOT NULL DEFAULT true;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -70,6 +70,8 @@ model Circle {
   name      String   @db.VarChar(50)
   createdAt DateTime @default(now())
 
+  sessionEmailNotificationEnabled Boolean @default(true)
+
   circleSessions    CircleSession[]
   circleMemberships CircleMembership[]
   inviteLinks       CircleInviteLink[]

--- a/server/application/circle-session/circle-session-membership-service.test.ts
+++ b/server/application/circle-session/circle-session-membership-service.test.ts
@@ -216,6 +216,7 @@ describe("CircleSession セッションメンバーシップサービス", () =>
       id: circleId("circle-1"),
       name: "さくら将棋研究会",
       createdAt: new Date("2024-01-01T00:00:00Z"),
+      sessionEmailNotificationEnabled: true,
     });
     await circleSessionRepository.save(
       createCircleSession({

--- a/server/application/circle/circle-invite-link-service.test.ts
+++ b/server/application/circle/circle-invite-link-service.test.ts
@@ -33,6 +33,7 @@ const baseCircle = () => ({
   id: circleId("circle-1"),
   name: "テスト研究会",
   createdAt: new Date(),
+  sessionEmailNotificationEnabled: true,
 });
 
 const baseLink = () => ({

--- a/server/application/circle/circle-membership-service.test.ts
+++ b/server/application/circle/circle-membership-service.test.ts
@@ -40,6 +40,7 @@ const baseCircle = () => ({
   id: circleId("circle-1"),
   name: "Circle One",
   createdAt: new Date(),
+  sessionEmailNotificationEnabled: true,
 });
 
 beforeEach(async () => {
@@ -110,6 +111,7 @@ describe("Circle メンバーシップサービス", () => {
       id: circleId("circle-2"),
       name: "Circle Two",
       createdAt: new Date("2025-01-02T00:00:00Z"),
+      sessionEmailNotificationEnabled: true,
     });
     await circleRepository.addMembership(
       circleId("circle-1"),
@@ -429,6 +431,7 @@ describe("UnitOfWork 経路", () => {
       id: circleId("circle-1"),
       name: "Circle One",
       createdAt: new Date(),
+      sessionEmailNotificationEnabled: true,
     });
     await repos.circleRepository.addMembership(
       circleId("circle-1"),

--- a/server/application/circle/circle-service.ts
+++ b/server/application/circle/circle-service.ts
@@ -90,6 +90,29 @@ export const createCircleService = (deps: CircleServiceDeps) => {
       return circle;
     },
 
+    async updateSessionEmailNotificationEnabled(
+      actorId: string,
+      id: CircleId,
+      enabled: boolean,
+    ): Promise<void> {
+      const circle = await deps.circleRepository.findById(id);
+      if (!circle) {
+        throw new NotFoundError("Circle");
+      }
+      const allowed = await deps.accessService.canEditCircle(
+        actorId,
+        id as string,
+      );
+      if (!allowed) {
+        throw new ForbiddenError();
+      }
+      const updated: Circle = {
+        ...circle,
+        sessionEmailNotificationEnabled: enabled,
+      };
+      await deps.circleRepository.save(updated);
+    },
+
     async deleteCircle(actorId: string, id: CircleId): Promise<void> {
       const circle = await deps.circleRepository.findById(id);
       if (!circle) {

--- a/server/application/notification/notification-service.test.ts
+++ b/server/application/notification/notification-service.test.ts
@@ -15,8 +15,10 @@ import type { UnsubscribeTokenService } from "@/server/domain/services/unsubscri
 import type { EmailSender } from "@/server/domain/common/email-sender";
 import type { CircleMembership } from "@/server/domain/models/circle/circle-membership";
 import type { User } from "@/server/domain/models/user/user";
+import { createCircle } from "@/server/domain/models/circle/circle";
 
 const mockCircleRepository = {
+  findById: vi.fn(),
   listMembershipsByCircleId: vi.fn(),
 } as unknown as CircleRepository;
 
@@ -77,9 +79,16 @@ const makeUser = (uid: string, email: string | null): User => ({
   createdAt: new Date("2024-01-01"),
 });
 
+const defaultCircle = createCircle({
+  id: circleId("circle-1"),
+  name: "将棋研究会",
+  sessionEmailNotificationEnabled: true,
+});
+
 beforeEach(() => {
   vi.clearAllMocks();
   mockEnv.BASE_URL = undefined;
+  vi.mocked(mockCircleRepository.findById).mockResolvedValue(defaultCircle);
   vi.mocked(mockNotificationPreferenceRepository.findByUserIds).mockResolvedValue([]);
   vi.mocked(mockUnsubscribeTokenService.generate).mockReturnValue("mock-token");
 });
@@ -257,6 +266,28 @@ describe("NotificationService", () => {
 
     const call = vi.mocked(mockEmailSender.send).mock.calls[0]?.[0];
     expect(call).not.toHaveProperty("headers");
+  });
+
+  test("研究会のメール通知設定が無効の場合、メール送信されない", async () => {
+    vi.mocked(mockCircleRepository.findById).mockResolvedValue(
+      createCircle({
+        id: circleId("circle-1"),
+        name: "将棋研究会",
+        sessionEmailNotificationEnabled: false,
+      }),
+    );
+
+    vi.mocked(mockCircleRepository.listMembershipsByCircleId).mockResolvedValue(
+      [makeMembership("user-1"), makeMembership("user-2")],
+    );
+    vi.mocked(mockUserRepository.findByIds).mockResolvedValue([
+      makeUser("user-2", "user2@example.com"),
+    ]);
+
+    await service.notifySessionCreated(session, circleName, actorId);
+
+    expect(mockEmailSender.send).not.toHaveBeenCalled();
+    expect(mockCircleRepository.listMembershipsByCircleId).not.toHaveBeenCalled();
   });
 
   test("BASE_URL が設定されている場合、メール本文に配信停止リンクが含まれる", async () => {

--- a/server/application/notification/notification-service.ts
+++ b/server/application/notification/notification-service.ts
@@ -22,6 +22,9 @@ export const createNotificationService = (deps: NotificationServiceDeps) => {
       circleName: string,
       actorId: string,
     ): Promise<void> {
+      const circle = await deps.circleRepository.findById(session.circleId);
+      if (!circle || !circle.sessionEmailNotificationEnabled) return;
+
       const memberships =
         await deps.circleRepository.listMembershipsByCircleId(
           session.circleId,

--- a/server/application/user/user-statistics-service.test.ts
+++ b/server/application/user/user-statistics-service.test.ts
@@ -44,7 +44,7 @@ let matchCounter = 0;
 
 const ensureCircle = (cId: ReturnType<typeof circleId>, name: string) => {
   if (!circleStore.has(cId)) {
-    circleStore.set(cId, { id: cId, name, createdAt: new Date() });
+    circleStore.set(cId, { id: cId, name, createdAt: new Date(), sessionEmailNotificationEnabled: true });
   }
   const csId = circleSessionId(`session-for-${cId}`);
   if (!circleSessionStore.has(csId)) {
@@ -98,7 +98,7 @@ const addMatch = (
   if (!circleSessionStore.has(csId)) {
     const cId = circleId("default-circle");
     if (!circleStore.has(cId)) {
-      circleStore.set(cId, { id: cId, name: "Default", createdAt: new Date() });
+      circleStore.set(cId, { id: cId, name: "Default", createdAt: new Date(), sessionEmailNotificationEnabled: true });
     }
     circleSessionStore.set(csId, {
       id: csId,

--- a/server/domain/models/circle/circle.ts
+++ b/server/domain/models/circle/circle.ts
@@ -10,12 +10,14 @@ export type Circle = {
   id: CircleId;
   name: string;
   createdAt: Date;
+  sessionEmailNotificationEnabled: boolean;
 };
 
 export type CircleCreateParams = {
   id: CircleId;
   name: string;
   createdAt?: Date;
+  sessionEmailNotificationEnabled?: boolean;
 };
 
 export const createCircle = (params: CircleCreateParams): Circle => ({
@@ -26,6 +28,8 @@ export const createCircle = (params: CircleCreateParams): Circle => ({
     "Circle name",
   ),
   createdAt: params.createdAt ?? new Date(),
+  sessionEmailNotificationEnabled:
+    params.sessionEmailNotificationEnabled ?? true,
 });
 
 export const renameCircle = (circle: Circle, name: string): Circle => ({

--- a/server/infrastructure/mappers/circle-mapper.test.ts
+++ b/server/infrastructure/mappers/circle-mapper.test.ts
@@ -13,6 +13,7 @@ describe("Circle マッパー", () => {
       id: "circle-1",
       name: "Home",
       createdAt: new Date("2024-01-01T00:00:00Z"),
+      sessionEmailNotificationEnabled: true,
     };
 
     const circle = mapCircleToDomain(prismaCircle);
@@ -35,6 +36,7 @@ describe("Circle マッパー", () => {
       id: "circle-1",
       name: "Home",
       createdAt: new Date("2024-01-01T00:00:00Z"),
+      sessionEmailNotificationEnabled: true,
     });
   });
 });

--- a/server/infrastructure/mappers/circle-mapper.ts
+++ b/server/infrastructure/mappers/circle-mapper.ts
@@ -9,10 +9,12 @@ export const mapCircleToDomain = (circle: PrismaCircle): Circle =>
     id: circleId(circle.id),
     name: circle.name,
     createdAt: circle.createdAt,
+    sessionEmailNotificationEnabled: circle.sessionEmailNotificationEnabled,
   });
 
 export const mapCircleToPersistence = (circle: Circle) => ({
   id: toPersistenceId(circle.id),
   name: circle.name,
   createdAt: circle.createdAt,
+  sessionEmailNotificationEnabled: circle.sessionEmailNotificationEnabled,
 });

--- a/server/infrastructure/repository/circle/prisma-circle-repository.test.ts
+++ b/server/infrastructure/repository/circle/prisma-circle-repository.test.ts
@@ -100,7 +100,10 @@ describe("Prisma Circle リポジトリ", () => {
 
     expect(mockedPrisma.circle.upsert).toHaveBeenCalledWith({
       where: { id: data.id },
-      update: { name: data.name },
+      update: {
+        name: data.name,
+        sessionEmailNotificationEnabled: data.sessionEmailNotificationEnabled,
+      },
       create: data,
     });
   });

--- a/server/infrastructure/repository/circle/prisma-circle-repository.ts
+++ b/server/infrastructure/repository/circle/prisma-circle-repository.ts
@@ -53,6 +53,7 @@ export const createPrismaCircleRepository = (
       where: { id: data.id },
       update: {
         name: data.name,
+        sessionEmailNotificationEnabled: data.sessionEmailNotificationEnabled,
       },
       create: data,
     });

--- a/server/presentation/dto/circle.ts
+++ b/server/presentation/dto/circle.ts
@@ -7,6 +7,7 @@ export const circleDtoSchema = z.object({
   id: circleIdSchema,
   name: z.string().trim().min(1),
   createdAt: z.date(),
+  sessionEmailNotificationEnabled: z.boolean(),
 });
 
 export type CircleDto = z.infer<typeof circleDtoSchema>;
@@ -41,3 +42,12 @@ export const circleDeleteInputSchema = z.object({
 });
 
 export type CircleDeleteInput = z.infer<typeof circleDeleteInputSchema>;
+
+export const circleUpdateSessionEmailNotificationInputSchema = z.object({
+  circleId: circleIdSchema,
+  enabled: z.boolean(),
+});
+
+export type CircleUpdateSessionEmailNotificationInput = z.infer<
+  typeof circleUpdateSessionEmailNotificationInputSchema
+>;

--- a/server/presentation/providers/circle-overview-provider.test.ts
+++ b/server/presentation/providers/circle-overview-provider.test.ts
@@ -33,6 +33,7 @@ const VALID_CIRCLE = {
   id: CIRCLE_ID,
   name: "テスト研究会",
   createdAt: NOW,
+  sessionEmailNotificationEnabled: true,
 };
 
 const makeCircleMembership = (uid: string, role: CircleRole) => ({
@@ -219,6 +220,50 @@ describe("getCircleOverviewViewModel", () => {
 
       const result = await getCircleOverviewViewModel("circle-1");
       expect(result.canEditNotificationSetting).toBe(false);
+    });
+  });
+
+  describe("sessionEmailNotificationEnabled", () => {
+    test("研究会のメール通知設定がViewModelに反映される", async () => {
+      const memberships = [
+        makeCircleMembership("viewer-1", CircleRole.CircleOwner),
+      ];
+      mockDeps.circleRepository.listMembershipsByCircleId.mockResolvedValue(
+        memberships,
+      );
+      mockDeps.userRepository.findByIds.mockResolvedValue([
+        makeUser("viewer-1", "オーナー"),
+      ]);
+      mockDeps.authzRepository.findCircleMembership.mockResolvedValue({
+        kind: "member" as const,
+        role: CircleRole.CircleOwner,
+      });
+
+      const result = await getCircleOverviewViewModel("circle-1");
+      expect(result.sessionEmailNotificationEnabled).toBe(true);
+    });
+
+    test("研究会のメール通知設定がfalseの場合、ViewModelにfalseが反映される", async () => {
+      mockDeps.circleRepository.findById.mockResolvedValue({
+        ...VALID_CIRCLE,
+        sessionEmailNotificationEnabled: false,
+      });
+      const memberships = [
+        makeCircleMembership("viewer-1", CircleRole.CircleOwner),
+      ];
+      mockDeps.circleRepository.listMembershipsByCircleId.mockResolvedValue(
+        memberships,
+      );
+      mockDeps.userRepository.findByIds.mockResolvedValue([
+        makeUser("viewer-1", "オーナー"),
+      ]);
+      mockDeps.authzRepository.findCircleMembership.mockResolvedValue({
+        kind: "member" as const,
+        role: CircleRole.CircleOwner,
+      });
+
+      const result = await getCircleOverviewViewModel("circle-1");
+      expect(result.sessionEmailNotificationEnabled).toBe(false);
     });
   });
 

--- a/server/presentation/providers/circle-overview-provider.ts
+++ b/server/presentation/providers/circle-overview-provider.ts
@@ -156,6 +156,7 @@ export async function getCircleOverviewViewModel(
     canTransferOwnership,
     canEditNotificationSetting:
       viewerRole === "owner" || viewerRole === "manager",
+    sessionEmailNotificationEnabled: circle.sessionEmailNotificationEnabled,
     viewerUserId: viewerId,
   };
 

--- a/server/presentation/providers/circle-session-detail-provider.test.ts
+++ b/server/presentation/providers/circle-session-detail-provider.test.ts
@@ -51,6 +51,7 @@ const VALID_CIRCLE = {
   id: CIRCLE_ID,
   name: "テスト研究会",
   createdAt: NOW,
+  sessionEmailNotificationEnabled: true,
 };
 
 const makeSessionMembership = (uid: string, role: CircleSessionRole) => ({

--- a/server/presentation/providers/invite-link-provider.test.ts
+++ b/server/presentation/providers/invite-link-provider.test.ts
@@ -48,6 +48,7 @@ const VALID_CIRCLE = {
   id: CIRCLE_ID,
   name: "テスト研究会",
   createdAt: new Date("2025-01-01T00:00:00Z"),
+  sessionEmailNotificationEnabled: true,
 };
 
 describe("getInviteLinkPageData", () => {

--- a/server/presentation/trpc/router.test.ts
+++ b/server/presentation/trpc/router.test.ts
@@ -17,6 +17,7 @@ const createContext = () => {
     createCircle: vi.fn(),
     renameCircle: vi.fn(),
     deleteCircle: vi.fn(),
+    updateSessionEmailNotificationEnabled: vi.fn(),
   };
   const circleMembershipService = {
     listByCircleId: vi.fn(),
@@ -112,6 +113,7 @@ describe("tRPC router", () => {
       id: circleId("circle-1"),
       name: "Test Circle",
       createdAt: new Date("2025-01-01T00:00:00Z"),
+      sessionEmailNotificationEnabled: true,
     });
 
     const caller = appRouter.createCaller(context);
@@ -224,6 +226,7 @@ describe("tRPC router", () => {
       id: circleId("circle-1"),
       name: "Renamed Circle",
       createdAt: new Date("2025-01-01T00:00:00Z"),
+      sessionEmailNotificationEnabled: true,
     });
 
     const caller = appRouter.createCaller(context);
@@ -518,6 +521,7 @@ describe("tRPC router", () => {
       id: circleId("circle-new"),
       name: "新しい研究会",
       createdAt: new Date("2025-01-01T00:00:00Z"),
+      sessionEmailNotificationEnabled: true,
     });
 
     const caller = appRouter.createCaller(context);

--- a/server/presentation/trpc/routers/circle-invite-link.test.ts
+++ b/server/presentation/trpc/routers/circle-invite-link.test.ts
@@ -25,6 +25,7 @@ const createTestContext = () => {
       createCircle: vi.fn(),
       renameCircle: vi.fn(),
       deleteCircle: vi.fn(),
+      updateSessionEmailNotificationEnabled: vi.fn(),
     },
     circleMembershipService: {
       listByCircleId: vi.fn(),

--- a/server/presentation/trpc/routers/circle-session.test.ts
+++ b/server/presentation/trpc/routers/circle-session.test.ts
@@ -24,6 +24,7 @@ const createTestContext = (
       createCircle: vi.fn(),
       renameCircle: vi.fn(),
       deleteCircle: vi.fn(),
+      updateSessionEmailNotificationEnabled: vi.fn(),
     },
     circleMembershipService: {
       listByCircleId: vi.fn(),

--- a/server/presentation/trpc/routers/circle.test.ts
+++ b/server/presentation/trpc/routers/circle.test.ts
@@ -1,0 +1,102 @@
+import { beforeEach, describe, expect, test, vi } from "vitest";
+import { appRouter } from "@/server/presentation/trpc/router";
+import type { Context } from "@/server/presentation/trpc/context";
+import { userId } from "@/server/domain/common/ids";
+import { ForbiddenError } from "@/server/domain/common/errors";
+
+const createTestContext = (
+  actorIdValue: ReturnType<typeof userId> | null = userId("user-1"),
+) => {
+  const circleService = {
+    getCircle: vi.fn(),
+    createCircle: vi.fn(),
+    renameCircle: vi.fn(),
+    deleteCircle: vi.fn(),
+    updateSessionEmailNotificationEnabled: vi.fn(),
+  };
+
+  const context: Context = {
+    actorId: actorIdValue,
+    clientIp: "1.2.3.4",
+    circleService,
+    circleMembershipService: {
+      listByCircleId: vi.fn(),
+      listByUserId: vi.fn(),
+      addMembership: vi.fn(),
+      changeMembershipRole: vi.fn(),
+      withdrawMembership: vi.fn(),
+      removeMembership: vi.fn(),
+      transferOwnership: vi.fn(),
+    },
+    circleSessionService: {} as Context["circleSessionService"],
+    circleSessionMembershipService:
+      {} as Context["circleSessionMembershipService"],
+    matchService: {} as Context["matchService"],
+    userService: {} as Context["userService"],
+    signupService: {} as Context["signupService"],
+    circleInviteLinkService: {} as Context["circleInviteLinkService"],
+    accessService: {} as Context["accessService"],
+    userStatisticsService: {} as Context["userStatisticsService"],
+    roundRobinScheduleService: {} as Context["roundRobinScheduleService"],
+    holidayProvider: {} as Context["holidayProvider"],
+    notificationPreferenceService:
+      {} as Context["notificationPreferenceService"],
+  };
+
+  return { context, mocks: { circleService } };
+};
+
+describe("circles.updateSessionEmailNotification", () => {
+  let ctx: ReturnType<typeof createTestContext>;
+
+  beforeEach(() => {
+    ctx = createTestContext();
+  });
+
+  test("正常に設定を更新できる", async () => {
+    ctx.mocks.circleService.updateSessionEmailNotificationEnabled.mockResolvedValue(
+      undefined,
+    );
+
+    const caller = appRouter.createCaller(ctx.context);
+    await caller.circles.updateSessionEmailNotification({
+      circleId: "circle-1",
+      enabled: false,
+    });
+
+    expect(
+      ctx.mocks.circleService.updateSessionEmailNotificationEnabled,
+    ).toHaveBeenCalledWith(
+      userId("user-1"),
+      expect.anything(),
+      false,
+    );
+  });
+
+  test("未認証ユーザーはUNAUTHORIZEDエラーになる", async () => {
+    const unauthCtx = createTestContext(null);
+    const caller = appRouter.createCaller(unauthCtx.context);
+
+    await expect(
+      caller.circles.updateSessionEmailNotification({
+        circleId: "circle-1",
+        enabled: false,
+      }),
+    ).rejects.toMatchObject({ code: "UNAUTHORIZED" });
+  });
+
+  test("権限のないユーザーはFORBIDDENエラーになる", async () => {
+    ctx.mocks.circleService.updateSessionEmailNotificationEnabled.mockRejectedValue(
+      new ForbiddenError(),
+    );
+
+    const caller = appRouter.createCaller(ctx.context);
+
+    await expect(
+      caller.circles.updateSessionEmailNotification({
+        circleId: "circle-1",
+        enabled: false,
+      }),
+    ).rejects.toMatchObject({ code: "FORBIDDEN" });
+  });
+});

--- a/server/presentation/trpc/routers/circle.ts
+++ b/server/presentation/trpc/routers/circle.ts
@@ -7,6 +7,7 @@ import {
   circleDtoSchema,
   circleGetInputSchema,
   circleRenameInputSchema,
+  circleUpdateSessionEmailNotificationInputSchema,
 } from "@/server/presentation/dto/circle";
 import { circleMembershipRouter } from "@/server/presentation/trpc/routers/circle-membership";
 import { circleInviteLinkRouter } from "@/server/presentation/trpc/routers/circle-invite-link";
@@ -66,6 +67,20 @@ export const circleRouter = router({
     .mutation(({ ctx, input }) =>
       handleTrpcError(async () => {
         await ctx.circleService.deleteCircle(ctx.actorId, input.circleId);
+        return;
+      }),
+    ),
+
+  updateSessionEmailNotification: protectedProcedure
+    .input(circleUpdateSessionEmailNotificationInputSchema)
+    .output(z.void())
+    .mutation(({ ctx, input }) =>
+      handleTrpcError(async () => {
+        await ctx.circleService.updateSessionEmailNotificationEnabled(
+          ctx.actorId,
+          input.circleId,
+          input.enabled,
+        );
         return;
       }),
     ),

--- a/server/presentation/trpc/routers/match.test.ts
+++ b/server/presentation/trpc/routers/match.test.ts
@@ -23,6 +23,7 @@ const createTestContext = (
       createCircle: vi.fn(),
       renameCircle: vi.fn(),
       deleteCircle: vi.fn(),
+      updateSessionEmailNotificationEnabled: vi.fn(),
     },
     circleMembershipService: {
       listByCircleId: vi.fn(),

--- a/server/presentation/trpc/routers/round-robin-schedule.test.ts
+++ b/server/presentation/trpc/routers/round-robin-schedule.test.ts
@@ -36,6 +36,7 @@ const createTestContext = (
       createCircle: vi.fn(),
       renameCircle: vi.fn(),
       deleteCircle: vi.fn(),
+      updateSessionEmailNotificationEnabled: vi.fn(),
     },
     circleMembershipService: {
       listByCircleId: vi.fn(),

--- a/server/presentation/trpc/routers/user-circle-membership.test.ts
+++ b/server/presentation/trpc/routers/user-circle-membership.test.ts
@@ -25,6 +25,7 @@ const createTestContext = (
       createCircle: vi.fn(),
       renameCircle: vi.fn(),
       deleteCircle: vi.fn(),
+      updateSessionEmailNotificationEnabled: vi.fn(),
     },
     circleMembershipService,
     circleSessionService: {

--- a/server/presentation/trpc/routers/user-circle-session-membership.test.ts
+++ b/server/presentation/trpc/routers/user-circle-session-membership.test.ts
@@ -27,6 +27,7 @@ const createTestContext = (
       createCircle: vi.fn(),
       renameCircle: vi.fn(),
       deleteCircle: vi.fn(),
+      updateSessionEmailNotificationEnabled: vi.fn(),
     },
     circleMembershipService: {
       listByCircleId: vi.fn(),

--- a/server/presentation/trpc/routers/user.test.ts
+++ b/server/presentation/trpc/routers/user.test.ts
@@ -28,6 +28,7 @@ const createTestContext = (
       createCircle: vi.fn(),
       renameCircle: vi.fn(),
       deleteCircle: vi.fn(),
+      updateSessionEmailNotificationEnabled: vi.fn(),
     },
     circleMembershipService: {
       listByCircleId: vi.fn(),

--- a/server/presentation/view-models/circle-overview.ts
+++ b/server/presentation/view-models/circle-overview.ts
@@ -34,5 +34,6 @@ export type CircleOverviewViewModel = {
   canRenameCircle: boolean;
   canTransferOwnership: boolean;
   canEditNotificationSetting: boolean;
+  sessionEmailNotificationEnabled: boolean;
   viewerUserId: string | null;
 };


### PR DESCRIPTION
## Summary

Closes #956

- Circleモデルに `sessionEmailNotificationEnabled` フラグを追加し、Prismaマイグレーションを作成
- `NotificationService.notifySessionCreated()` で研究会設定を参照し、無効時はメール送信をスキップ
- tRPCミューテーション `circle.updateSessionEmailNotificationEnabled` を追加（CircleOwner/Manager のみ更新可能）
- #955 で作成したフロントエンドのダミー実装を実APIに差し替え

## Test plan

- [x] 全1198テスト合格、TypeScriptコンパイルエラーなし
- [ ] 研究会概要ページでOwner/Managerロールで通知トグルが表示されることを確認
- [ ] トグルON/OFF後、リロードで設定が保持されることを確認
- [ ] CircleMemberロールではトグルが表示されないことを確認
- [ ] 通知OFF時にセッション作成してもメール通知が送信されないことを確認
- [ ] 通知ONに戻してセッション作成し、メール通知が送信されることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)