### PR TITLE
feat: WebPマジックバイト検証にWEBP FourCCチェックを追加する

### DIFF
--- a/server/application/user/__tests__/user-service-upload-avatar.test.ts
+++ b/server/application/user/__tests__/user-service-upload-avatar.test.ts
@@ -103,4 +103,30 @@ describe("uploadAvatar", () => {
       service.uploadAvatar(actorId, jpegBuffer, "image/png"),
     ).rejects.toThrow(BadRequestError);
   });
+
+  test("正当なWebPファイルがアップロード成功する", async () => {
+    addTestUser();
+    // RIFF....WEBP header (offset 0: RIFF, offset 8: WEBP)
+    const webpBuffer = Buffer.from([
+      0x52, 0x49, 0x46, 0x46, 0x00, 0x00, 0x00, 0x00, 0x57, 0x45, 0x42, 0x50,
+    ]);
+
+    await service.uploadAvatar(actorId, webpBuffer, "image/webp");
+
+    const stored = userStore.get(actorId);
+    expect(stored?.imageData).toEqual(webpBuffer);
+    expect(stored?.imageMimeType).toBe("image/webp");
+  });
+
+  test("非WebP RIFFファイルが image/webp として拒否される", async () => {
+    addTestUser();
+    // RIFF....WAVE header (valid RIFF but not WebP)
+    const wavBuffer = Buffer.from([
+      0x52, 0x49, 0x46, 0x46, 0x00, 0x00, 0x00, 0x00, 0x57, 0x41, 0x56, 0x45,
+    ]);
+
+    await expect(
+      service.uploadAvatar(actorId, wavBuffer, "image/webp"),
+    ).rejects.toThrow(BadRequestError);
+  });
 });

--- a/server/application/user/user-service.ts
+++ b/server/application/user/user-service.ts
@@ -20,11 +20,16 @@ const AVATAR_ALLOWED_MIME_TYPES = [
   "image/gif",
 ] as const;
 
-const AVATAR_MAGIC_BYTES: Record<string, number[]> = {
-  "image/png": [0x89, 0x50, 0x4e, 0x47],
-  "image/jpeg": [0xff, 0xd8, 0xff],
-  "image/webp": [0x52, 0x49, 0x46, 0x46],
-  "image/gif": [0x47, 0x49, 0x46, 0x38],
+type MagicBytesSegment = { offset: number; bytes: number[] };
+
+const AVATAR_MAGIC_BYTES: Record<string, MagicBytesSegment[]> = {
+  "image/png": [{ offset: 0, bytes: [0x89, 0x50, 0x4e, 0x47] }],
+  "image/jpeg": [{ offset: 0, bytes: [0xff, 0xd8, 0xff] }],
+  "image/webp": [
+    { offset: 0, bytes: [0x52, 0x49, 0x46, 0x46] },
+    { offset: 8, bytes: [0x57, 0x45, 0x42, 0x50] },
+  ],
+  "image/gif": [{ offset: 0, bytes: [0x47, 0x49, 0x46, 0x38] }],
 };
 
 type AccessService = ReturnType<typeof createAccessService>;
@@ -164,11 +169,12 @@ export const createUserService = (deps: UserServiceDeps) => ({
       throw new BadRequestError("Unsupported image format");
     }
 
-    const expectedBytes = AVATAR_MAGIC_BYTES[mimeType];
-    if (expectedBytes) {
-      const header = fileBuffer.subarray(0, expectedBytes.length);
-      const matches = expectedBytes.every(
-        (byte, index) => header[index] === byte,
+    const segments = AVATAR_MAGIC_BYTES[mimeType];
+    if (segments) {
+      const matches = segments.every((segment) =>
+        segment.bytes.every(
+          (byte, index) => fileBuffer[segment.offset + index] === byte,
+        ),
       );
       if (!matches) {
         throw new BadRequestError(


### PR DESCRIPTION
## Summary

Closes #1040

- WebPのmagic bytes検証にoffset 8-11の`WEBP` FourCCチェックを追加し、WAV/AVI等の非WebP RIFFファイルが`image/webp`として通過することを防止
- データ構造を`MagicBytesSegment[]`に拡張し、複数オフセットの検証に対応
- 正当なWebPアップロード成功・非WebP RIFF拒否のテストを追加

## Test plan

- [x] 既存テスト7件すべてパス
- [ ] WebPファイルのアップロードが正常に動作すること
- [ ] WAVファイルを`image/webp`としてアップロードした際に拒否されること
- [ ] PNG/JPEG/GIFのアップロードが引き続き正常に動作すること

## Related issues

- Follow-up: #1043 (magic bytes検証の前にバッファ最小長チェックを追加する)

🤖 Generated with [Claude Code](https://claude.com/claude-code)