### PR TITLE
refactor: 出力DTOのバリデーションを統一 (#986)

### DIFF
--- a/server/presentation/dto/circle-session.ts
+++ b/server/presentation/dto/circle-session.ts
@@ -18,7 +18,7 @@ export const circleSessionDtoSchema = z.object({
   title: z.string().min(1),
   startsAt: z.date(),
   endsAt: z.date(),
-  location: z.string().max(CIRCLE_SESSION_LOCATION_MAX_LENGTH).nullable(),
+  location: z.string().nullable(),
   note: z.string(),
   createdAt: z.date(),
 });


### PR DESCRIPTION
## Summary

- `circleSessionDtoSchema` の `location` フィールドから `.max(CIRCLE_SESSION_LOCATION_MAX_LENGTH)` を削除
- 出力DTOはDBから取得済みの値を返すため、`.max()` による再検証は不要と判断（方針B）
- `note` フィールドと一貫性のあるスキーマ定義に統一

Closes #986

## Test plan

- [ ] 既存テストが通ることを確認（出力DTOの制約緩和のためリグレッションなし）
- [ ] `circleSessionDtoSchema` で `location` が長い文字列でもパースエラーにならないことを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)