### PR TITLE
refactor: PermissionRow の権限値を string からユニオン型に変更

### DIFF
--- a/app/(authenticated)/help/page.tsx
+++ b/app/(authenticated)/help/page.tsx
@@ -2,11 +2,13 @@ import { env } from "@/server/env";
 import { validateContactFormUrl } from "@/lib/url";
 import { ExternalLink } from "lucide-react";
 
+type PermissionValue = "○" | "—" | "○ ※";
+
 type PermissionRow = {
   operation: string;
-  owner: string;
-  manager: string;
-  member: string;
+  owner: PermissionValue;
+  manager: PermissionValue;
+  member: PermissionValue;
 };
 
 type PermissionTableConfig = {
@@ -66,7 +68,7 @@ const permissionTables: PermissionTableConfig[] = [
   },
 ];
 
-function renderPermissionCell(value: string, noteId?: string) {
+function renderPermissionCell(value: PermissionValue, noteId?: string) {
   switch (value) {
     case "○ ※":
       return {
@@ -96,8 +98,6 @@ function renderPermissionCell(value: string, noteId?: string) {
           </>
         ),
       };
-    default:
-      return { content: value };
   }
 }
 


### PR DESCRIPTION
## Summary

- `PermissionValue = "○" | "—" | "○ ※"` ユニオン型を導入し、`PermissionRow` の権限値フィールドを `string` から変更
- `renderPermissionCell` の引数型も `PermissionValue` に変更し、exhaustive switch により `default` 分岐を除去

Closes #716

## Test plan

- [x] `npx tsc --noEmit` でコンパイルエラーなし
- [ ] `/help` ページで権限テーブルが正しく表示されること

🤖 Generated with [Claude Code](https://claude.com/claude-code)