### PR TITLE
test: signout ページに getCsrfToken undefined テストを追加

### DIFF
--- a/app/auth/signout/page.test.tsx
+++ b/app/auth/signout/page.test.tsx
@@ -1,5 +1,5 @@
 // @vitest-environment jsdom
-import { cleanup, render, screen } from "@testing-library/react";
+import { act, cleanup, render, screen } from "@testing-library/react";
 import { afterEach, describe, expect, it, vi } from "vitest";
 
 import SignOutPage from "./page";
@@ -83,6 +83,28 @@ describe("SignOutPage", () => {
         "トークンの取得に失敗しました。ページを再読み込みしてください。",
       );
       expect(screen.getByRole("button", { name: "ログアウト" })).toBeDisabled();
+    });
+  });
+
+  describe("getCsrfToken が undefined を resolve した場合", () => {
+    it("ログアウトボタンが disabled である", async () => {
+      mockGetCsrfToken.mockResolvedValue(undefined);
+      render(<SignOutPage />);
+      await act(async () => {});
+      expect(
+        screen.getByRole("button", { name: "ログアウト" }),
+      ).toBeDisabled();
+    });
+
+    it("エラーメッセージが表示されない", async () => {
+      mockGetCsrfToken.mockResolvedValue(undefined);
+      render(<SignOutPage />);
+      await act(async () => {});
+      expect(
+        screen.queryByText(
+          "トークンの取得に失敗しました。ページを再読み込みしてください。",
+        ),
+      ).not.toBeInTheDocument();
     });
   });
 


### PR DESCRIPTION
## Summary

- `getCsrfToken` が `undefined` を resolve した場合のテストケースを2件追加
- ボタンが `disabled` になること、エラーメッセージが表示されないことを検証

Closes #683

## Test plan

- [ ] `npx vitest run app/auth/signout/page.test.tsx` で全9テスト PASS を確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)