### PR TITLE
feat(schedule): 総当たりスケジュール生成にランダム性を追加

### DIFF
--- a/server/domain/models/round-robin-schedule/generate-rounds.test.ts
+++ b/server/domain/models/round-robin-schedule/generate-rounds.test.ts
@@ -124,4 +124,24 @@ describe("generateRounds", () => {
       expect(numbers).toEqual([1, 2, 3]);
     });
   });
+
+  describe("ランダム性", () => {
+    test("同じ入力で複数回呼び出すと異なる対戦順序が生成される", () => {
+      const participants = ids("u1", "u2", "u3", "u4", "u5", "u6");
+
+      const serialize = (rounds: ReturnType<typeof generateRounds>) =>
+        JSON.stringify(
+          rounds.map((r) =>
+            r.pairings.map((p) => `${p.player1Id}-${p.player2Id}`),
+          ),
+        );
+
+      const results = new Set<string>();
+      for (let i = 0; i < 20; i++) {
+        results.add(serialize(generateRounds(participants)));
+      }
+
+      expect(results.size).toBeGreaterThan(1);
+    });
+  });
 });

--- a/server/domain/models/round-robin-schedule/generate-rounds.ts
+++ b/server/domain/models/round-robin-schedule/generate-rounds.ts
@@ -29,8 +29,15 @@ export const generateRounds = (participantIds: UserId[]): Round[] => {
     throw new BadRequestError("Duplicate participant IDs are not allowed");
   }
 
+  // 入力をシャッフルして毎回異なる対戦順序を生成（Fisher-Yates）
+  const shuffled = [...participantIds];
+  for (let i = shuffled.length - 1; i > 0; i--) {
+    const j = Math.floor(Math.random() * (i + 1));
+    [shuffled[i], shuffled[j]] = [shuffled[j], shuffled[i]];
+  }
+
   // 奇数の場合は BYE (null) を追加して偶数にする
-  const players: (UserId | null)[] = [...participantIds];
+  const players: (UserId | null)[] = [...shuffled];
   if (players.length % 2 !== 0) {
     players.push(null);
   }


### PR DESCRIPTION
## Summary

- 総当たりスケジュール生成（`generateRounds`）で参加者リストをFisher-Yatesシャッフルし、毎回異なる対戦順序を生成するようにした
- ランダム性を検証するテストを追加（6人×20回試行で結果が1通りでないことを確認）

Closes #1084

## 変更ファイル

- `server/domain/models/round-robin-schedule/generate-rounds.ts` — シャッフル処理追加
- `server/domain/models/round-robin-schedule/generate-rounds.test.ts` — ランダム性テスト追加

## Verification

- `npx vitest run server/domain/models/round-robin-schedule/generate-rounds.test.ts` — 13テスト全件パス
- Fisher-Yates (Durstenfeld variant) を正しく実装、入力配列は非破壊
- 既存の不変条件テスト（全ペア網羅、ラウンド内重複なし）がランダムシャッフル後も毎回パス

## Review points

- 確率的テストのフレーク率（6人720順列中20回全同一の確率は事実上ゼロ）
- `Math.random` 直接使用（シード化は #1087 で対応予定）

## Follow-up issues

- #1086 ランダム性テストで構造的正当性も検証する
- #1087 オプショナルなランダムシード機能を追加する

🤖 Generated with [Claude Code](https://claude.com/claude-code)