### PR TITLE
refactor: toLocalDateString を lib/date-utils に移動 (#857)

### DIFF
--- a/app/(authenticated)/circles/components/circle-overview-calendar.tsx
+++ b/app/(authenticated)/circles/components/circle-overview-calendar.tsx
@@ -3,8 +3,8 @@
 import {
   SessionCalendar,
   type SessionExtendedProps,
-  toLocalDateString,
 } from "@/components/calendar/session-calendar";
+import { toLocalDateString } from "@/lib/date-utils";
 import { Button } from "@/components/ui/button";
 import type { CircleOverviewSession } from "@/server/presentation/view-models/circle-overview";
 import type { EventInput } from "@fullcalendar/core";

--- a/components/calendar/session-calendar-hover.test.ts
+++ b/components/calendar/session-calendar-hover.test.ts
@@ -1,9 +1,5 @@
 import { describe, expect, it } from "vitest";
-import {
-  buildSessionDates,
-  getDayCellClassNames,
-  toLocalDateString,
-} from "./session-calendar";
+import { buildSessionDates, getDayCellClassNames } from "./session-calendar";
 
 describe("buildSessionDates", () => {
   it("events が undefined → 空 Set を返す", () => {
@@ -120,15 +116,3 @@ describe("getDayCellClassNames", () => {
   });
 });
 
-describe("toLocalDateString", () => {
-  it("Date オブジェクトからローカル日付の YYYY-MM-DD 文字列を返す", () => {
-    // 日中の時刻: タイムゾーンに依存しない
-    const date = new Date(2025, 0, 15, 14, 0);
-    expect(toLocalDateString(date)).toBe("2025-01-15");
-  });
-
-  it("月・日が1桁の場合もゼロ埋めされる", () => {
-    const date = new Date(2025, 2, 5, 10, 0);
-    expect(toLocalDateString(date)).toBe("2025-03-05");
-  });
-});

--- a/components/calendar/session-calendar.tsx
+++ b/components/calendar/session-calendar.tsx
@@ -15,18 +15,11 @@ import {
   TooltipContent,
   TooltipTrigger,
 } from "@/components/ui/tooltip";
-import { formatTooltipDateTime } from "@/lib/date-utils";
+import { formatTooltipDateTime, toLocalDateString } from "@/lib/date-utils";
 import { trpc } from "@/lib/trpc/client";
 import "./session-calendar.css";
 
 const FC_PLUGINS = [dayGridPlugin, interactionPlugin];
-
-export function toLocalDateString(date: Date): string {
-  const y = date.getFullYear();
-  const m = String(date.getMonth() + 1).padStart(2, "0");
-  const d = String(date.getDate()).padStart(2, "0");
-  return `${y}-${m}-${d}`;
-}
 
 export type SessionExtendedProps = {
   startsAt: string | Date;

--- a/lib/date-utils.test.ts
+++ b/lib/date-utils.test.ts
@@ -6,6 +6,7 @@ import {
   formatDateForInput,
   formatDateTimeForInput,
   formatTooltipDateTime,
+  toLocalDateString,
 } from "./date-utils";
 
 describe("formatDate", () => {
@@ -96,6 +97,18 @@ describe("formatDateTimeForInput", () => {
     expect(formatDateTimeForInput(new Date("2025-01-14T15:30:00Z"))).toBe(
       "2025-01-15T00:30",
     );
+  });
+});
+
+describe("toLocalDateString", () => {
+  it("Date オブジェクトからローカル日付の YYYY-MM-DD 文字列を返す", () => {
+    const date = new Date(2025, 0, 15, 14, 0);
+    expect(toLocalDateString(date)).toBe("2025-01-15");
+  });
+
+  it("月・日が1桁の場合もゼロ埋めされる", () => {
+    const date = new Date(2025, 2, 5, 10, 0);
+    expect(toLocalDateString(date)).toBe("2025-03-05");
   });
 });
 

--- a/lib/date-utils.ts
+++ b/lib/date-utils.ts
@@ -32,6 +32,13 @@ export const formatDateTimeForInput = (date: Date) => {
   return `${formatDateForInput(date)}T${timePart}`;
 };
 
+export function toLocalDateString(date: Date): string {
+  const y = date.getFullYear();
+  const m = String(date.getMonth() + 1).padStart(2, "0");
+  const d = String(date.getDate()).padStart(2, "0");
+  return `${y}-${m}-${d}`;
+}
+
 export function formatTooltipDateTime(
   startsAt: string | Date,
   endsAt: string | Date,


### PR DESCRIPTION
## Summary

- `toLocalDateString` を `components/calendar/session-calendar.tsx` から `lib/date-utils.ts` に移動
- 全インポートパス（`circle-overview-calendar.tsx`, `session-calendar-hover.test.ts`）を更新
- テストも `lib/date-utils.test.ts` に移動し、カバレッジを維持

Closes #857

## Test plan

- [x] `lib/date-utils.test.ts`: 22 tests passed（toLocalDateString の 2 テストケースを含む）
- [x] `components/calendar/session-calendar-hover.test.ts`: 12 tests passed
- [ ] 旧パスからの `toLocalDateString` インポートが存在しないことを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)