### PR TITLE
refactor: 対局選択UIをMatchSelectコンポーネントに抽出する (#119)

### DIFF
--- a/app/(authenticated)/circle-sessions/components/match-delete-dialog.tsx
+++ b/app/(authenticated)/circle-sessions/components/match-delete-dialog.tsx
@@ -13,6 +13,7 @@ import {
   type ActiveDialog,
   type PairMatchEntry,
 } from "./match-utils";
+import { MatchSelect } from "./match-select";
 
 type MatchDeleteDialogProps = {
   activeDialog: ActiveDialog | null;
@@ -65,34 +66,19 @@ export function MatchDeleteDialog({
               >
                 対象の対局結果
               </label>
-              {activePairMatches.length > 1 ? (
-                <select
-                  id="delete-match-select"
-                  className="mt-2 w-full rounded-lg border border-border/60 bg-white px-3 py-2 text-sm text-(--brand-ink) shadow-xs focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring/30"
-                  value={selectedMatch?.index ?? ""}
-                  onChange={(event) =>
-                    handleMatchSelectChange(Number(event.target.value))
-                  }
-                >
-                  {activePairMatches.map((entry, index) => {
-                    const outcome = getMatchOutcome(
-                      activeDialog.rowId,
-                      entry.match,
-                    );
-                    return (
-                      <option key={entry.index} value={entry.index}>
-                        第{index + 1}局目: {outcome.title}
-                      </option>
-                    );
-                  })}
-                </select>
-              ) : (
-                <p className="mt-2 text-sm text-(--brand-ink-muted)">
-                  {selectedMatch
-                    ? `第1局目: ${getMatchOutcome(activeDialog.rowId, selectedMatch.match).title}`
-                    : "対局結果なし"}
-                </p>
-              )}
+              <MatchSelect
+                id="delete-match-select"
+                activePairMatches={activePairMatches}
+                selectedMatch={selectedMatch}
+                onMatchSelectChange={handleMatchSelectChange}
+                getOptionLabel={(entry, index) => {
+                  const outcome = getMatchOutcome(
+                    activeDialog.rowId,
+                    entry.match,
+                  );
+                  return `第${index + 1}局目: ${outcome.title}`;
+                }}
+              />
             </div>
           </>
         ) : null}

--- a/app/(authenticated)/circle-sessions/components/match-dialog.tsx
+++ b/app/(authenticated)/circle-sessions/components/match-dialog.tsx
@@ -16,6 +16,7 @@ import {
   type PairMatchEntry,
   type RowOutcome,
 } from "./match-utils";
+import { MatchSelect } from "./match-select";
 
 type MatchDialogProps = {
   activeDialog: ActiveDialog | null;
@@ -86,30 +87,22 @@ export function MatchDialog({
             <label className="text-xs font-semibold text-(--brand-ink)">
               対象の対局結果
             </label>
-            <select
-              className="mt-2 w-full rounded-lg border border-border/60 bg-white px-3 py-2 text-sm text-(--brand-ink) shadow-xs focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring/30"
-              value={selectedMatch?.index ?? ""}
-              onChange={(event) =>
-                handleMatchSelectChange(Number(event.target.value))
-              }
-            >
-              {activePairMatches.map((entry, index) => {
+            <MatchSelect
+              activePairMatches={activePairMatches}
+              selectedMatch={selectedMatch}
+              onMatchSelectChange={handleMatchSelectChange}
+              getOptionLabel={(entry, index) => {
                 const rowOutcome = getRowOutcomeValue(
                   activeDialog.rowId,
                   entry.match,
                 );
-                return (
-                  <option key={entry.index} value={entry.index}>
-                    第{index + 1}局目:{" "}
-                    {getOutcomeLabel(
-                      rowOutcome,
-                      dialogRowName,
-                      dialogColumnName,
-                    )}
-                  </option>
-                );
-              })}
-            </select>
+                return `第${index + 1}局目: ${getOutcomeLabel(
+                  rowOutcome,
+                  dialogRowName,
+                  dialogColumnName,
+                )}`;
+              }}
+            />
           </div>
         ) : null}
 

--- a/app/(authenticated)/circle-sessions/components/match-select.tsx
+++ b/app/(authenticated)/circle-sessions/components/match-select.tsx
@@ -1,0 +1,44 @@
+import type { PairMatchEntry } from "./match-utils";
+
+type MatchSelectProps = {
+  id?: string;
+  activePairMatches: PairMatchEntry[];
+  selectedMatch: PairMatchEntry | null;
+  onMatchSelectChange: (nextIndex: number) => void;
+  getOptionLabel: (entry: PairMatchEntry, index: number) => string;
+};
+
+export function MatchSelect({
+  id,
+  activePairMatches,
+  selectedMatch,
+  onMatchSelectChange,
+  getOptionLabel,
+}: MatchSelectProps) {
+  if (activePairMatches.length > 1) {
+    return (
+      <select
+        id={id}
+        className="mt-2 w-full rounded-lg border border-border/60 bg-white px-3 py-2 text-sm text-(--brand-ink) shadow-xs focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring/30"
+        value={selectedMatch?.index ?? ""}
+        onChange={(event) =>
+          onMatchSelectChange(Number(event.target.value))
+        }
+      >
+        {activePairMatches.map((entry, index) => (
+          <option key={entry.index} value={entry.index}>
+            {getOptionLabel(entry, index)}
+          </option>
+        ))}
+      </select>
+    );
+  }
+
+  return (
+    <p className="mt-2 text-sm text-(--brand-ink-muted)">
+      {selectedMatch
+        ? getOptionLabel(selectedMatch, 0)
+        : "対局結果なし"}
+    </p>
+  );
+}


### PR DESCRIPTION
## Summary

- 対局選択UI（`<select>` + 単一対局時の `<p>` フォールバック）を `MatchSelect` 共通コンポーネントとして抽出
- `MatchDeleteDialog` と `MatchDialog` の重複コードを解消し、DRYに
- `getOptionLabel` コールバックで各利用箇所のラベル生成差異を吸収

Closes #119

## Test plan

- [ ] セッション詳細画面で、対局結果が1つのペアの「編集」モードを開く → `<p>` フォールバックで表示される
- [ ] 対局結果が複数あるペアの「編集」モードを開く → `<select>` で対局選択できる
- [ ] 「削除」ダイアログで同様に `<select>` / `<p>` が適切に表示される
- [ ] 追加・編集・削除の各操作が正常に動作する
- [ ] `npx tsc --noEmit` が型エラーなしで通過する

🤖 Generated with [Claude Code](https://claude.com/claude-code)