### PR TITLE
test: Retry-After ヘッダーのエッジケーステストを追加 (#970)

### DIFF
--- a/app/api/auth/signup/route.test.ts
+++ b/app/api/auth/signup/route.test.ts
@@ -132,6 +132,30 @@ describe("POST /api/auth/signup", () => {
     expect(mockCheck).toHaveBeenCalledWith("1.2.3.4");
   });
 
+  test("レート制限のRetry-Afterはsub-secondでも最小1秒になる", async () => {
+    mockCheck.mockRejectedValueOnce(new TooManyRequestsError(500));
+
+    const res = await postJson(validBody);
+    expect(res.status).toBe(429);
+    expect(res.headers.get("Retry-After")).toBe("1");
+  });
+
+  test("レート制限のRetry-Afterはゼロでも最小1秒になる", async () => {
+    mockCheck.mockRejectedValueOnce(new TooManyRequestsError(0));
+
+    const res = await postJson(validBody);
+    expect(res.status).toBe(429);
+    expect(res.headers.get("Retry-After")).toBe("1");
+  });
+
+  test("レート制限のRetry-Afterは負値でも最小1秒になる", async () => {
+    mockCheck.mockRejectedValueOnce(new TooManyRequestsError(-1000));
+
+    const res = await postJson(validBody);
+    expect(res.status).toBe(429);
+    expect(res.headers.get("Retry-After")).toBe("1");
+  });
+
   test("正常リクエスト後にrecordAttemptが呼ばれる", async () => {
     await postJson(validBody);
     expect(mockRecordFailure).toHaveBeenCalledWith("1.2.3.4");


### PR DESCRIPTION
## Summary

- Retry-After ヘッダーのエッジケーステスト3件を追加
  - `retryAfterMs: 500`（sub-second）→ `"1"`（切り上げ）
  - `retryAfterMs: 0` → `"1"`（最小値クランプ）
  - `retryAfterMs: -1000`（負値）→ `"1"`（最小値クランプ）

Closes #970

## Test plan

- [ ] `npx vitest run app/api/auth/signup/route.test.ts` → 全11テストがパス
- [ ] 変更が `app/api/auth/signup/route.test.ts` のみであること

🤖 Generated with [Claude Code](https://claude.com/claude-code)