### PR TITLE
feat: CircleSession.location に文字数制限を追加 (#545)

### DIFF
--- a/app/(authenticated)/circle-sessions/components/circle-session-edit-dialog.tsx
+++ b/app/(authenticated)/circle-sessions/components/circle-session-edit-dialog.tsx
@@ -15,6 +15,7 @@ import { Textarea } from "@/components/ui/textarea";
 import { trimWithFullwidth } from "@/lib/string";
 import { trpc } from "@/lib/trpc/client";
 import {
+  CIRCLE_SESSION_LOCATION_MAX_LENGTH,
   CIRCLE_SESSION_NOTE_MAX_LENGTH,
   CIRCLE_SESSION_TITLE_MAX_LENGTH,
 } from "@/server/domain/models/circle-session/circle-session";
@@ -177,6 +178,7 @@ export function CircleSessionEditDialog({
               value={location}
               onChange={(e) => setLocation(e.target.value)}
               placeholder="例: 将棋会館 3F"
+              maxLength={CIRCLE_SESSION_LOCATION_MAX_LENGTH}
               className="bg-white"
             />
           </div>

--- a/app/(authenticated)/circles/[circleId]/sessions/new/circle-session-create-form.tsx
+++ b/app/(authenticated)/circles/[circleId]/sessions/new/circle-session-create-form.tsx
@@ -9,6 +9,7 @@ import { Textarea } from "@/components/ui/textarea";
 import { trpc } from "@/lib/trpc/client";
 import { trimWithFullwidth } from "@/lib/string";
 import {
+  CIRCLE_SESSION_LOCATION_MAX_LENGTH,
   CIRCLE_SESSION_NOTE_MAX_LENGTH,
   CIRCLE_SESSION_TITLE_MAX_LENGTH,
 } from "@/server/domain/models/circle-session/circle-session";
@@ -180,6 +181,7 @@ export function CircleSessionCreateForm({
             value={location}
             onChange={(e) => setLocation(e.target.value)}
             placeholder="例: 将棋会館 3F"
+            maxLength={CIRCLE_SESSION_LOCATION_MAX_LENGTH}
             className="bg-white"
           />
         </div>

--- a/prisma/migrations/20260308000000_add_varchar_limit_to_circle_session_location/migration.sql
+++ b/prisma/migrations/20260308000000_add_varchar_limit_to_circle_session_location/migration.sql
@@ -1,0 +1,2 @@
+-- AlterTable
+ALTER TABLE "CircleSession" ALTER COLUMN "location" SET DATA TYPE VARCHAR(100);

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -101,7 +101,7 @@ model CircleSession {
   /// 複数日開催も許容
   startsAt DateTime
   endsAt   DateTime
-  location String?
+  location String?  @db.VarChar(100)
   note     String   @default("") @db.VarChar(500)
 
   circle Circle @relation(fields: [circleId], references: [id], onDelete: Cascade)

--- a/server/application/circle-session/circle-session-service.ts
+++ b/server/application/circle-session/circle-session-service.ts
@@ -3,6 +3,7 @@ import {
   createCircleSession,
   renameCircleSession,
   rescheduleCircleSession,
+  updateCircleSessionLocation,
   updateCircleSessionNote,
 } from "@/server/domain/models/circle-session/circle-session";
 import type { CircleId, CircleSessionId } from "@/server/domain/common/ids";
@@ -167,10 +168,10 @@ export const createCircleSessionService = (deps: CircleSessionServiceDeps) => {
       }
 
       if (params.location !== undefined) {
-        updated = {
-          ...updated,
-          location: params.location ?? null,
-        };
+        updated = updateCircleSessionLocation(
+          updated,
+          params.location ?? null,
+        );
       }
 
       if (params.note !== undefined) {

--- a/server/domain/models/circle-session/circle-session.ts
+++ b/server/domain/models/circle-session/circle-session.ts
@@ -7,6 +7,7 @@ import {
 } from "@/server/domain/common/validation";
 
 export const CIRCLE_SESSION_TITLE_MAX_LENGTH = 100;
+export const CIRCLE_SESSION_LOCATION_MAX_LENGTH = 100;
 export const CIRCLE_SESSION_NOTE_MAX_LENGTH = 500;
 
 export type CircleSession = {
@@ -49,7 +50,13 @@ export const createCircleSession = (
     title,
     startsAt,
     endsAt,
-    location: params.location ?? null,
+    location: params.location
+      ? assertMaxLength(
+          params.location,
+          CIRCLE_SESSION_LOCATION_MAX_LENGTH,
+          "CircleSession location",
+        )
+      : null,
     note: assertMaxLength(
       params.note?.trim() ?? "",
       CIRCLE_SESSION_NOTE_MAX_LENGTH,
@@ -81,6 +88,20 @@ export const updateCircleSessionNote = (
     CIRCLE_SESSION_NOTE_MAX_LENGTH,
     "CircleSession note",
   ),
+});
+
+export const updateCircleSessionLocation = (
+  session: CircleSession,
+  location: string | null,
+): CircleSession => ({
+  ...session,
+  location: location
+    ? assertMaxLength(
+        location,
+        CIRCLE_SESSION_LOCATION_MAX_LENGTH,
+        "CircleSession location",
+      )
+    : null,
 });
 
 export const rescheduleCircleSession = (

--- a/server/presentation/dto/circle-session.ts
+++ b/server/presentation/dto/circle-session.ts
@@ -1,5 +1,6 @@
 import { z } from "zod";
 import {
+  CIRCLE_SESSION_LOCATION_MAX_LENGTH,
   CIRCLE_SESSION_NOTE_MAX_LENGTH,
   CIRCLE_SESSION_TITLE_MAX_LENGTH,
 } from "@/server/domain/models/circle-session/circle-session";
@@ -17,7 +18,7 @@ export const circleSessionDtoSchema = z.object({
   title: z.string().min(1),
   startsAt: z.date(),
   endsAt: z.date(),
-  location: z.string().nullable(),
+  location: z.string().max(CIRCLE_SESSION_LOCATION_MAX_LENGTH).nullable(),
   note: z.string(),
   createdAt: z.date(),
 });
@@ -46,7 +47,7 @@ export const circleSessionCreateInputSchema = z.object({
     .pipe(z.string().min(1).max(CIRCLE_SESSION_TITLE_MAX_LENGTH)),
   startsAt: dateInputSchema,
   endsAt: dateInputSchema,
-  location: z.string().nullable().optional(),
+  location: z.string().max(CIRCLE_SESSION_LOCATION_MAX_LENGTH).nullable().optional(),
   note: z.string().max(CIRCLE_SESSION_NOTE_MAX_LENGTH).optional(),
 });
 
@@ -64,7 +65,7 @@ export const circleSessionUpdateInputSchema = z
       .optional(),
     startsAt: dateInputSchema.optional(),
     endsAt: dateInputSchema.optional(),
-    location: z.string().nullable().optional(),
+    location: z.string().max(CIRCLE_SESSION_LOCATION_MAX_LENGTH).nullable().optional(),
     note: z.string().max(CIRCLE_SESSION_NOTE_MAX_LENGTH).optional(),
   })
   .refine(


### PR DESCRIPTION
## Summary

- `CircleSession.location` に最大100文字の文字数制限を4層（フロントエンド `maxLength`・Zod `.max()`・ドメイン `assertMaxLength`・DB `VarChar(100)`）で追加
- updateパスで欠落していたドメインバリデーションを `updateCircleSessionLocation` 関数として新規追加
- 既存の `title` / `note` と一貫した定数命名・防御パターンを適用

Closes #545

## Test plan

- [ ] セッション作成フォームで location に101文字以上入力できないことを確認
- [ ] セッション編集ダイアログで同様に確認
- [ ] API経由で101文字の location を送信し、Zodバリデーションエラーが返ることを確認
- [ ] 全テスト（1214件）パス済み
- [ ] マイグレーション適用済み

## Follow-up issues

- #986 circleSessionDtoSchema の出力バリデーションを統一する
- #987 createCircleSession の location 最大文字数バリデーションにユニットテストを追加する

🤖 Generated with [Claude Code](https://claude.com/claude-code)