### PR TITLE
feat: validateContactFormUrl を URL コンストラクタベースに移行

### DIFF
--- a/lib/url.test.ts
+++ b/lib/url.test.ts
@@ -185,18 +185,38 @@ describe("validateContactFormUrl", () => {
       ).toBeUndefined();
     });
 
-    it("パストラバーサルを含む URL はプレフィックスマッチによりそのまま返す", () => {
+    it("パストラバーサルを含む URL は正規化により /forms/ 外になるため拒否する", () => {
       expect(
         validateContactFormUrl("https://docs.google.com/forms/../../other"),
-      ).toBe("https://docs.google.com/forms/../../other");
+      ).toBeUndefined();
     });
 
-    it("null バイトを含む URL はプレフィックスマッチによりそのまま返す", () => {
+    it("null バイトを含む URL は拒否する", () => {
       expect(
         validateContactFormUrl(
           "https://docs.google.com/forms/\0javascript:alert(1)",
         ),
-      ).toBe("https://docs.google.com/forms/\0javascript:alert(1)");
+      ).toBeUndefined();
+    });
+
+    it("http:// プロトコルは拒否する", () => {
+      expect(
+        validateContactFormUrl("http://docs.google.com/forms/d/e/xxx/viewform"),
+      ).toBeUndefined();
+    });
+
+    it("正規化済み URL を返す", () => {
+      const input = "https://docs.google.com/forms/d/e/xxx/viewform";
+      const result = validateContactFormUrl(input);
+      expect(result).toBe(new URL(input).href);
+    });
+
+    it("フラグメント付き URL は正規化されて返る", () => {
+      expect(
+        validateContactFormUrl(
+          "https://docs.google.com/forms/d/e/xxx/viewform#section",
+        ),
+      ).toBe("https://docs.google.com/forms/d/e/xxx/viewform#section");
     });
   });
 });

--- a/lib/url.ts
+++ b/lib/url.ts
@@ -55,10 +55,25 @@ export function sanitizeCallbackUrl(url: string | undefined): string {
   return DEFAULT_CALLBACK;
 }
 
-const GOOGLE_FORMS_URL_PATTERN = /^https:\/\/docs\.google\.com\/forms\//;
-
 export function validateContactFormUrl(
   raw: string | undefined,
 ): string | undefined {
-  return raw && GOOGLE_FORMS_URL_PATTERN.test(raw) ? raw : undefined;
+  if (!raw) return undefined;
+
+  // Reject null bytes before parsing (URL constructor silently strips them)
+  if (raw.includes("\0")) return undefined;
+
+  let parsed: URL;
+  try {
+    parsed = new URL(raw);
+  } catch {
+    return undefined;
+  }
+
+  if (parsed.protocol !== "https:") return undefined;
+  if (parsed.hostname !== "docs.google.com") return undefined;
+  if (!parsed.pathname.startsWith("/forms/")) return undefined;
+  if (parsed.username !== "" || parsed.password !== "") return undefined;
+
+  return parsed.href;
 }


### PR DESCRIPTION
## Summary

- `validateContactFormUrl` を正規表現ベースから `URL` コンストラクタベースのバリデーションに移行
- パストラバーサル、null バイト、userinfo バイパスを防御
- 返却値を正規化済み URL (`parsed.href`) に変更し、生入力の通過を防止

Closes #973

## Test plan

- [x] `npx vitest run lib/url.test.ts` → 40 tests passed
- [ ] パストラバーサル URL が拒否されることを確認
- [ ] null バイト URL が拒否されることを確認
- [ ] userinfo 付き URL が拒否されることを確認
- [ ] 正当な Google Forms URL が正規化済みで返ることを確認

## Follow-up

- #975: ポート番号の明示的チェック追加（priority: low）

🤖 Generated with [Claude Code](https://claude.com/claude-code)