### PR TITLE
feat: アバターアップロードRoute Handlerで早期ファイルサイズチェックを追加する

### DIFF
--- a/app/api/upload/avatar/route.test.ts
+++ b/app/api/upload/avatar/route.test.ts
@@ -98,5 +98,8 @@ describe("POST /api/upload/avatar", () => {
     const res = await POST(createFormDataRequest(file));
 
     expect(res.status).toBe(400);
+    expect(await res.json()).toEqual({
+      message: "ファイルサイズが大きすぎます",
+    });
   });
 });

--- a/app/api/upload/avatar/route.ts
+++ b/app/api/upload/avatar/route.ts
@@ -33,6 +33,13 @@ export async function POST(request: Request) {
     );
   }
 
+  if (file.size > 2 * 1024 * 1024) {
+    return NextResponse.json(
+      { message: "ファイルサイズが大きすぎます" },
+      { status: 400 },
+    );
+  }
+
   const arrayBuffer = await file.arrayBuffer();
   const buffer = Buffer.from(arrayBuffer);
   const mimeType = file.type;


### PR DESCRIPTION
## Summary

Closes #1038

- Route Handler層で`file.size`による早期サイズチェック（2MB上限）を追加し、`file.arrayBuffer()`によるバッファ読み込み前に大きなファイルを拒否する
- サービス層の既存バリデーションはそのまま残し、多層防御を維持
- テストにレスポンスボディのアサーションを追加

## Verification

- `npx vitest run app/api/upload/avatar/route.test.ts` — 全5テスト pass
- verify結果: `.claude/artifacts/issue-1038/verify.md`

## Review points

- safety finding #1: `request.formData()`時点でリクエストボディ全体がパース済みのため、`file.size`チェック前にメモリ消費が発生する。Vercel Freeプランのリクエストサイズ制限（4.5MB）で緩和済み。`Content-Length`プリチェックは #1045 で対応予定
- サイズ上限の定数化は #1046 で対応予定

## Follow-up issues

- #1045: Content-Lengthプリチェックの追加
- #1046: ファイルサイズ上限の定数化

🤖 Generated with [Claude Code](https://claude.com/claude-code)