### PR TITLE
test: クォート種別混在を防ぐためパターンを分離する

### DIFF
--- a/server/domain/common/errors-static-message.test.ts
+++ b/server/domain/common/errors-static-message.test.ts
@@ -53,8 +53,10 @@ function isExcluded(filePath: string): boolean {
 const COMMON_ALLOWED_PATTERNS = [
   // 引数なし: XxxError()
   /^\(\s*\)/,
-  // 静的文字列リテラルのみ: XxxError("msg") or XxxError('msg')（末尾カンマ許容）
-  /^\(\s*["'][^"']*["']\s*,?\s*\)/,
+  // 静的文字列リテラルのみ: XxxError("msg")（末尾カンマ許容）
+  /^\(\s*"[^"]*"\s*,?\s*\)/,
+  // 静的文字列リテラルのみ: XxxError('msg')（末尾カンマ許容）
+  /^\(\s*'[^']*'\s*,?\s*\)/,
 ];
 
 // TooManyRequestsError 専用: 第1引数が数値/変数
@@ -62,7 +64,9 @@ const TOO_MANY_REQUESTS_PATTERNS = [
   // 第1引数が数値/変数のみ: TooManyRequestsError(retryAfterMs)
   /^\(\s*[^"'`),]+\s*,?\s*\)/,
   // 第1引数が数値/変数 + 第2引数が静的文字列: TooManyRequestsError(retryAfterMs, "msg")
-  /^\(\s*[^"'`),]+,\s*["'][^"']*["']\s*,?\s*\)/,
+  /^\(\s*[^"'`),]+,\s*"[^"]*"\s*,?\s*\)/,
+  // 第1引数が数値/変数 + 第2引数が静的文字列: TooManyRequestsError(retryAfterMs, 'msg')
+  /^\(\s*[^"'`),]+,\s*'[^']*'\s*,?\s*\)/,
 ];
 
 function extractArgs(content: string, startIndex: number): string {


### PR DESCRIPTION
## Summary

- `errors-static-message.test.ts` の静的文字列リテラル判定パターンで `["']` を使っていた箇所を、ダブルクォート用・シングルクォート用に分離
- `COMMON_ALLOWED_PATTERNS` と `TOO_MANY_REQUESTS_PATTERNS` の両方を修正

Closes #1001

## Test plan

- [x] `npx vitest run server/domain/common/errors-static-message.test.ts` → passed
- [x] 手動でdiffを確認し、正規表現の分離が正確であることを検証済み

🤖 Generated with [Claude Code](https://claude.com/claude-code)