### PR TITLE
test: invite-link-provider に未認証ユーザーのテストケースを追加

### DIFF
--- a/server/presentation/providers/invite-link-provider.test.ts
+++ b/server/presentation/providers/invite-link-provider.test.ts
@@ -75,6 +75,22 @@ describe("getInviteLinkPageData", () => {
     });
   });
 
+  test("未認証ユーザーの場合 isAuthenticated が false を返す", async () => {
+    mockDeps.circleInviteLinkRepository.findByToken.mockResolvedValueOnce(
+      VALID_INVITE_LINK,
+    );
+    mockDeps.circleRepository.findById.mockResolvedValueOnce(VALID_CIRCLE);
+
+    const result = await getInviteLinkPageData(VALID_TOKEN_UUID);
+
+    expect(result).toEqual({
+      circleName: "テスト研究会",
+      circleId: "circle-1",
+      expired: false,
+      isAuthenticated: false,
+    });
+  });
+
   test("NotFoundError の場合 null を返す", async () => {
     // findByToken returns null -> service throws NotFoundError -> tRPC converts to NOT_FOUND
     mockDeps.circleInviteLinkRepository.findByToken.mockResolvedValueOnce(null);


### PR DESCRIPTION
## Summary

- `getInviteLinkPageData` に未認証ユーザー（`actorId = null`）のテストケースを追加
- `isAuthenticated: false` が正しく返されることを検証
- 既存4テストに影響なし（回帰なし）

Closes #371

## Verification

- `npx vitest run server/presentation/providers/invite-link-provider.test.ts` → 5 tests passed
- 新規テスト: "未認証ユーザーの場合 isAuthenticated が false を返す" — pass

## Review points

- 既存の認証済みテストとの対称性（`actorId` 設定の有無のみが差分）
- Provider テストパターン（リポジトリ層モック、実サービス層通過）に準拠

🤖 Generated with [Claude Code](https://claude.com/claude-code)