### PR TITLE
ci: PRクローズ時にNeonプレビューブランチを自動削除

### DIFF
--- a/.github/workflows/neon-branch-cleanup.yml
+++ b/.github/workflows/neon-branch-cleanup.yml
@@ -1,0 +1,17 @@
+name: Delete Neon Branch on PR Close
+
+on:
+  pull_request:
+    types: [closed]
+
+jobs:
+  delete-neon-branch:
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - name: Delete Neon Branch
+        uses: neondatabase/delete-branch-action@v3
+        with:
+          project_id: ${{ vars.NEON_PROJECT_ID }}
+          branch: preview/${{ github.head_ref }}
+          api_key: ${{ secrets.NEON_API_KEY }}


### PR DESCRIPTION
## Summary
- PRクローズ（マージ含む）時にVercel Neon Integrationが作成したプレビューブランチ(`preview/<branch>`)を自動削除するGitHub Actionsワークフローを追加
- 不要なNeonブランチが長期間残り続ける問題を解消

## Test plan
- [ ] テスト用PRを作成し、Neon Consoleでプレビューブランチが作成されることを確認
- [ ] PRをクローズまたはマージし、GitHub ActionsログとNeon Consoleでブランチが削除されることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)