### PR TITLE
test: toUserDto のアバターURL分岐ロジックに単体テストを追加する

### DIFF
--- a/server/presentation/mappers/__tests__/user-mapper.test.ts
+++ b/server/presentation/mappers/__tests__/user-mapper.test.ts
@@ -1,0 +1,54 @@
+import { describe, expect, test } from "vitest";
+import { toUserDto } from "@/server/presentation/mappers/user-mapper";
+import { createUser } from "@/server/domain/models/user/user";
+import { toUserId } from "@/server/domain/common/ids";
+
+describe("toUserDto アバターURL", () => {
+  test("hasCustomImage=true のとき /api/avatar/{id} を返す", () => {
+    const user = createUser({
+      id: toUserId("user-1"),
+      hasCustomImage: true,
+      image: "https://example.com/oauth-image.png",
+    });
+
+    const dto = toUserDto(user);
+
+    expect(dto.image).toBe("/api/avatar/user-1");
+  });
+
+  test("hasCustomImage=false かつ OAuth画像URLありのとき、そのURLを返す", () => {
+    const user = createUser({
+      id: toUserId("user-2"),
+      hasCustomImage: false,
+      image: "https://example.com/oauth-image.png",
+    });
+
+    const dto = toUserDto(user);
+
+    expect(dto.image).toBe("https://example.com/oauth-image.png");
+  });
+
+  test("hasCustomImage=false かつ imageが空白文字のみのとき null を返す", () => {
+    const user = createUser({
+      id: toUserId("user-4"),
+      hasCustomImage: false,
+      image: "   ",
+    });
+
+    const dto = toUserDto(user);
+
+    expect(dto.image).toBeNull();
+  });
+
+  test("hasCustomImage=false かつ image=null のとき null を返す", () => {
+    const user = createUser({
+      id: toUserId("user-3"),
+      hasCustomImage: false,
+      image: null,
+    });
+
+    const dto = toUserDto(user);
+
+    expect(dto.image).toBeNull();
+  });
+});


### PR DESCRIPTION
## Summary

- `toUserDto` の `hasCustomImage` による アバターURL分岐ロジックに単体テストを追加
- 4つの分岐パターンを直接検証: カスタム画像あり、OAuth画像あり、空白文字のみ、null

Closes #1052

## Test plan

- [ ] `npx vitest run server/presentation/mappers/__tests__/user-mapper.test.ts` で全4テストがパスすること
- [ ] 既存テストに影響がないこと

🤖 Generated with [Claude Code](https://claude.com/claude-code)