### PR TITLE
fix: getNameInitialが空白のみの入力で未トリム文字列を返すバグを修正する

### DIFF
--- a/app/(authenticated)/circle-sessions/components/__tests__/match-utils.test.ts
+++ b/app/(authenticated)/circle-sessions/components/__tests__/match-utils.test.ts
@@ -141,8 +141,12 @@ describe("getNameInitial", () => {
     expect(getNameInitial(" 田中 ")).toBe("田");
   });
 
-  it("空文字の場合はそのまま返す", () => {
+  it("空文字の場合は空文字を返す", () => {
     expect(getNameInitial("")).toBe("");
+  });
+
+  it("空白のみの場合は空文字を返す", () => {
+    expect(getNameInitial("   ")).toBe("");
   });
 });
 

--- a/app/(authenticated)/circle-sessions/components/match-utils.ts
+++ b/app/(authenticated)/circle-sessions/components/match-utils.ts
@@ -31,7 +31,7 @@ export const convertRowOutcomeToApiOutcome = (
 };
 
 export const getNameInitial = (name: string) =>
-  Array.from(name.trim())[0] ?? name;
+  Array.from(name.trim())[0] ?? "";
 
 export const getOutcomeLabel = (
   outcome: RowOutcome,


### PR DESCRIPTION
## Summary

- `getNameInitial` の nullish coalescing フォールバックを `name` → `""` に修正し、空白のみの入力で未トリムの文字列が返されるバグを解消
- 空白のみ入力のテストケースを追加

Closes #1011

## Verification

```bash
npx vitest run app/\(authenticated\)/circle-sessions/components/__tests__/match-utils.test.ts
```

- 全テスト通過を確認済み

## Review Points

- 変更は `?? name` → `?? ""` の1文字修正のみ
- 空文字入力（`""`）の既存動作に影響なし
- フォローアップ: サロゲートペアのテストケース追加 → #1013

🤖 Generated with [Claude Code](https://claude.com/claude-code)