### PR TITLE
test: 未認証ユーザーパスのプロバイダーテストを追加 (#964)

### DIFF
--- a/server/presentation/providers/circle-overview-provider.test.ts
+++ b/server/presentation/providers/circle-overview-provider.test.ts
@@ -17,11 +17,12 @@ const VIEWER_ID = toUserId("viewer-1");
 const NOW = new Date("2025-01-01T00:00:00Z");
 
 let mockDeps: MockDeps;
+let actorId: ReturnType<typeof toUserId> | null = VIEWER_ID;
 
 vi.mock("@/server/presentation/trpc/context", () => ({
   createContext: () => {
     const services = createServiceContainer(toServiceContainerDeps(mockDeps));
-    return Promise.resolve({ actorId: VIEWER_ID, ...services });
+    return Promise.resolve({ actorId, ...services });
   },
 }));
 
@@ -56,6 +57,7 @@ const makeUser = (uid: string, name: string) => ({
 describe("getCircleOverviewViewModel", () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    actorId = VIEWER_ID;
     mockDeps = createMockDeps();
 
     // Circle exists
@@ -158,6 +160,18 @@ describe("getCircleOverviewViewModel", () => {
       await expect(
         getCircleOverviewViewModel("circle-1"),
       ).rejects.toMatchObject({ code: "FORBIDDEN" });
+    });
+
+    test("未認証ユーザーが研究会詳細を取得するとUNAUTHORIZEDエラーになる", async () => {
+      actorId = null;
+
+      await expect(
+        getCircleOverviewViewModel("circle-1"),
+      ).rejects.toThrow(TRPCError);
+
+      await expect(
+        getCircleOverviewViewModel("circle-1"),
+      ).rejects.toMatchObject({ code: "UNAUTHORIZED" });
     });
   });
 });

--- a/server/presentation/providers/circle-session-detail-provider.test.ts
+++ b/server/presentation/providers/circle-session-detail-provider.test.ts
@@ -24,11 +24,12 @@ const VIEWER_ID = toUserId("viewer-1");
 const NOW = new Date("2025-01-01T00:00:00Z");
 
 let mockDeps: MockDeps;
+let actorId: ReturnType<typeof toUserId> | null = VIEWER_ID;
 
 vi.mock("@/server/presentation/trpc/context", () => ({
   createContext: () => {
     const services = createServiceContainer(toServiceContainerDeps(mockDeps));
-    return Promise.resolve({ actorId: VIEWER_ID, ...services });
+    return Promise.resolve({ actorId, ...services });
   },
 }));
 
@@ -74,6 +75,7 @@ const makeUser = (uid: string, name: string) => ({
 describe("getCircleSessionDetailViewModel", () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    actorId = VIEWER_ID;
     mockDeps = createMockDeps();
 
     // Session exists
@@ -200,6 +202,18 @@ describe("getCircleSessionDetailViewModel", () => {
       await expect(
         getCircleSessionDetailViewModel("session-1"),
       ).rejects.toMatchObject({ code: "FORBIDDEN" });
+    });
+
+    test("未認証ユーザーがセッション詳細を取得するとUNAUTHORIZEDエラーになる", async () => {
+      actorId = null;
+
+      await expect(
+        getCircleSessionDetailViewModel("session-1"),
+      ).rejects.toThrow(TRPCError);
+
+      await expect(
+        getCircleSessionDetailViewModel("session-1"),
+      ).rejects.toMatchObject({ code: "UNAUTHORIZED" });
     });
   });
 });

--- a/server/presentation/providers/circle-settings-provider.test.ts
+++ b/server/presentation/providers/circle-settings-provider.test.ts
@@ -16,11 +16,12 @@ const VIEWER_ID = toUserId("viewer-1");
 const NOW = new Date("2025-01-01T00:00:00Z");
 
 let mockDeps: MockDeps;
+let actorId: ReturnType<typeof toUserId> | null = VIEWER_ID;
 
 vi.mock("@/server/presentation/trpc/context", () => ({
   createContext: () => {
     const services = createServiceContainer(toServiceContainerDeps(mockDeps));
-    return Promise.resolve({ actorId: VIEWER_ID, ...services });
+    return Promise.resolve({ actorId, ...services });
   },
 }));
 
@@ -55,6 +56,7 @@ const makeUser = (uid: string, name: string) => ({
 describe("getCircleSettingsViewModel", () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    actorId = VIEWER_ID;
     mockDeps = createMockDeps();
 
     mockDeps.circleRepository.findById.mockResolvedValue(VALID_CIRCLE);
@@ -86,6 +88,14 @@ describe("getCircleSettingsViewModel", () => {
 
   test("認可ゲート: 非メンバーにはnullを返す", async () => {
     // findCircleMembership のデフォルトは { kind: "none" }
+    const result = await getCircleSettingsViewModel("circle-1");
+
+    expect(result).toBeNull();
+  });
+
+  test("認可ゲート: 未認証ユーザーにはnullを返す", async () => {
+    actorId = null;
+
     const result = await getCircleSettingsViewModel("circle-1");
 
     expect(result).toBeNull();


### PR DESCRIPTION
## Summary

- プロバイダーテストで未認証ユーザー（`actorId: null`）パスをカバー
- `actorId` を mutable 変数化し、テストごとにオーバーライド可能に変更
- 対象: `circle-overview-provider`, `circle-session-detail-provider`, `circle-settings-provider`

## 変更内容

| ファイル | 追加テスト |
|---|---|
| `circle-overview-provider.test.ts` | 未認証 → `UNAUTHORIZED` エラー |
| `circle-session-detail-provider.test.ts` | 未認証 → `UNAUTHORIZED` エラー |
| `circle-settings-provider.test.ts` | 未認証 → `null` を返す |

## Test plan

- [ ] `npx vitest run server/presentation/providers/circle-overview-provider.test.ts`
- [ ] `npx vitest run server/presentation/providers/circle-session-detail-provider.test.ts`
- [ ] `npx vitest run server/presentation/providers/circle-settings-provider.test.ts`

Closes #964

🤖 Generated with [Claude Code](https://claude.com/claude-code)