### PR TITLE
fix(upload): アバターアップロードにCSRF保護を追加

### DIFF
--- a/app/api/upload/avatar/route.test.ts
+++ b/app/api/upload/avatar/route.test.ts
@@ -2,7 +2,9 @@ import { beforeEach, describe, expect, test, vi } from "vitest";
 import { type UserId } from "@/server/domain/common/ids";
 import { UnauthorizedError } from "@/server/domain/common/errors";
 
-vi.mock("@/server/env", () => ({ env: {} }));
+vi.mock("@/server/env", () => ({
+  env: { NEXTAUTH_URL: "http://localhost:3000" },
+}));
 
 import {
   createMockDeps,
@@ -27,14 +29,23 @@ const { POST } = await import("./route");
 
 const actorId = "user-1" as UserId;
 
-const createFormDataRequest = (file?: File) => {
+const createFormDataRequest = (
+  file?: File,
+  options?: { origin?: string | null },
+) => {
   const formData = new FormData();
   if (file) {
     formData.append("file", file);
   }
+  const headers: Record<string, string> = {};
+  const origin = options?.origin === undefined ? "http://localhost:3000" : options.origin;
+  if (origin !== null) {
+    headers["Origin"] = origin;
+  }
   return new Request("http://localhost/api/upload/avatar", {
     method: "POST",
     body: formData,
+    headers,
   });
 };
 
@@ -114,5 +125,31 @@ describe("POST /api/upload/avatar", () => {
     expect(await res.json()).toEqual({
       message: "ファイルサイズが大きすぎます",
     });
+  });
+
+  test("Originヘッダーが不正なオリジンの場合に403が返る", async () => {
+    const file = new File(["fake"], "avatar.png", { type: "image/png" });
+    const res = await POST(
+      createFormDataRequest(file, { origin: "https://evil.example.com" }),
+    );
+
+    expect(res.status).toBe(403);
+  });
+
+  test("Originヘッダーが未設定の場合に403が返る", async () => {
+    const file = new File(["fake"], "avatar.png", { type: "image/png" });
+    const res = await POST(createFormDataRequest(file, { origin: null }));
+
+    expect(res.status).toBe(403);
+  });
+
+  test("正当なOriginヘッダーの場合は処理が継続される", async () => {
+    const pngData = new Uint8Array([0x89, 0x50, 0x4e, 0x47, 0x00, 0x00]);
+    const file = new File([pngData], "avatar.png", { type: "image/png" });
+    const res = await POST(
+      createFormDataRequest(file, { origin: "http://localhost:3000" }),
+    );
+
+    expect(res.status).toBe(200);
   });
 });

--- a/app/api/upload/avatar/route.ts
+++ b/app/api/upload/avatar/route.ts
@@ -5,8 +5,16 @@ import {
 } from "@/server/presentation/trpc/context";
 import { toUserId } from "@/server/domain/common/ids";
 import { BadRequestError, UnauthorizedError } from "@/server/domain/common/errors";
+import { env } from "@/server/env";
 
 export async function POST(request: Request) {
+  if (env.NEXTAUTH_URL) {
+    const origin = request.headers.get("Origin");
+    const allowedOrigin = new URL(env.NEXTAUTH_URL).origin;
+    if (!origin || origin !== allowedOrigin) {
+      return NextResponse.json({ message: "Forbidden" }, { status: 403 });
+    }
+  }
   let actorId: string;
   try {
     actorId = await getSessionUserId();


### PR DESCRIPTION
## Summary

- アバターアップロードRoute Handlerに`Origin`ヘッダー検証によるCSRF保護を追加
- `multipart/form-data` POSTはCORSプリフライトを経由しないため、Origin検証で不正オリジンからのリクエストを拒否
- テスト3件追加（不正Origin → 403、Origin未設定 → 403、正当Origin → 200）

Closes #1066

## 検証手順

1. 自動テスト: `npx vitest run app/api/upload/avatar/route.test.ts`（全9件合格）
2. ローカルでアバターアップロードが正常動作することを確認
3. curlで不正Originを指定し403が返ることを確認:
   ```bash
   curl -X POST http://localhost:3000/api/upload/avatar \
     -H "Origin: https://evil.example.com" \
     -H "Cookie: <session_cookie>" \
     -F "file=@avatar.png"
   ```

## レビューポイント

- `NEXTAUTH_URL`未設定時（開発環境）はCSRF検証スキップ（本番では`server/env.ts`のZodスキーマが強制）
- 認証チェック前にCSRF検証を配置し、不正リクエストのセッション確認コストを回避
- 他のAPI Route（`/api/unsubscribe`等）へのCSRF保護は本issueのスコープ外

🤖 Generated with [Claude Code](https://claude.com/claude-code)