### PR TITLE
refactor: DomainErrorCode → tRPC エラーコードのコンパイル時マッピング検証を追加 (#488)

### DIFF
--- a/server/presentation/trpc/errors.ts
+++ b/server/presentation/trpc/errors.ts
@@ -1,5 +1,18 @@
-import { TRPCError } from "@trpc/server";
-import { DomainError, TooManyRequestsError } from "@/server/domain/common/errors";
+import { TRPCError, type TRPC_ERROR_CODE_KEY } from "@trpc/server";
+import {
+  type DomainErrorCode,
+  DomainError,
+  TooManyRequestsError,
+} from "@/server/domain/common/errors";
+
+const DOMAIN_TO_TRPC_CODE = {
+  NOT_FOUND: "NOT_FOUND",
+  FORBIDDEN: "FORBIDDEN",
+  UNAUTHORIZED: "UNAUTHORIZED",
+  BAD_REQUEST: "BAD_REQUEST",
+  CONFLICT: "CONFLICT",
+  TOO_MANY_REQUESTS: "TOO_MANY_REQUESTS",
+} as const satisfies Record<DomainErrorCode, TRPC_ERROR_CODE_KEY>;
 
 export const toTrpcError = (error: unknown): TRPCError => {
   if (error instanceof TRPCError) {
@@ -18,7 +31,7 @@ export const toTrpcError = (error: unknown): TRPCError => {
   // Do not include dynamic data (IDs, emails, SQL, etc.) in DomainError messages.
   if (error instanceof DomainError) {
     return new TRPCError({
-      code: error.code,
+      code: DOMAIN_TO_TRPC_CODE[error.code],
       message: error.message,
       cause:
         error instanceof TooManyRequestsError


### PR DESCRIPTION
## Summary

- `toTrpcError` の `as` キャストを `satisfies Record<DomainErrorCode, TRPC_ERROR_CODE_KEY>` によるコンパイル時マッピング検証に置き換え
- `DomainErrorCode` に tRPC に存在しない値が追加された場合、コンパイルエラーで即座に検出可能に
- ランタイム挙動の変更なし

Closes #488

## Test plan

- [ ] `tsc --noEmit` がパスすること
- [ ] `vitest run server/presentation/trpc/errors.test.ts` が全パスすること
- [ ] `DomainErrorCode` に無効な値を追加した際にコンパイルエラーが発生すること（手動確認）

🤖 Generated with [Claude Code](https://claude.com/claude-code)