### PR TITLE
fix(security): アバター画像のマジックバイト検出方式への変更 (#1029)

### DIFF
--- a/server/application/user/__tests__/user-service-upload-avatar.test.ts
+++ b/server/application/user/__tests__/user-service-upload-avatar.test.ts
@@ -121,14 +121,16 @@ describe("uploadAvatar", () => {
     ).rejects.toThrow(BadRequestError);
   });
 
-  test("magic bytesが宣言されたMIMEタイプと一致しない場合 BadRequestError がスローされる", async () => {
+  test("クライアント提供MIMEタイプと実際のバイト内容が異なる場合、検出されたMIMEタイプで保存される", async () => {
     addTestUser();
     // JPEG magic bytes with PNG MIME type
     const jpegBuffer = Buffer.from([0xff, 0xd8, 0xff, 0xe0, 0x00]);
 
-    await expect(
-      service.uploadAvatar(actorId, jpegBuffer, "image/png"),
-    ).rejects.toThrow(BadRequestError);
+    await service.uploadAvatar(actorId, jpegBuffer, "image/png");
+
+    const stored = userStore.get(actorId);
+    expect(stored?.imageData).toEqual(jpegBuffer);
+    expect(stored?.imageMimeType).toBe("image/jpeg");
   });
 
   test.each([
@@ -179,6 +181,15 @@ describe("uploadAvatar", () => {
 
     await expect(
       service.uploadAvatar(actorId, wavBuffer, "image/webp"),
+    ).rejects.toThrow(BadRequestError);
+  });
+
+  test("どのシグネチャにも一致しないバイト列で BadRequestError がスローされる", async () => {
+    addTestUser();
+    const unknownBuffer = Buffer.from([0x00, 0x00, 0x00, 0x00, 0x00, 0x00]);
+
+    await expect(
+      service.uploadAvatar(actorId, unknownBuffer, "image/png"),
     ).rejects.toThrow(BadRequestError);
   });
 });

--- a/server/application/user/user-service.ts
+++ b/server/application/user/user-service.ts
@@ -169,31 +169,39 @@ export const createUserService = (deps: UserServiceDeps) => ({
       throw new BadRequestError("Unsupported image format");
     }
 
-    const segments = AVATAR_MAGIC_BYTES[mimeType];
-    if (segments) {
+    // Detect MIME type from magic bytes (scan all allowed types)
+    let detectedMimeType: string | null = null;
+    for (const [candidateMime, segments] of Object.entries(
+      AVATAR_MAGIC_BYTES,
+    )) {
       const minRequired = segments.reduce(
         (max, segment) => Math.max(max, segment.offset + segment.bytes.length),
         0,
       );
-      if (fileBuffer.length < minRequired) {
-        throw new BadRequestError(
-          "File content does not match declared MIME type",
-        );
-      }
+      if (fileBuffer.length < minRequired) continue;
 
       const matches = segments.every((segment) =>
         segment.bytes.every(
           (byte, index) => fileBuffer[segment.offset + index] === byte,
         ),
       );
-      if (!matches) {
-        throw new BadRequestError(
-          "File content does not match declared MIME type",
-        );
+      if (matches) {
+        detectedMimeType = candidateMime;
+        break;
       }
     }
 
-    await deps.userRepository.saveImageData(actorId, fileBuffer, mimeType);
+    if (detectedMimeType === null) {
+      throw new BadRequestError(
+        "File content does not match any supported image format",
+      );
+    }
+
+    await deps.userRepository.saveImageData(
+      actorId,
+      fileBuffer,
+      detectedMimeType,
+    );
   },
 
   async findImageData(


### PR DESCRIPTION
## Summary

- アバター画像アップロード時のMIMEタイプ検証を「クライアント提供MIMEタイプとの一致チェック」から「マジックバイトによるMIMEタイプ検出」方式に変更
- 検出されたMIMEタイプで保存することで、偽装Content-Typeによるバイパスを防止
- どのシグネチャにも一致しないファイルは `BadRequestError` で拒否

Closes #1029

## Test plan

- [ ] `npx vitest run server/application/user/__tests__/user-service-upload-avatar.test.ts` — 14テスト全パス
- [ ] MIMEタイプ不一致時に検出MIMEタイプで保存されることを確認（JPEG bytes + PNG MIME → image/jpeg）
- [ ] 全シグネチャ不一致のバイト列が拒否されることを確認
- [ ] 既存テスト（正当なアップロード、サイズ超過、不正MIME等）が引き続きパスすること

🤖 Generated with [Claude Code](https://claude.com/claude-code)