### PR TITLE
feat(schedule): 総当たりスケジュールの再生成ボタンを追加

### DIFF
--- a/app/(authenticated)/circle-sessions/components/round-robin-schedule-section.tsx
+++ b/app/(authenticated)/circle-sessions/components/round-robin-schedule-section.tsx
@@ -68,6 +68,7 @@ export function RoundRobinScheduleSection({
 }: RoundRobinScheduleSectionProps) {
   const router = useRouter();
   const [showDeleteDialog, setShowDeleteDialog] = useState(false);
+  const [showRegenerateDialog, setShowRegenerateDialog] = useState(false);
 
   const generate = trpc.roundRobinSchedules.generate.useMutation({
     onSuccess: () => {
@@ -114,9 +115,18 @@ export function RoundRobinScheduleSection({
             <Button
               variant="outline"
               size="sm"
+              onClick={() => setShowRegenerateDialog(true)}
+              disabled={generate.isPending || deleteSchedule.isPending}
+            >
+              <Shuffle className="size-3.5" aria-hidden="true" />
+              再生成
+            </Button>
+            <Button
+              variant="outline"
+              size="sm"
               className="text-red-700 hover:bg-red-50 hover:text-red-800"
               onClick={() => setShowDeleteDialog(true)}
-              disabled={deleteSchedule.isPending}
+              disabled={deleteSchedule.isPending || generate.isPending}
             >
               <Trash2 className="size-3.5" aria-hidden="true" />
               削除
@@ -152,6 +162,41 @@ export function RoundRobinScheduleSection({
           ) : null}
         </div>
       )}
+
+      <AlertDialog
+        open={showRegenerateDialog}
+        onOpenChange={(open) => {
+          if (!generate.isPending) setShowRegenerateDialog(open);
+        }}
+      >
+        <AlertDialogContent>
+          <AlertDialogHeader>
+            <AlertDialogTitle>スケジュールを再生成</AlertDialogTitle>
+            <AlertDialogDescription>
+              既存のスケジュールが上書きされます。再生成しますか？
+            </AlertDialogDescription>
+          </AlertDialogHeader>
+          <AlertDialogFooter>
+            <AlertDialogCancel disabled={generate.isPending}>
+              キャンセル
+            </AlertDialogCancel>
+            <AlertDialogAction
+              onClick={(e) => {
+                e.preventDefault();
+                generate.mutate(
+                  { circleSessionId },
+                  {
+                    onSettled: () => setShowRegenerateDialog(false),
+                  },
+                );
+              }}
+              disabled={generate.isPending}
+            >
+              {generate.isPending ? "生成中…" : "再生成する"}
+            </AlertDialogAction>
+          </AlertDialogFooter>
+        </AlertDialogContent>
+      </AlertDialog>
 
       <AlertDialog
         open={showDeleteDialog}


### PR DESCRIPTION
## Summary

- スケジュール生成済み状態で「再生成」ボタンを追加し、確認ダイアログ付きでワンクリック再生成を実現
- 削除・再生成ボタンの相互排他ガード（`isPending` 中の `disabled`）を追加

Closes #1085

## 検証手順

1. スケジュール生成済みの状態で「再生成」ボタンと「削除」ボタンが並んで表示されること
2. 「再生成」クリック → 確認ダイアログ表示 → 「再生成する」クリック → スケジュールが更新されること
3. 「キャンセル」でダイアログが閉じ、スケジュールが変更されないこと
4. 再生成中に削除ボタンが disabled、削除中に再生成ボタンが disabled になること
5. `canManage = false` のユーザーには再生成ボタンが表示されないこと

## レビューポイント

- 再生成ダイアログと削除ダイアログの構造が類似しているが、2つのみのため現時点では共通化不要と判断
- 再生成は既存の `generate` mutation を再利用（サーバー側で既存スケジュールの削除→再生成を処理）

🤖 Generated with [Claude Code](https://claude.com/claude-code)