### PR TITLE
fix(upload): Route Handlerで0バイトファイルを早期拒否する

### DIFF
--- a/app/api/upload/avatar/route.test.ts
+++ b/app/api/upload/avatar/route.test.ts
@@ -91,6 +91,18 @@ describe("POST /api/upload/avatar", () => {
     expect(res.status).toBe(400);
   });
 
+  test("0バイトファイル時に400が返る", async () => {
+    const file = new File([], "empty.png", {
+      type: "image/png",
+    });
+    const res = await POST(createFormDataRequest(file));
+
+    expect(res.status).toBe(400);
+    expect(await res.json()).toEqual({
+      message: "ファイルが空です",
+    });
+  });
+
   test("ファイルサイズ超過時に400が返る", async () => {
     const largeContent = new Uint8Array(2 * 1024 * 1024 + 1);
     const file = new File([largeContent], "large.png", {

--- a/app/api/upload/avatar/route.ts
+++ b/app/api/upload/avatar/route.ts
@@ -33,6 +33,13 @@ export async function POST(request: Request) {
     );
   }
 
+  if (file.size === 0) {
+    return NextResponse.json(
+      { message: "ファイルが空です" },
+      { status: 400 },
+    );
+  }
+
   if (file.size > 2 * 1024 * 1024) {
     return NextResponse.json(
       { message: "ファイルサイズが大きすぎます" },


### PR DESCRIPTION
## Summary

- アバターアップロードのRoute Handlerに `file.size === 0` チェックを追加し、空ファイルを400で早期拒否する
- defense-in-depthとして、サービス層到達前にAPI境界で不正入力を排除

Closes #1049

## Verification

- `npx vitest run app/api/upload/avatar/route.test.ts` → 全6テストパス（既存5 + 新規1）
- 手動確認: 0バイトファイル → 400 `"ファイルが空です"`、有効ファイル → 200、2MB超 → 400（既存動作維持）

## Review points

- バリデーション順序: 認証 → instanceof → **空チェック（新規）** → サイズ上限チェック → MIME チェック
- 関連フォローアップissue: #1064, #1065, #1066

🤖 Generated with [Claude Code](https://claude.com/claude-code)