### PR TITLE
refactor: MatchRepositoryの勝敗統計取得をDB層集計に置き換える (#505)

### DIFF
--- a/server/application/test-helpers/mock-repositories.ts
+++ b/server/application/test-helpers/mock-repositories.ts
@@ -20,6 +20,9 @@ export const createMockMatchRepository = () =>
     listByBothPlayerIds: vi.fn(),
     listByPlayerIdWithCircle: vi.fn(),
     listDistinctOpponentIds: vi.fn(),
+    countMatchStatisticsByUserId: vi.fn(),
+    countMatchStatisticsByUserIdGroupByCircle: vi.fn(),
+    countMatchStatisticsByBothPlayerIds: vi.fn(),
     save: vi.fn(),
   }) satisfies MatchRepository;
 

--- a/server/application/user/match-statistics.ts
+++ b/server/application/user/match-statistics.ts
@@ -1,10 +1,6 @@
 import type { CircleId } from "@/server/domain/common/ids";
 
-export type UserMatchStatistics = {
-  wins: number;
-  losses: number;
-  draws: number;
-};
+export type { UserMatchStatistics } from "@/server/domain/models/match/match-statistics";
 
 export type CircleMatchStatistics = {
   circleId: CircleId;

--- a/server/application/user/user-statistics-service.ts
+++ b/server/application/user/user-statistics-service.ts
@@ -1,7 +1,6 @@
-import type { CircleId, UserId } from "@/server/domain/common/ids";
+import type { UserId } from "@/server/domain/common/ids";
 import type { MatchRepository } from "@/server/domain/models/match/match-repository";
 import type { UserRepository } from "@/server/domain/models/user/user-repository";
-import { classifyOutcomeForUser } from "@/server/application/match/match-outcome";
 import type {
   CircleMatchStatistics,
   UserMatchStatistics,
@@ -24,43 +23,12 @@ export const createUserStatisticsService = (
     total: UserMatchStatistics;
     byCircle: CircleMatchStatistics[];
   }> {
-    const matches =
-      await deps.matchRepository.listByPlayerIdWithCircle(targetUserId);
-
-    const total = { wins: 0, losses: 0, draws: 0 };
-    const circleMap = new Map<
-      CircleId,
-      { circleName: string; wins: number; losses: number; draws: number }
-    >();
-
-    for (const match of matches) {
-      const isPlayer1 = match.player1Id === targetUserId;
-      const classified = classifyOutcomeForUser(match.outcome, isPlayer1);
-      if (classified === null) continue;
-
-      // Update total
-      if (classified === "win") total.wins++;
-      else if (classified === "loss") total.losses++;
-      else total.draws++;
-
-      // Update per-circle
-      let entry = circleMap.get(match.circleId);
-      if (!entry) {
-        entry = { circleName: match.circleName, wins: 0, losses: 0, draws: 0 };
-        circleMap.set(match.circleId, entry);
-      }
-
-      if (classified === "win") entry.wins++;
-      else if (classified === "loss") entry.losses++;
-      else entry.draws++;
-    }
-
-    const byCircle = Array.from(circleMap.entries())
-      .map(([cId, stats]) => ({
-        circleId: cId,
-        ...stats,
-      }))
-      .sort((a, b) => a.circleName.localeCompare(b.circleName, "ja"));
+    const [total, byCircle] = await Promise.all([
+      deps.matchRepository.countMatchStatisticsByUserId(targetUserId),
+      deps.matchRepository.countMatchStatisticsByUserIdGroupByCircle(
+        targetUserId,
+      ),
+    ]);
 
     return { total, byCircle };
   },
@@ -81,23 +49,9 @@ export const createUserStatisticsService = (
     targetUserId: UserId,
     opponentId: UserId,
   ): Promise<UserMatchStatistics> {
-    const matches = await deps.matchRepository.listByBothPlayerIds(
+    return deps.matchRepository.countMatchStatisticsByBothPlayerIds(
       targetUserId,
       opponentId,
     );
-
-    const stats: UserMatchStatistics = { wins: 0, losses: 0, draws: 0 };
-
-    for (const match of matches) {
-      const isPlayer1 = match.player1Id === targetUserId;
-      const classified = classifyOutcomeForUser(match.outcome, isPlayer1);
-      if (classified === null) continue;
-
-      if (classified === "win") stats.wins++;
-      else if (classified === "loss") stats.losses++;
-      else stats.draws++;
-    }
-
-    return stats;
   },
 });

--- a/server/domain/models/match/match-repository.ts
+++ b/server/domain/models/match/match-repository.ts
@@ -1,6 +1,10 @@
 import type { Match } from "@/server/domain/models/match/match";
 import type { MatchWithCircle } from "@/server/domain/models/match/match-read-models";
 import type {
+  CircleMatchStatisticsRow,
+  UserMatchStatistics,
+} from "@/server/domain/models/match/match-statistics";
+import type {
   CircleSessionId,
   MatchId,
   UserId,
@@ -18,5 +22,16 @@ export type MatchRepository = {
   listByPlayerIdWithCircle(playerId: UserId): Promise<MatchWithCircle[]>;
   /** 論理削除を除外し、player1/player2 両方のポジションから対戦相手IDを重複排除して返す。 */
   listDistinctOpponentIds(playerId: UserId): Promise<UserId[]>;
+  /** 指定ユーザーの勝敗引き分け数を集計して返す（論理削除・UNKNOWN除外）。 */
+  countMatchStatisticsByUserId(userId: UserId): Promise<UserMatchStatistics>;
+  /** 指定ユーザーの勝敗引き分け数をサークル別に集計して返す（論理削除・UNKNOWN除外）。 */
+  countMatchStatisticsByUserIdGroupByCircle(
+    userId: UserId,
+  ): Promise<CircleMatchStatisticsRow[]>;
+  /** 指定ユーザーと対戦相手の勝敗引き分け数を集計して返す（論理削除・UNKNOWN除外）。 */
+  countMatchStatisticsByBothPlayerIds(
+    userId: UserId,
+    opponentId: UserId,
+  ): Promise<UserMatchStatistics>;
   save(match: Match): Promise<void>;
 };

--- a/server/domain/models/match/match-statistics.ts
+++ b/server/domain/models/match/match-statistics.ts
@@ -1,0 +1,20 @@
+/**
+ * 対局統計の集計結果型
+ *
+ * リポジトリの集計クエリが返す読み取り専用の型定義。
+ */
+import type { CircleId } from "@/server/domain/common/ids";
+
+export type UserMatchStatistics = {
+  wins: number;
+  losses: number;
+  draws: number;
+};
+
+export type CircleMatchStatisticsRow = {
+  circleId: CircleId;
+  circleName: string;
+  wins: number;
+  losses: number;
+  draws: number;
+};

--- a/server/infrastructure/repository/in-memory/in-memory-match-repository.ts
+++ b/server/infrastructure/repository/in-memory/in-memory-match-repository.ts
@@ -1,7 +1,10 @@
 import type { MatchRepository } from "@/server/domain/models/match/match-repository";
-import type { Match } from "@/server/domain/models/match/match";
+import type { Match, MatchOutcome } from "@/server/domain/models/match/match";
 import type { MatchWithCircle } from "@/server/domain/models/match/match-read-models";
+import type { UserMatchStatistics } from "@/server/domain/models/match/match-statistics";
+import type { CircleMatchStatisticsRow } from "@/server/domain/models/match/match-statistics";
 import type {
+  CircleId,
   CircleSessionId,
   MatchId,
   UserId,
@@ -10,6 +13,28 @@ import type { CircleSessionStore } from "./in-memory-circle-session-repository";
 import type { CircleStore } from "./in-memory-circle-repository";
 
 export type MatchStore = Map<string, Match>;
+
+const accumulateStats = (
+  stats: UserMatchStatistics,
+  outcome: MatchOutcome,
+  isPlayer1: boolean,
+): void => {
+  switch (outcome) {
+    case "P1_WIN":
+      if (isPlayer1) stats.wins++;
+      else stats.losses++;
+      break;
+    case "P2_WIN":
+      if (isPlayer1) stats.losses++;
+      else stats.wins++;
+      break;
+    case "DRAW":
+      stats.draws++;
+      break;
+    case "UNKNOWN":
+      break;
+  }
+};
 
 export const createInMemoryMatchRepository = (
   matchStore: MatchStore = new Map(),
@@ -111,6 +136,76 @@ export const createInMemoryMatchRepository = (
       if (m.player2Id === playerId) ids.add(m.player1Id);
     }
     return [...ids];
+  },
+
+  async countMatchStatisticsByUserId(
+    userId: UserId,
+  ): Promise<UserMatchStatistics> {
+    const stats: UserMatchStatistics = { wins: 0, losses: 0, draws: 0 };
+    for (const m of matchStore.values()) {
+      if (m.deletedAt !== null) continue;
+      if (m.player1Id !== userId && m.player2Id !== userId) continue;
+      accumulateStats(stats, m.outcome, m.player1Id === userId);
+    }
+    return stats;
+  },
+
+  async countMatchStatisticsByUserIdGroupByCircle(
+    userId: UserId,
+  ): Promise<CircleMatchStatisticsRow[]> {
+    if (!deps) {
+      throw new Error(
+        "InMemoryMatchRepository requires circleSessionStore and circleStore for countMatchStatisticsByUserIdGroupByCircle",
+      );
+    }
+    const circleMap = new Map<
+      string,
+      { circleName: string; stats: UserMatchStatistics }
+    >();
+    for (const m of matchStore.values()) {
+      if (m.deletedAt !== null) continue;
+      if (m.player1Id !== userId && m.player2Id !== userId) continue;
+      if (m.outcome === "UNKNOWN") continue;
+
+      const session = deps.circleSessionStore.get(m.circleSessionId);
+      if (!session) continue;
+      const circle = deps.circleStore.get(session.circleId);
+      if (!circle) continue;
+
+      let entry = circleMap.get(circle.id);
+      if (!entry) {
+        entry = {
+          circleName: circle.name,
+          stats: { wins: 0, losses: 0, draws: 0 },
+        };
+        circleMap.set(circle.id, entry);
+      }
+      accumulateStats(entry.stats, m.outcome, m.player1Id === userId);
+    }
+
+    return Array.from(circleMap.entries())
+      .map(([cId, { circleName, stats }]) => ({
+        circleId: cId as CircleId,
+        circleName,
+        ...stats,
+      }))
+      .sort((a, b) => a.circleName.localeCompare(b.circleName, "ja"));
+  },
+
+  async countMatchStatisticsByBothPlayerIds(
+    userId: UserId,
+    opponentId: UserId,
+  ): Promise<UserMatchStatistics> {
+    const stats: UserMatchStatistics = { wins: 0, losses: 0, draws: 0 };
+    for (const m of matchStore.values()) {
+      if (m.deletedAt !== null) continue;
+      const isPair =
+        (m.player1Id === userId && m.player2Id === opponentId) ||
+        (m.player1Id === opponentId && m.player2Id === userId);
+      if (!isPair) continue;
+      accumulateStats(stats, m.outcome, m.player1Id === userId);
+    }
+    return stats;
   },
 
   async save(match: Match): Promise<void> {

--- a/server/infrastructure/repository/match/prisma-match-repository.ts
+++ b/server/infrastructure/repository/match/prisma-match-repository.ts
@@ -1,4 +1,6 @@
 import type { MatchRepository } from "@/server/domain/models/match/match-repository";
+import type { UserMatchStatistics } from "@/server/domain/models/match/match-statistics";
+import type { CircleMatchStatisticsRow } from "@/server/domain/models/match/match-statistics";
 import { prisma, type PrismaClientLike } from "@/server/infrastructure/db";
 import {
   mapMatchToDomain,
@@ -13,6 +15,7 @@ import type {
 } from "@/server/domain/common/ids";
 import { toCircleId, toUserId } from "@/server/domain/common/ids";
 import { toPersistenceId } from "@/server/infrastructure/common/id-utils";
+import { Prisma } from "@/generated/prisma/client";
 
 export const createPrismaMatchRepository = (
   client: PrismaClientLike,
@@ -122,6 +125,127 @@ export const createPrismaMatchRepository = (
     for (const m of asPlayer2) ids.add(m.player1Id);
 
     return [...ids].map(toUserId);
+  },
+
+  async countMatchStatisticsByUserId(
+    userId: UserId,
+  ): Promise<UserMatchStatistics> {
+    const pid = toPersistenceId(userId);
+
+    const rows = await client.$queryRaw<
+      { wins: bigint; losses: bigint; draws: bigint }[]
+    >(Prisma.sql`
+      SELECT
+        COALESCE(SUM(CASE
+          WHEN ("player1Id" = ${pid} AND outcome = 'P1_WIN')
+            OR ("player2Id" = ${pid} AND outcome = 'P2_WIN')
+          THEN 1 ELSE 0 END), 0) AS wins,
+        COALESCE(SUM(CASE
+          WHEN ("player1Id" = ${pid} AND outcome = 'P2_WIN')
+            OR ("player2Id" = ${pid} AND outcome = 'P1_WIN')
+          THEN 1 ELSE 0 END), 0) AS losses,
+        COALESCE(SUM(CASE
+          WHEN outcome = 'DRAW'
+            AND ("player1Id" = ${pid} OR "player2Id" = ${pid})
+          THEN 1 ELSE 0 END), 0) AS draws
+      FROM "Match"
+      WHERE "deletedAt" IS NULL
+        AND ("player1Id" = ${pid} OR "player2Id" = ${pid})
+        AND outcome != 'UNKNOWN'
+    `);
+
+    const row = rows[0]!;
+    return {
+      wins: Number(row.wins),
+      losses: Number(row.losses),
+      draws: Number(row.draws),
+    };
+  },
+
+  async countMatchStatisticsByUserIdGroupByCircle(
+    userId: UserId,
+  ): Promise<CircleMatchStatisticsRow[]> {
+    const pid = toPersistenceId(userId);
+
+    const rows = await client.$queryRaw<
+      {
+        circleId: string;
+        circleName: string;
+        wins: bigint;
+        losses: bigint;
+        draws: bigint;
+      }[]
+    >(Prisma.sql`
+      SELECT
+        c.id AS "circleId",
+        c.name AS "circleName",
+        COALESCE(SUM(CASE
+          WHEN (m."player1Id" = ${pid} AND m.outcome = 'P1_WIN')
+            OR (m."player2Id" = ${pid} AND m.outcome = 'P2_WIN')
+          THEN 1 ELSE 0 END), 0) AS wins,
+        COALESCE(SUM(CASE
+          WHEN (m."player1Id" = ${pid} AND m.outcome = 'P2_WIN')
+            OR (m."player2Id" = ${pid} AND m.outcome = 'P1_WIN')
+          THEN 1 ELSE 0 END), 0) AS losses,
+        COALESCE(SUM(CASE
+          WHEN m.outcome = 'DRAW'
+            AND (m."player1Id" = ${pid} OR m."player2Id" = ${pid})
+          THEN 1 ELSE 0 END), 0) AS draws
+      FROM "Match" m
+      JOIN "CircleSession" cs ON m."circleSessionId" = cs.id
+      JOIN "Circle" c ON cs."circleId" = c.id
+      WHERE m."deletedAt" IS NULL
+        AND (m."player1Id" = ${pid} OR m."player2Id" = ${pid})
+        AND m.outcome != 'UNKNOWN'
+      GROUP BY c.id, c.name
+      ORDER BY c.name
+    `);
+
+    return rows.map((row) => ({
+      circleId: toCircleId(row.circleId),
+      circleName: row.circleName,
+      wins: Number(row.wins),
+      losses: Number(row.losses),
+      draws: Number(row.draws),
+    }));
+  },
+
+  async countMatchStatisticsByBothPlayerIds(
+    userId: UserId,
+    opponentId: UserId,
+  ): Promise<UserMatchStatistics> {
+    const uid = toPersistenceId(userId);
+    const oid = toPersistenceId(opponentId);
+
+    const rows = await client.$queryRaw<
+      { wins: bigint; losses: bigint; draws: bigint }[]
+    >(Prisma.sql`
+      SELECT
+        COALESCE(SUM(CASE
+          WHEN ("player1Id" = ${uid} AND outcome = 'P1_WIN')
+            OR ("player2Id" = ${uid} AND outcome = 'P2_WIN')
+          THEN 1 ELSE 0 END), 0) AS wins,
+        COALESCE(SUM(CASE
+          WHEN ("player1Id" = ${uid} AND outcome = 'P2_WIN')
+            OR ("player2Id" = ${uid} AND outcome = 'P1_WIN')
+          THEN 1 ELSE 0 END), 0) AS losses,
+        COALESCE(SUM(CASE
+          WHEN outcome = 'DRAW' THEN 1 ELSE 0 END), 0) AS draws
+      FROM "Match"
+      WHERE "deletedAt" IS NULL
+        AND outcome != 'UNKNOWN'
+        AND (
+          ("player1Id" = ${uid} AND "player2Id" = ${oid})
+          OR ("player1Id" = ${oid} AND "player2Id" = ${uid})
+        )
+    `);
+
+    const row = rows[0]!;
+    return {
+      wins: Number(row.wins),
+      losses: Number(row.losses),
+      draws: Number(row.draws),
+    };
   },
 
   async save(match: Match): Promise<void> {

--- a/server/presentation/providers/__tests__/helpers/create-mock-deps.ts
+++ b/server/presentation/providers/__tests__/helpers/create-mock-deps.ts
@@ -74,6 +74,15 @@ export const createMockDeps = (): MockDeps => ({
     listByBothPlayerIds: vi.fn().mockResolvedValue([]),
     listByPlayerIdWithCircle: vi.fn().mockResolvedValue([]),
     listDistinctOpponentIds: vi.fn().mockResolvedValue([]),
+    countMatchStatisticsByUserId: vi
+      .fn()
+      .mockResolvedValue({ wins: 0, losses: 0, draws: 0 }),
+    countMatchStatisticsByUserIdGroupByCircle: vi
+      .fn()
+      .mockResolvedValue([]),
+    countMatchStatisticsByBothPlayerIds: vi
+      .fn()
+      .mockResolvedValue({ wins: 0, losses: 0, draws: 0 }),
     save: vi.fn().mockResolvedValue(undefined),
   },
   userRepository: {

--- a/server/presentation/providers/user-profile-provider.test.ts
+++ b/server/presentation/providers/user-profile-provider.test.ts
@@ -113,17 +113,18 @@ describe("getUserProfileViewModel", () => {
       ]);
 
       // 対局統計
-      mockDeps.matchRepository.listByPlayerIdWithCircle.mockResolvedValue([
+      mockDeps.matchRepository.countMatchStatisticsByUserId.mockResolvedValue({
+        wins: 1,
+        losses: 0,
+        draws: 0,
+      });
+      mockDeps.matchRepository.countMatchStatisticsByUserIdGroupByCircle.mockResolvedValue([
         {
-          id: "match-1" as never,
-          circleSessionId: "session-past" as never,
           circleId: "circle-1" as never,
           circleName: "テスト研究会",
-          player1Id: TARGET_USER_ID,
-          player2Id: toUserId("opponent-1"),
-          outcome: "P1_WIN" as never,
-          createdAt: NOW,
-          deletedAt: null,
+          wins: 1,
+          losses: 0,
+          draws: 0,
         },
       ]);
 


### PR DESCRIPTION
## Summary

- `UserMatchStatistics` 型を application 層から domain 層（`match-statistics.ts`）に移動し、`CircleMatchStatisticsRow` を新設
- `MatchRepository` に DB 層集計メソッド3つ（`countMatchStatisticsByUserId`, `countMatchStatisticsByUserIdGroupByCircle`, `countMatchStatisticsByBothPlayerIds`）を追加
- `UserStatisticsService` のアプリケーション層イテレーション（全 Match フェッチ → ループ集計）をリポジトリ呼び出しに置換
- Prisma 実装では `$queryRaw` で `CASE/SUM/GROUP BY` による効率的な集計クエリを使用

Closes #505

## Test plan

- [ ] `npx tsc --noEmit` で型エラーなし
- [ ] `npx vitest run` で全テスト pass（1285テスト）
- [ ] ユーザープロフィール画面で対局統計（総合・サークル別）が正しく表示される
- [ ] 対戦相手別成績が正しく表示される
- [ ] 対局0件のユーザーでエラーが発生しない

🤖 Generated with [Claude Code](https://claude.com/claude-code)