### PR TITLE
test: アバターアップロード/配信Route Handlerのテストを追加する (#1034)

### DIFF
--- a/app/api/avatar/[userId]/route.test.ts
+++ b/app/api/avatar/[userId]/route.test.ts
@@ -1,0 +1,73 @@
+import { beforeEach, describe, expect, test, vi } from "vitest";
+import { type UserId } from "@/server/domain/common/ids";
+
+vi.mock("@/server/env", () => ({ env: {} }));
+
+import {
+  createMockDeps,
+  createServiceContainer,
+  toServiceContainerDeps,
+} from "@/server/presentation/providers/__tests__/helpers/create-mock-deps";
+
+const mockDeps = createMockDeps();
+
+vi.mock("@/server/presentation/trpc/context", () => ({
+  buildServiceContainer: () => {
+    return createServiceContainer(toServiceContainerDeps(mockDeps));
+  },
+}));
+
+const { GET } = await import("./route");
+
+const userId = "user-1" as UserId;
+
+const createGetRequest = () =>
+  new Request(`http://localhost/api/avatar/${userId}`);
+
+const callGET = (id: string = userId) =>
+  GET(createGetRequest(), { params: Promise.resolve({ userId: id }) });
+
+describe("GET /api/avatar/[userId]", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  test("画像データが存在する場合に正しいContent-Typeとバイナリデータが返る（200）", async () => {
+    const imageBuffer = Buffer.from("fake-png-data");
+    mockDeps.userRepository.findImageData.mockResolvedValue({
+      data: imageBuffer,
+      mimeType: "image/png",
+    });
+
+    const res = await callGET();
+
+    expect(res.status).toBe(200);
+    expect(res.headers.get("Content-Type")).toBe("image/png");
+
+    const body = await res.arrayBuffer();
+    expect(Buffer.from(body)).toEqual(imageBuffer);
+  });
+
+  test("レスポンスヘッダーにセキュリティヘッダーが含まれる", async () => {
+    mockDeps.userRepository.findImageData.mockResolvedValue({
+      data: Buffer.from("fake-data"),
+      mimeType: "image/jpeg",
+    });
+
+    const res = await callGET();
+
+    expect(res.headers.get("Cache-Control")).toBe("no-cache");
+    expect(res.headers.get("X-Content-Type-Options")).toBe("nosniff");
+    expect(res.headers.get("Content-Security-Policy")).toBe(
+      "default-src 'none'; style-src 'unsafe-inline'",
+    );
+  });
+
+  test("画像データが存在しない場合に404が返る", async () => {
+    mockDeps.userRepository.findImageData.mockResolvedValue(null);
+
+    const res = await callGET();
+
+    expect(res.status).toBe(404);
+  });
+});

--- a/app/api/upload/avatar/route.test.ts
+++ b/app/api/upload/avatar/route.test.ts
@@ -1,0 +1,100 @@
+import { beforeEach, describe, expect, test, vi } from "vitest";
+import { type UserId } from "@/server/domain/common/ids";
+import { UnauthorizedError } from "@/server/domain/common/errors";
+
+vi.mock("@/server/env", () => ({ env: {} }));
+
+import {
+  createMockDeps,
+  createServiceContainer,
+  toServiceContainerDeps,
+} from "@/server/presentation/providers/__tests__/helpers/create-mock-deps";
+
+const mockDeps = createMockDeps();
+
+const { mockGetSessionUserId } = vi.hoisted(() => ({
+  mockGetSessionUserId: vi.fn(),
+}));
+
+vi.mock("@/server/presentation/trpc/context", () => ({
+  buildServiceContainer: () => {
+    return createServiceContainer(toServiceContainerDeps(mockDeps));
+  },
+  getSessionUserId: mockGetSessionUserId,
+}));
+
+const { POST } = await import("./route");
+
+const actorId = "user-1" as UserId;
+
+const createFormDataRequest = (file?: File) => {
+  const formData = new FormData();
+  if (file) {
+    formData.append("file", file);
+  }
+  return new Request("http://localhost/api/upload/avatar", {
+    method: "POST",
+    body: formData,
+  });
+};
+
+describe("POST /api/upload/avatar", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockGetSessionUserId.mockResolvedValue(actorId);
+    mockDeps.userRepository.findById.mockResolvedValue({
+      id: actorId,
+      name: "Taro",
+      email: "taro@example.com",
+      image: null,
+      profileVisibility: "PUBLIC",
+      createdAt: new Date(),
+    });
+  });
+
+  test("アップロード成功時に200とsuccess:trueが返る", async () => {
+    const file = new File(["fake-image"], "avatar.png", {
+      type: "image/png",
+    });
+    const res = await POST(createFormDataRequest(file));
+
+    expect(res.status).toBe(200);
+    expect(await res.json()).toEqual({ success: true });
+  });
+
+  test("未認証時に401が返る", async () => {
+    mockGetSessionUserId.mockRejectedValue(new UnauthorizedError());
+
+    const file = new File(["fake-image"], "avatar.png", {
+      type: "image/png",
+    });
+    const res = await POST(createFormDataRequest(file));
+
+    expect(res.status).toBe(401);
+  });
+
+  test("ファイルが含まれないリクエストで400が返る", async () => {
+    const res = await POST(createFormDataRequest());
+
+    expect(res.status).toBe(400);
+  });
+
+  test("不正なMIMEタイプ時に400が返る", async () => {
+    const file = new File(["not-an-image"], "file.txt", {
+      type: "text/plain",
+    });
+    const res = await POST(createFormDataRequest(file));
+
+    expect(res.status).toBe(400);
+  });
+
+  test("ファイルサイズ超過時に400が返る", async () => {
+    const largeContent = new Uint8Array(2 * 1024 * 1024 + 1);
+    const file = new File([largeContent], "large.png", {
+      type: "image/png",
+    });
+    const res = await POST(createFormDataRequest(file));
+
+    expect(res.status).toBe(400);
+  });
+});

