### PR TITLE
feat: magic bytes検証の前にバッファ最小長チェックを追加する

### DIFF
--- a/server/application/user/__tests__/user-service-upload-avatar.test.ts
+++ b/server/application/user/__tests__/user-service-upload-avatar.test.ts
@@ -131,6 +131,45 @@ describe("uploadAvatar", () => {
     ).rejects.toThrow(BadRequestError);
   });
 
+  test.each([
+    {
+      format: "PNG",
+      buffer: Buffer.from([0x89, 0x50, 0x4e]),
+      mimeType: "image/png",
+      minRequired: 4,
+    },
+    {
+      format: "JPEG",
+      buffer: Buffer.from([0xff, 0xd8]),
+      mimeType: "image/jpeg",
+      minRequired: 3,
+    },
+    {
+      format: "WebP",
+      buffer: Buffer.from([
+        0x52, 0x49, 0x46, 0x46, 0x00, 0x00, 0x00, 0x00, 0x57, 0x45, 0x42,
+      ]),
+      mimeType: "image/webp",
+      minRequired: 12,
+    },
+    {
+      format: "GIF",
+      buffer: Buffer.from([0x47, 0x49, 0x46]),
+      mimeType: "image/gif",
+      minRequired: 4,
+    },
+  ])(
+    "$format の最小必要バイト数($minRequired)未満のバッファで BadRequestError がスローされる",
+    async ({ buffer, mimeType, minRequired }) => {
+      addTestUser();
+      expect(buffer.length).toBeLessThan(minRequired);
+
+      await expect(
+        service.uploadAvatar(actorId, buffer, mimeType),
+      ).rejects.toThrow(BadRequestError);
+    },
+  );
+
   test("非WebP RIFFファイルが image/webp として拒否される", async () => {
     addTestUser();
     // RIFF....WAVE header (valid RIFF but not WebP)

--- a/server/application/user/user-service.ts
+++ b/server/application/user/user-service.ts
@@ -171,6 +171,16 @@ export const createUserService = (deps: UserServiceDeps) => ({
 
     const segments = AVATAR_MAGIC_BYTES[mimeType];
     if (segments) {
+      const minRequired = segments.reduce(
+        (max, segment) => Math.max(max, segment.offset + segment.bytes.length),
+        0,
+      );
+      if (fileBuffer.length < minRequired) {
+        throw new BadRequestError(
+          "File content does not match declared MIME type",
+        );
+      }
+
       const matches = segments.every((segment) =>
         segment.bytes.every(
           (byte, index) => fileBuffer[segment.offset + index] === byte,


### PR DESCRIPTION
## Summary

- magic bytes比較の前にバッファ最小長チェックを追加（defense-in-depth）
- `segments.reduce` で各フォーマットの必要最小バイト数を算出し、不足時は `BadRequestError` をスロー
- 4フォーマット（PNG/JPEG/WebP/GIF）のパラメタライズドテストを追加（全13テスト合格）

Closes #1043

## Test plan

- [x] `npx vitest run server/application/user/__tests__/user-service-upload-avatar.test.ts` — 全13テスト合格
- [ ] 既存のアバターアップロード機能が正常に動作することを確認

## Verification

verify.md の結果:
- **safety**: INFO x3, LOW x1（Route Handler層での0バイト早期拒否は未実装→ #1049）
- **implementation**: INFO x2, LOW x1（テストデータの `minRequired` がアサーション未使用）

## Follow-up issues

- #1049 Route Handlerで0バイトファイルの早期拒否を追加する
- #1050 AVATAR_ALLOWED_MIME_TYPESとAVATAR_MAGIC_BYTESの整合性を型レベルで保証する

🤖 Generated with [Claude Code](https://claude.com/claude-code)