### PR TITLE
refactor(user): updateProfileのリポジトリ呼び出しを1箇所に統一

### DIFF
--- a/server/application/user/user-service.ts
+++ b/server/application/user/user-service.ts
@@ -82,20 +82,22 @@ export const createUserService = (deps: UserServiceDeps) => ({
       await deps.userRepository.findPasswordHashById(actorId);
     const isOAuthUser = passwordHash === null;
 
+    let finalEmail: string;
+
     if (isOAuthUser) {
       if (email !== user.email) {
         throw new BadRequestError("OAuth users cannot change email");
       }
-      await deps.userRepository.updateProfile(actorId, name, user.email);
-      return;
+      finalEmail = user.email;
+    } else {
+      const exists = await deps.userRepository.emailExists(email, actorId);
+      if (exists) {
+        throw new ConflictError("Email already in use");
+      }
+      finalEmail = email;
     }
 
-    const exists = await deps.userRepository.emailExists(email, actorId);
-    if (exists) {
-      throw new ConflictError("Email already in use");
-    }
-
-    await deps.userRepository.updateProfile(actorId, name, email);
+    await deps.userRepository.updateProfile(actorId, name, finalEmail);
   },
 
   async changePassword(


### PR DESCRIPTION
## Summary

- `updateProfile` のOAuth/非OAuthパスで重複していたリポジトリ呼び出しを `finalEmail` 変数の導入により1箇所に統一
- ガード節で検証のみ行い、実際の更新呼び出しをメソッド末尾に集約

Closes #1060

## Test plan

- [x] 既存テスト20件全パス確認済み
- [ ] OAuthユーザーで名前変更 → 成功
- [ ] OAuthユーザーでメール変更 → BadRequestErrorで拒否
- [ ] 非OAuthユーザーでプロフィール変更 → 成功
- [ ] 非OAuthユーザーで既存メールに変更 → ConflictErrorで拒否

🤖 Generated with [Claude Code](https://claude.com/claude-code)