### PR TITLE
fix: invite-link/page.tsx に actorId の null チェックを追加 (#473)

### DIFF
--- a/app/(authenticated)/circles/[circleId]/invite-link/page.tsx
+++ b/app/(authenticated)/circles/[circleId]/invite-link/page.tsx
@@ -1,6 +1,6 @@
 import { appRouter } from "@/server/presentation/trpc/router";
 import { createContext } from "@/server/presentation/trpc/context";
-import { notFound } from "next/navigation";
+import { forbidden, notFound } from "next/navigation";
 import Link from "next/link";
 import { ChevronLeft, UserPlus } from "lucide-react";
 import { InviteLinkGenerator } from "./invite-link-generator";
@@ -16,6 +16,9 @@ export default async function InviteLinkPage({ params }: InviteLinkPageProps) {
   }
 
   const ctx = await createContext();
+  if (ctx.actorId === null) {
+    forbidden();
+  }
   const caller = appRouter.createCaller(ctx);
   const circle = await caller.circles.get({ circleId });
   if (!circle) {


### PR DESCRIPTION
## Summary

- `invite-link/page.tsx` の `createContext()` 後、`caller` 生成前に `actorId === null` のガードクロースを追加
- `forbidden()` を呼び出すことで未認証時に 403 を返す defense-in-depth パターンを適用
- `sessions/new/page.tsx` と一貫したパターン

## Test plan

- [x] `npx tsc --noEmit` pass（型チェック通過）
- [ ] `createContext()` 後、`createCaller()` 前にガードが配置されていることをコードレビューで確認
- [ ] `sessions/new/page.tsx` と同一パターンであることを確認

Closes #473

🤖 Generated with [Claude Code](https://claude.com/claude-code)