### PR TITLE
feat: signup 429レスポンスに Retry-After ヘッダーを追加

### DIFF
--- a/app/api/auth/signup/route.test.ts
+++ b/app/api/auth/signup/route.test.ts
@@ -126,6 +126,7 @@ describe("POST /api/auth/signup", () => {
 
     const res = await postJson(validBody);
     expect(res.status).toBe(429);
+    expect(res.headers.get("Retry-After")).toBe("45");
     const body = await res.json();
     expect(body.message).toContain("リクエストが多すぎます");
     expect(mockCheck).toHaveBeenCalledWith("1.2.3.4");

--- a/app/api/auth/signup/route.ts
+++ b/app/api/auth/signup/route.ts
@@ -24,7 +24,12 @@ export async function POST(request: Request) {
     if (e instanceof TooManyRequestsError) {
       return NextResponse.json(
         { message: "リクエストが多すぎます。しばらくしてからお試しください。" },
-        { status: 429 },
+        {
+          status: 429,
+          headers: {
+            "Retry-After": Math.max(1, Math.ceil(e.retryAfterMs / 1000)).toString(),
+          },
+        },
       );
     }
     throw e;


### PR DESCRIPTION
Closes #870

## Summary

- signup エンドポイントの 429 レスポンスに RFC 6585 準拠の `Retry-After` ヘッダーを追加
- `TooManyRequestsError.retryAfterMs` を delta-seconds 形式に変換し、`Math.max(1, ...)` で最小1秒を保証
- テストで `Retry-After: "45"` の検証を追加

## Changed files

- `app/api/auth/signup/route.ts` — 429 レスポンスに `Retry-After` ヘッダーを付与
- `app/api/auth/signup/route.test.ts` — ヘッダー値の検証を追加

## Verification

- [x] `npx vitest run app/api/auth/signup/route.test.ts` — 全8テスト合格
- [x] セキュリティ確認済み（ヘッダーインジェクション・情報漏洩リスクなし）

## Follow-up

- #970 エッジケーステスト（sub-second, 0, 負値）を追加

🤖 Generated with [Claude Code](https://claude.com/claude-code)