### PR TITLE
fix(user): OAuthユーザーがプロフィール（名前）を更新できるようにする

### DIFF
--- a/server/application/user/user-service.test.ts
+++ b/server/application/user/user-service.test.ts
@@ -133,11 +133,21 @@ describe("updateProfile", () => {
     userRepository.updateProfile = originalUpdateProfile;
   });
 
-  test("OAuthユーザー（パスワード未設定）がメール変更を試みた場合 BadRequest エラー", async () => {
+  test("OAuthユーザーが同一メールで名前を更新できる", async () => {
+    addTestUser(null);
+
+    await service.updateProfile(actorId, "NewName", "taro@example.com");
+
+    const stored = userStore.get(actorId);
+    expect(stored?.name).toBe("NewName");
+    expect(stored?.email).toBe("taro@example.com");
+  });
+
+  test("OAuthユーザーがメール変更を試みた場合 BadRequest エラー", async () => {
     addTestUser(null);
 
     await expect(
-      service.updateProfile(actorId, "NewName", "new@example.com"),
+      service.updateProfile(actorId, "NewName", "different@example.com"),
     ).rejects.toThrow("OAuth users cannot change email");
 
     // ストアが変更されていないことを検証

--- a/server/application/user/user-service.ts
+++ b/server/application/user/user-service.ts
@@ -80,8 +80,14 @@ export const createUserService = (deps: UserServiceDeps) => ({
 
     const passwordHash =
       await deps.userRepository.findPasswordHashById(actorId);
-    if (passwordHash === null) {
-      throw new BadRequestError("OAuth users cannot change email");
+    const isOAuthUser = passwordHash === null;
+
+    if (isOAuthUser) {
+      if (email !== user.email) {
+        throw new BadRequestError("OAuth users cannot change email");
+      }
+      await deps.userRepository.updateProfile(actorId, name, user.email);
+      return;
     }
 
     const exists = await deps.userRepository.emailExists(email, actorId);


### PR DESCRIPTION
## Summary

- OAuthユーザーが `updateProfile` を呼び出した際、メールアドレスが現在の値と同一であれば名前の更新を許可する
- メールアドレスの変更は従来通り `BadRequestError` でブロック
- テストを追加・修正（OAuthユーザーの名前更新成功ケース）

Closes #1057

## Verification

### 自動テスト
- `server/application/user/user-service.test.ts` — 全20テストパス
  - `OAuthユーザーが同一メールで名前を更新できる` — 新規追加
  - `OAuthユーザーがメール変更を試みた場合 BadRequest エラー` — 既存修正

### 手動検証手順
1. OAuthユーザーでログインし、プロフィール設定画面で名前を変更 → 成功すること
2. OAuthユーザーでメールアドレスを変更 → エラーが表示されること
3. Credentialsユーザーで名前・メール変更が従来通り動作すること

## Review Points

- メール比較は `user.email`（DB値）を使用し、書き込みにも `user.email` を使うため安全
- OAuth/非OAuthで `updateProfile` 呼び出しが2箇所に分かれるが、可読性を優先
- 関連フォローアップ: #1059, #1060, #1061

🤖 Generated with [Claude Code](https://claude.com/claude-code)