### PR TITLE
test: getNameInitialにサロゲートペア入力のテストケースを追加する

### DIFF
--- a/app/(authenticated)/circle-sessions/components/__tests__/match-utils.test.ts
+++ b/app/(authenticated)/circle-sessions/components/__tests__/match-utils.test.ts
@@ -148,6 +148,10 @@ describe("getNameInitial", () => {
   it("空白のみの場合は空文字を返す", () => {
     expect(getNameInitial("   ")).toBe("");
   });
+
+  it("サロゲートペア（絵文字）を含む名前から先頭1文字を正しく返す", () => {
+    expect(getNameInitial("🎯テスト")).toBe("🎯");
+  });
 });
 
 describe("getOutcomeLabel", () => {


### PR DESCRIPTION
## Summary

- `getNameInitial` が `Array.from` を使用してサロゲートペア（絵文字等）を正しく1文字として扱う振る舞いを検証するテストケースを追加

Closes #1013

## Verification

- `vitest run match-utils.test.ts` — 全37テスト合格（新規1件含む）

## Review Points

- テストケースの命名が振る舞いを正しく表現しているか
- 既存テストとの一貫性

🤖 Generated with [Claude Code](https://claude.com/claude-code)