### PR TITLE
feat(calendar): FullCalendarをnext/dynamicで動的インポート化

### DIFF
--- a/app/(authenticated)/circles/components/circle-overview-calendar.tsx
+++ b/app/(authenticated)/circles/components/circle-overview-calendar.tsx
@@ -3,7 +3,7 @@
 import {
   SessionCalendar,
   type SessionExtendedProps,
-} from "@/app/components/calendar/session-calendar";
+} from "@/app/components/calendar";
 import { toLocalDateString } from "@/lib/date-utils";
 import { Button } from "@/components/ui/button";
 import type { CircleOverviewSession } from "@/server/presentation/view-models/circle-overview";

--- a/app/(authenticated)/home/home-view.tsx
+++ b/app/(authenticated)/home/home-view.tsx
@@ -3,7 +3,7 @@
 import {
   SessionCalendar,
   type SessionExtendedProps,
-} from "@/app/components/calendar/session-calendar";
+} from "@/app/components/calendar";
 import { formatDate, formatTime } from "@/lib/date-utils";
 import type { HomeViewModel } from "@/server/presentation/view-models/home";
 import type { EventInput } from "@fullcalendar/core";

--- a/app/components/calendar/calendar-skeleton.tsx
+++ b/app/components/calendar/calendar-skeleton.tsx
@@ -1,0 +1,28 @@
+import { Skeleton } from "@/components/ui/skeleton";
+
+export function CalendarSkeleton() {
+  return (
+    <div className="session-calendar" aria-hidden="true">
+      {/* Header: prev / title / next */}
+      <div className="mb-4 flex items-center justify-between">
+        <Skeleton className="h-8 w-8 rounded" />
+        <Skeleton className="h-6 w-28" />
+        <Skeleton className="h-8 w-8 rounded" />
+      </div>
+
+      {/* Day-of-week header */}
+      <div className="mb-2 grid grid-cols-7 gap-1">
+        {Array.from({ length: 7 }, (_, i) => (
+          <Skeleton key={i} className="mx-auto h-4 w-6" />
+        ))}
+      </div>
+
+      {/* 5 rows of day cells */}
+      <div className="grid grid-cols-7 gap-1">
+        {Array.from({ length: 35 }, (_, i) => (
+          <Skeleton key={i} className="h-16 w-full rounded" />
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/app/components/calendar/index.tsx
+++ b/app/components/calendar/index.tsx
@@ -1,0 +1,9 @@
+import dynamic from "next/dynamic";
+import { CalendarSkeleton } from "./calendar-skeleton";
+
+export const SessionCalendar = dynamic(
+  () => import("./session-calendar").then((m) => m.SessionCalendar),
+  { ssr: false, loading: () => <CalendarSkeleton /> },
+);
+
+export type { SessionExtendedProps } from "./session-calendar";


### PR DESCRIPTION
## Summary

- `SessionCalendar`を`next/dynamic`でラップし、FullCalendar（~200KB）を遅延ロード化
- `CalendarSkeleton`コンポーネントを追加し、ロード中のレイアウトシフトを防止
- 利用側（home, circle-overview）はimportパスの変更のみで影響最小

Closes #1078

## Test plan

- [x] `tsc --noEmit` エラーなし
- [x] `vitest run` 全1323テスト通過
- [ ] `/home` でカレンダーが正常に表示されること
- [ ] サークル概要画面でカレンダーが正常に表示されること
- [ ] DevTools Networkタブで FullCalendar チャンクが遅延ロードされることを確認
- [ ] 低速ネットワークで CalendarSkeleton が表示されることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)