--- a/server/application/user/__tests__/user-service-upload-avatar.test.ts
+++ b/server/application/user/__tests__/user-service-upload-avatar.test.ts
@@ -1,0 +1,95 @@
+import { beforeEach, describe, expect, test, vi } from "vitest";
+import { createUserService } from "@/server/application/user/user-service";
+import { createAccessServiceStub } from "@/server/application/test-helpers/access-service-stub";
+import { createInMemoryUserRepository } from "@/server/infrastructure/repository/in-memory";
+import type { UserStore } from "@/server/infrastructure/repository/in-memory/in-memory-user-repository";
+import type { PasswordHasher } from "@/server/domain/common/password-hasher";
+import type { RateLimiter } from "@/server/domain/common/rate-limiter";
+import { toUserId } from "@/server/domain/common/ids";
+import { createUser } from "@/server/domain/models/user/user";
+import {
+  BadRequestError,
+  ForbiddenError,
+} from "@/server/domain/common/errors";
+
+const userStore: UserStore = new Map();
+const userRepository = createInMemoryUserRepository(userStore);
+
+const accessService = createAccessServiceStub();
+
+const passwordHasher: PasswordHasher = {
+  hash: vi.fn((p: string) => `hashed:${p}`),
+  verify: vi.fn((p: string, h: string) => h === `hashed:${p}`),
+};
+
+const changePasswordRateLimiter: RateLimiter = {
+  check: vi.fn(),
+  recordAttempt: vi.fn(),
+  reset: vi.fn(),
+};
+
+const service = createUserService({
+  userRepository,
+  accessService,
+  passwordHasher,
+  changePasswordRateLimiter,
+});
+
+const actorId = toUserId("user-1");
+const testUser = createUser({
+  id: actorId,
+  name: "Taro",
+  email: "taro@example.com",
+  createdAt: new Date("2024-01-01"),
+});
+
+const addTestUser = () => {
+  userStore.set(actorId, {
+    ...testUser,
+    passwordHash: null,
+    passwordChangedAt: null,
+  });
+};
+
+beforeEach(() => {
+  userStore.clear();
+  vi.clearAllMocks();
+});
+
+describe("uploadAvatar", () => {
+  const validBuffer = Buffer.from("fake-image-data");
+  const validMimeType = "image/png";
+
+  test("アップロード成功時にリポジトリにデータが保存される", async () => {
+    addTestUser();
+
+    await service.uploadAvatar(actorId, validBuffer, validMimeType);
+
+    const stored = userStore.get(actorId);
+    expect(stored?.imageData).toEqual(validBuffer);
+    expect(stored?.imageMimeType).toBe(validMimeType);
+  });
+
+  test("存在しないユーザーで ForbiddenError がスローされる", async () => {
+    await expect(
+      service.uploadAvatar(actorId, validBuffer, validMimeType),
+    ).rejects.toThrow(ForbiddenError);
+  });
+
+  test("ファイルサイズ超過（2MB超）で BadRequestError がスローされる", async () => {
+    addTestUser();
+    const largeBuffer = Buffer.alloc(2 * 1024 * 1024 + 1);
+
+    await expect(
+      service.uploadAvatar(actorId, largeBuffer, validMimeType),
+    ).rejects.toThrow(BadRequestError);
+  });
+
+  test("不正なMIMEタイプで BadRequestError がスローされる", async () => {
+    addTestUser();
+
+    await expect(
+      service.uploadAvatar(actorId, validBuffer, "text/plain"),
+    ).rejects.toThrow(BadRequestError);
+  });
+});


### PR DESCRIPTION
## Summary

Closes #1034

- `UserService.uploadAvatar` の単体テスト（InMemoryRepository使用、4ケース）
- `POST /api/upload/avatar` Route Handler 統合テスト（5ケース: 成功、未認証401、不正MIMEタイプ400、サイズ超過400、ファイル未添付400）
- `GET /api/avatar/[userId]` Route Handler 統合テスト（3ケース: 成功+セキュリティヘッダー検証、404）

## Test plan

- [ ] `npx vitest run server/application/user/__tests__/user-service-upload-avatar.test.ts "app/api/upload/avatar/route.test.ts" "app/api/avatar/[userId]/route.test.ts"` で新規12テスト全パス
- [ ] `npx vitest run` で全テストスイート回帰なし

## Notes

検証時に発見した改善点は別issueとして起票済み:
- #1037 magic-byte検証の追加
- #1038 Route Handler側の早期ファイルサイズチェック

🤖 Generated with [Claude Code](https://claude.com/claude-code)