### PR TITLE
test: allowlistパターン正規表現に$アンカーを追加する

### DIFF
--- a/server/domain/common/errors-static-message.test.ts
+++ b/server/domain/common/errors-static-message.test.ts
@@ -52,21 +52,21 @@ function isExcluded(filePath: string): boolean {
 // allowlist: throw new XxxError(...) の引数部分として許可するパターン
 const COMMON_ALLOWED_PATTERNS = [
   // 引数なし: XxxError()
-  /^\(\s*\)/,
+  /^\(\s*\)$/,
   // 静的文字列リテラルのみ: XxxError("msg")（末尾カンマ許容）
-  /^\(\s*"[^"]*"\s*,?\s*\)/,
+  /^\(\s*"[^"]*"\s*,?\s*\)$/,
   // 静的文字列リテラルのみ: XxxError('msg')（末尾カンマ許容）
-  /^\(\s*'[^']*'\s*,?\s*\)/,
+  /^\(\s*'[^']*'\s*,?\s*\)$/,
 ];
 
 // TooManyRequestsError 専用: 第1引数が数値/変数
 const TOO_MANY_REQUESTS_PATTERNS = [
   // 第1引数が数値/変数のみ: TooManyRequestsError(retryAfterMs)
-  /^\(\s*[^"'`),]+\s*,?\s*\)/,
+  /^\(\s*[^"'`),]+\s*,?\s*\)$/,
   // 第1引数が数値/変数 + 第2引数が静的文字列: TooManyRequestsError(retryAfterMs, "msg")
-  /^\(\s*[^"'`),]+,\s*"[^"]*"\s*,?\s*\)/,
+  /^\(\s*[^"'`),]+,\s*"[^"]*"\s*,?\s*\)$/,
   // 第1引数が数値/変数 + 第2引数が静的文字列: TooManyRequestsError(retryAfterMs, 'msg')
-  /^\(\s*[^"'`),]+,\s*'[^']*'\s*,?\s*\)/,
+  /^\(\s*[^"'`),]+,\s*'[^']*'\s*,?\s*\)$/,
 ];
 
 function extractArgs(content: string, startIndex: number): string {


### PR DESCRIPTION
## Summary

- `errors-static-message.test.ts` の allowlist パターン正規表現6箇所すべてに `$` アンカーを追加
- `extractArgs` の戻り値は常に `)` で終端するため既存動作に影響なし
- 防御的に末尾マッチを明示し、正規表現の意図を明確化

Closes #1000

## Test plan

- [x] `npx vitest run server/domain/common/errors-static-message.test.ts` → 1 test passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)