### PR TITLE
refactor: プロバイダー境界でcircleIdにbranded type変換を適用

### DIFF
--- a/server/presentation/providers/circle-overview-provider.ts
+++ b/server/presentation/providers/circle-overview-provider.ts
@@ -1,4 +1,5 @@
 import { formatDateTimeRange } from "@/lib/date-utils";
+import { toCircleId } from "@/server/domain/common/ids";
 import { CircleRole } from "@/server/domain/models/circle/circle-role";
 import { NotFoundError } from "@/server/domain/common/errors";
 import { UNKNOWN_USER_NAME } from "@/server/presentation/constants";
@@ -42,8 +43,9 @@ const getViewerRole = (
 };
 
 export async function getCircleOverviewViewModel(
-  circleId: string,
+  rawCircleId: string,
 ): Promise<CircleOverviewViewModel> {
+  const circleId = toCircleId(rawCircleId);
   const ctx = await createContext();
   const caller = appRouter.createCaller(ctx);
 

--- a/server/presentation/providers/circle-settings-provider.ts
+++ b/server/presentation/providers/circle-settings-provider.ts
@@ -1,3 +1,4 @@
+import { toCircleId } from "@/server/domain/common/ids";
 import { CircleRole } from "@/server/domain/models/circle/circle-role";
 import { NotFoundError } from "@/server/domain/common/errors";
 import { UNKNOWN_USER_NAME } from "@/server/presentation/constants";
@@ -13,8 +14,9 @@ const roleKeyByDto: Record<CircleRole, CircleRoleKey> = {
 };
 
 export async function getCircleSettingsViewModel(
-  circleId: string,
+  rawCircleId: string,
 ): Promise<CircleSettingsViewModel | null> {
+  const circleId = toCircleId(rawCircleId);
   const ctx = await createContext();
   const viewerId = ctx.actorId ?? null;
 


### PR DESCRIPTION
## Summary

- `circle-overview-provider.ts` と `circle-settings-provider.ts` のプロバイダー関数入口で、raw string パラメータを `toCircleId()` で `CircleId` branded type に変換
- パラメータ名を `circleId` → `rawCircleId` にリネームし、外部境界からの未変換値であることを明示

Closes #965

## Test plan

- [x] `tsc --noEmit` 型チェック通過
- [x] `circle-overview-provider.test.ts` 3テスト通過
- [x] `circle-settings-provider.test.ts` 5テスト通過

🤖 Generated with [Claude Code](https://claude.com/claude-code)