### PR TITLE
fix: IDファクトリ関数で空白のみの文字列を拒否する (#293)

### DIFF
--- a/server/domain/common/ids.test.ts
+++ b/server/domain/common/ids.test.ts
@@ -6,6 +6,7 @@ import {
   toMatchId,
   toCircleInviteLinkId,
   toInviteLinkToken,
+  toRoundRobinScheduleId,
 } from "./ids";
 import { BadRequestError } from "./errors";
 
@@ -19,6 +20,12 @@ describe("toUserId", () => {
     expect(() => toUserId("")).toThrow(BadRequestError);
     expect(() => toUserId("")).toThrow("Invalid user ID");
   });
+
+  it("空白のみの文字列はBadRequestErrorをスローする", () => {
+    expect(() => toUserId("   ")).toThrow(BadRequestError);
+    expect(() => toUserId("\t")).toThrow(BadRequestError);
+    expect(() => toUserId("\n")).toThrow(BadRequestError);
+  });
 });
 
 describe("toCircleId", () => {
@@ -30,6 +37,12 @@ describe("toCircleId", () => {
   it("should throw BadRequestError for empty string", () => {
     expect(() => toCircleId("")).toThrow(BadRequestError);
     expect(() => toCircleId("")).toThrow("Invalid circle ID");
+  });
+
+  it("空白のみの文字列はBadRequestErrorをスローする", () => {
+    expect(() => toCircleId("   ")).toThrow(BadRequestError);
+    expect(() => toCircleId("\t")).toThrow(BadRequestError);
+    expect(() => toCircleId("\n")).toThrow(BadRequestError);
   });
 });
 
@@ -43,6 +56,12 @@ describe("toCircleSessionId", () => {
     expect(() => toCircleSessionId("")).toThrow(BadRequestError);
     expect(() => toCircleSessionId("")).toThrow("Invalid circle session ID");
   });
+
+  it("空白のみの文字列はBadRequestErrorをスローする", () => {
+    expect(() => toCircleSessionId("   ")).toThrow(BadRequestError);
+    expect(() => toCircleSessionId("\t")).toThrow(BadRequestError);
+    expect(() => toCircleSessionId("\n")).toThrow(BadRequestError);
+  });
 });
 
 describe("toMatchId", () => {
@@ -54,6 +73,12 @@ describe("toMatchId", () => {
   it("should throw BadRequestError for empty string", () => {
     expect(() => toMatchId("")).toThrow(BadRequestError);
     expect(() => toMatchId("")).toThrow("Invalid match ID");
+  });
+
+  it("空白のみの文字列はBadRequestErrorをスローする", () => {
+    expect(() => toMatchId("   ")).toThrow(BadRequestError);
+    expect(() => toMatchId("\t")).toThrow(BadRequestError);
+    expect(() => toMatchId("\n")).toThrow(BadRequestError);
   });
 });
 
@@ -68,6 +93,32 @@ describe("toCircleInviteLinkId", () => {
     expect(() => toCircleInviteLinkId("")).toThrow(
       "Invalid circle invite link ID",
     );
+  });
+
+  it("空白のみの文字列はBadRequestErrorをスローする", () => {
+    expect(() => toCircleInviteLinkId("   ")).toThrow(BadRequestError);
+    expect(() => toCircleInviteLinkId("\t")).toThrow(BadRequestError);
+    expect(() => toCircleInviteLinkId("\n")).toThrow(BadRequestError);
+  });
+});
+
+describe("toRoundRobinScheduleId", () => {
+  it("should return branded RoundRobinScheduleId for valid string", () => {
+    const id = toRoundRobinScheduleId("schedule-123");
+    expect(id).toBe("schedule-123");
+  });
+
+  it("should throw BadRequestError for empty string", () => {
+    expect(() => toRoundRobinScheduleId("")).toThrow(BadRequestError);
+    expect(() => toRoundRobinScheduleId("")).toThrow(
+      "Invalid round robin schedule ID",
+    );
+  });
+
+  it("空白のみの文字列はBadRequestErrorをスローする", () => {
+    expect(() => toRoundRobinScheduleId("   ")).toThrow(BadRequestError);
+    expect(() => toRoundRobinScheduleId("\t")).toThrow(BadRequestError);
+    expect(() => toRoundRobinScheduleId("\n")).toThrow(BadRequestError);
   });
 });
 

--- a/server/domain/common/ids.ts
+++ b/server/domain/common/ids.ts
@@ -11,29 +11,29 @@ export type InviteLinkToken = Brand<string, "InviteLinkToken">;
 export type RoundRobinScheduleId = Brand<string, "RoundRobinScheduleId">;
 
 export const toUserId = (value: string): UserId => {
-  if (!value) throw new BadRequestError("Invalid user ID");
+  if (!value.trim()) throw new BadRequestError("Invalid user ID");
   return value as UserId;
 };
 export const toCircleId = (value: string): CircleId => {
-  if (!value) throw new BadRequestError("Invalid circle ID");
+  if (!value.trim()) throw new BadRequestError("Invalid circle ID");
   return value as CircleId;
 };
 export const toCircleSessionId = (value: string): CircleSessionId => {
-  if (!value) throw new BadRequestError("Invalid circle session ID");
+  if (!value.trim()) throw new BadRequestError("Invalid circle session ID");
   return value as CircleSessionId;
 };
 export const toMatchId = (value: string): MatchId => {
-  if (!value) throw new BadRequestError("Invalid match ID");
+  if (!value.trim()) throw new BadRequestError("Invalid match ID");
   return value as MatchId;
 };
 export const toCircleInviteLinkId = (value: string): CircleInviteLinkId => {
-  if (!value) throw new BadRequestError("Invalid circle invite link ID");
+  if (!value.trim()) throw new BadRequestError("Invalid circle invite link ID");
   return value as CircleInviteLinkId;
 };
 export const toRoundRobinScheduleId = (
   value: string,
 ): RoundRobinScheduleId => {
-  if (!value) throw new BadRequestError("Invalid round robin schedule ID");
+  if (!value.trim()) throw new BadRequestError("Invalid round robin schedule ID");
   return value as RoundRobinScheduleId;
 };
 


### PR DESCRIPTION
## Summary

- IDファクトリ関数（`toUserId`, `toCircleId`, `toCircleSessionId`, `toMatchId`, `toCircleInviteLinkId`, `toRoundRobinScheduleId`）のバリデーションを `!value` から `!value.trim()` に変更
- 空白のみの文字列（スペース・タブ・改行）が `BadRequestError` をスローするように修正
- 全6関数に対応するテストケースを追加（`toRoundRobinScheduleId` は既存テストがなかったため基本テストも追加）

## Test plan

- [x] `npx vitest run server/domain/common/ids.test.ts` → 23テスト全パス
- [ ] 空白のみ文字列でエラーになることを確認
- [ ] `toInviteLinkToken` が変更されていないことを確認（UUID正規表現で既にカバー）

Closes #293

🤖 Generated with [Claude Code](https://claude.com/claude-code)