### PR TITLE
fix: フォームの onError で isValidationError を処理 (#644)

### DIFF
--- a/app/(authenticated)/account/notification-form.tsx
+++ b/app/(authenticated)/account/notification-form.tsx
@@ -20,6 +20,12 @@ export function NotificationForm({
     },
     onError: (error) => {
       setEmailEnabled((prev) => !prev);
+      if (error.data?.isValidationError) {
+        toast.error(
+          "通知設定の更新に失敗しました。入力内容を確認してください。",
+        );
+        return;
+      }
       toast.error(error.message);
     },
   });

--- a/app/(authenticated)/account/profile-form.tsx
+++ b/app/(authenticated)/account/profile-form.tsx
@@ -29,6 +29,12 @@ export function ProfileFormInner({
       await utils.users.me.invalidate();
     },
     onError: (error) => {
+      if (error.data?.isValidationError) {
+        toast.error(
+          "プロフィールの更新に失敗しました。入力内容を確認してください。",
+        );
+        return;
+      }
       toast.error(error.message);
     },
   });

--- a/app/(authenticated)/account/visibility-form.tsx
+++ b/app/(authenticated)/account/visibility-form.tsx
@@ -20,6 +20,12 @@ export function VisibilityForm({
     },
     onError: (error) => {
       setIsPublic((prev) => !prev);
+      if (error.data?.isValidationError) {
+        toast.error(
+          "設定の更新に失敗しました。入力内容を確認してください。",
+        );
+        return;
+      }
       toast.error(error.message);
     },
   });


### PR DESCRIPTION
## Summary

- profile-form, visibility-form, notification-form の `onError` ハンドラーで `isValidationError` フラグを判定
- バリデーションエラー時に英語の "Validation failed" ではなく、各フォームに適した日本語メッセージを表示
- password-form.tsx の既存パターンに準拠した実装

Closes #644

## Test plan

- [ ] プロフィール編集で不正な値を送信 → 日本語エラーメッセージが表示される
- [ ] 公開設定トグルでバリデーションエラー → トグルがロールバックし日本語メッセージが表示される
- [ ] 通知設定トグルでバリデーションエラー → トグルがロールバックし日本語メッセージが表示される
- [ ] バリデーションエラー以外（ネットワークエラー等）では従来どおり `error.message` が表示される

🤖 Generated with [Claude Code](https://claude.com/claude-code)