### PR TITLE
test: validateContactFormUrl にセキュリティエッジケーステストを追加

### DIFF
--- a/lib/url.test.ts
+++ b/lib/url.test.ts
@@ -177,4 +177,26 @@ describe("validateContactFormUrl", () => {
   it("空文字は undefined を返す", () => {
     expect(validateContactFormUrl("")).toBeUndefined();
   });
+
+  describe("セキュリティエッジケース", () => {
+    it("userinfo を使ったドメインバイパスを拒否する", () => {
+      expect(
+        validateContactFormUrl("https://docs.google.com@evil.com/forms/d/xxx"),
+      ).toBeUndefined();
+    });
+
+    it("パストラバーサルを含む URL はプレフィックスマッチによりそのまま返す", () => {
+      expect(
+        validateContactFormUrl("https://docs.google.com/forms/../../other"),
+      ).toBe("https://docs.google.com/forms/../../other");
+    });
+
+    it("null バイトを含む URL はプレフィックスマッチによりそのまま返す", () => {
+      expect(
+        validateContactFormUrl(
+          "https://docs.google.com/forms/\0javascript:alert(1)",
+        ),
+      ).toBe("https://docs.google.com/forms/\0javascript:alert(1)");
+    });
+  });
 });


### PR DESCRIPTION
## Summary

- `validateContactFormUrl` に セキュリティエッジケースのテストを3件追加 (#891)
  - userinfo バイパス (`@evil.com`) → 正しく `undefined` を返すことを確認
  - パストラバーサル (`../../other`) → 現行動作を文書化
  - null バイト (`\0javascript:alert(1)`) → 現行動作を文書化

## Test plan

- [ ] `npx vitest run lib/url.test.ts` → 全37テストパス

## Related

- Closes #891
- Follow-up: #973 (`URL` コンストラクタベースへの移行)

🤖 Generated with [Claude Code](https://claude.com/claude-code)