### PR TITLE
fix: 権限マトリックステーブルの aria-label と caption の重複アナウンスを解消

### DIFF
--- a/app/(authenticated)/help/page.tsx
+++ b/app/(authenticated)/help/page.tsx
@@ -141,10 +141,12 @@ export default function HelpPage() {
             className="mt-4 overflow-x-auto rounded-md focus:outline-2 focus:outline-offset-2 focus:outline-(--brand-moss)"
             tabIndex={0}
             role="region"
-            aria-label={table.ariaLabel}
+            aria-labelledby={`${table.noteId}-caption`}
           >
             <table className="w-full text-sm text-(--brand-ink-muted)">
-              <caption className="sr-only">{table.ariaLabel}</caption>
+              <caption id={`${table.noteId}-caption`} className="sr-only">
+                {table.ariaLabel}
+              </caption>
               <thead>
                 <tr className="border-b border-border/60 text-left">
                   <th


### PR DESCRIPTION
## Summary

- 権限マトリックステーブルで `<div role="region" aria-label>` と `<caption>` が同一テキストを使用し、スクリーンリーダーが冗長に読み上げる問題を修正
- `aria-label` を `aria-labelledby` に変更し、`<caption>` に `id` を付与して同一 DOM ノードから名前を参照させる方式に統一

Closes #718

## Test plan

- [ ] `/help` ページで権限マトリックステーブルが正常に表示される
- [ ] VoiceOver でランドマーク移動時に region 名が正しく読み上げられる
- [ ] テーブルフォーカス時に同じテキストが2回読み上げられない
- [ ] Tab キーでスクロール可能領域にフォーカスリングが表示される

🤖 Generated with [Claude Code](https://claude.com/claude-code)