### PR TITLE
test: THROW_PATTERNを括弧ネスト対応にする

### DIFF
--- a/server/domain/common/errors-static-message.test.ts
+++ b/server/domain/common/errors-static-message.test.ts
@@ -20,7 +20,7 @@ const TARGET_ERROR_CLASSES = [
 ];
 
 const THROW_PATTERN = new RegExp(
-  `throw\\s+new\\s+(${TARGET_ERROR_CLASSES.join("|")})(\\([^)]*\\))`,
+  `throw\\s+new\\s+(${TARGET_ERROR_CLASSES.join("|")})\\(`,
   "gs",
 );
 
@@ -65,6 +65,42 @@ const TOO_MANY_REQUESTS_PATTERNS = [
   /^\(\s*[^"'`),]+,\s*["'][^"']*["']\s*,?\s*\)/,
 ];
 
+function extractArgs(content: string, startIndex: number): string {
+  let depth = 0;
+  let inString: "'" | '"' | "`" | null = null;
+
+  for (let i = startIndex; i < content.length; i++) {
+    const ch = content[i];
+
+    if (inString) {
+      if (ch === "\\") {
+        i++; // skip escaped character
+        continue;
+      }
+      if (ch === inString) {
+        inString = null;
+      }
+      continue;
+    }
+
+    if (ch === '"' || ch === "'" || ch === "`") {
+      inString = ch;
+      continue;
+    }
+
+    if (ch === "(") {
+      depth++;
+    } else if (ch === ")") {
+      depth--;
+      if (depth === 0) {
+        return content.slice(startIndex, i + 1);
+      }
+    }
+  }
+
+  return content.slice(startIndex);
+}
+
 function getLineNumber(content: string, index: number): number {
   return content.slice(0, index).split("\n").length;
 }
@@ -91,14 +127,16 @@ describe("DomainError メッセージの静的検証", () => {
       const content = fs.readFileSync(filePath, "utf-8");
       for (const match of content.matchAll(THROW_PATTERN)) {
         const errorClass = match[1];
-        const argsStr = match[2];
+        const argsStart = match.index! + match[0].length - 1; // position of '('
+        const argsStr = extractArgs(content, argsStart);
 
         if (!isAllowedArgs(argsStr, errorClass)) {
           const line = getLineNumber(content, match.index!);
+          const fullMatch = match[0].slice(0, -1) + argsStr; // replace trailing '(' with full args
           violations.push({
             file: path.relative(SERVER_DIR, filePath),
             line,
-            content: match[0].replace(/\s+/g, " ").trim(),
+            content: fullMatch.replace(/\s+/g, " ").trim(),
           });
         }
       }


### PR DESCRIPTION
## Summary

Closes #1003

- `THROW_PATTERN` の正規表現 `[^)]*` を `extractArgs` 関数に置き換え、括弧の深さを追跡する方式に変更
- 文字列リテラル内の `)` やエスケープ文字を正しく処理
- 既存テストはすべてパス

## 変更内容

- `THROW_PATTERN` から引数キャプチャ部分 `([^)]*)` を除去し、`throw new ErrorClass(` の検出のみに変更
- `extractArgs` 関数を追加: 括弧の深さカウンタと文字列リテラル追跡で引数全体を正確に抽出
- マッチ結果の再構成ロジックを更新

## Test plan

- [x] `npx vitest run server/domain/common/errors-static-message.test.ts` → 1 test passed
- [ ] 括弧を含む文字列リテラル（例: `"指定された値(foo)は不正です"`）が将来追加された場合も正しく検出されること

## Remaining Limitations

- テンプレートリテラル内の `${}` 式にネストしたバッククォートが含まれる場合は未対応（DomainError引数での使用可能性は極めて低い）

🤖 Generated with [Claude Code](https://claude.com/claude-code)