### PR TITLE
fix(upload): サービス層に0バイトファイルガードを追加

### DIFF
--- a/server/application/user/__tests__/user-service-upload-avatar.test.ts
+++ b/server/application/user/__tests__/user-service-upload-avatar.test.ts
@@ -104,6 +104,15 @@ describe("uploadAvatar", () => {
     ).rejects.toThrow(ForbiddenError);
   });
 
+  test("0バイトバッファで BadRequestError がスローされる", async () => {
+    addTestUser();
+    const emptyBuffer = Buffer.alloc(0);
+
+    await expect(
+      service.uploadAvatar(actorId, emptyBuffer, validMimeType),
+    ).rejects.toThrow(BadRequestError);
+  });
+
   test("ファイルサイズ超過（2MB超）で BadRequestError がスローされる", async () => {
     addTestUser();
     const largeBuffer = Buffer.alloc(2 * 1024 * 1024 + 1);

--- a/server/application/user/user-service.ts
+++ b/server/application/user/user-service.ts
@@ -161,6 +161,10 @@ export const createUserService = (deps: UserServiceDeps) => ({
       throw new ForbiddenError();
     }
 
+    if (fileBuffer.length === 0) {
+      throw new BadRequestError("File is empty");
+    }
+
     if (fileBuffer.length > AVATAR_MAX_SIZE) {
       throw new BadRequestError("File size exceeds 2MB limit");
     }


### PR DESCRIPTION
## Summary

- `UserService.uploadAvatar` に `fileBuffer.length === 0` のガードを追加し、0バイトバッファで `BadRequestError` をスローするようにした
- Route Handler の既存ガードとは独立した defense-in-depth として機能
- テスト「0バイトバッファで BadRequestError がスローされる」を追加

Closes #1064

## Verification

- 全15テスト pass（新規1件含む）
- ガード順序: ユーザー存在確認 → 空ファイル → サイズ上限 → MIMEタイプ → マジックバイト → 保存
- Route Handler 側の既存チェックは変更なし

## Review Points

- ガードの配置順序が適切か
- エラーメッセージ "File is empty" が妥当か

🤖 Generated with [Claude Code](https://claude.com/claude-code)