### PR TITLE
perf(provider): fetchAddableMemberCandidates内のデータ取得を並列化

### DIFF
--- a/server/presentation/providers/circle-session-detail-provider.ts
+++ b/server/presentation/providers/circle-session-detail-provider.ts
@@ -208,20 +208,20 @@ const fetchAddableMemberCandidates = async (
     return { candidates: [], newNames: new Map() };
   }
 
-  const circleMembers = await caller.circles.memberships.list({
-    circleId: session.circleId,
-  });
+  const [circleMembers, deletedMemberships] = await Promise.all([
+    caller.circles.memberships.list({
+      circleId: session.circleId,
+    }),
+    circleSessionMembershipService.listDeletedMemberships(
+      toCircleSessionId(session.id),
+    ),
+  ]);
   const sessionMemberIds = new Set(memberships.map((m) => m.userId));
   const candidateUserIds = new Set(
     circleMembers
       .filter((cm) => !sessionMemberIds.has(cm.userId))
       .map((cm) => cm.userId),
   );
-
-  const deletedMemberships =
-    await circleSessionMembershipService.listDeletedMemberships(
-      toCircleSessionId(session.id),
-    );
   for (const dm of deletedMemberships) {
     if (!sessionMemberIds.has(dm.userId)) {
       candidateUserIds.add(dm.userId);


### PR DESCRIPTION
## Summary

- `fetchAddableMemberCandidates()`内の`circleMembers`取得と`deletedMemberships`取得を`Promise.all()`で並列化
- セッション詳細ページのレスポンスタイム改善（2つの独立したI/O待ちが並列実行に）

Closes #1080

## Verification

- 自動テスト: `npx vitest run server/presentation/providers/circle-session-detail-provider.test.ts` — 5テスト全パス
- 手動確認: セッション詳細ページの「メンバー追加」候補リストが正しく表示されること

## Review Points

- 2つの呼び出しは完全に独立（入力に相互依存なし、両方とも読み取り専用）
- `Promise.all`のfail-fast動作は逐次実行時と同等のエラーハンドリング
- 同ファイル内の既存`Promise.all`パターンと一貫性あり

🤖 Generated with [Claude Code](https://claude.com/claude-code)