### PR TITLE
test(round-robin): ランダム性テストで構造的正当性も検証する (#1086)

### DIFF
--- a/server/domain/models/round-robin-schedule/generate-rounds.test.ts
+++ b/server/domain/models/round-robin-schedule/generate-rounds.test.ts
@@ -5,6 +5,39 @@ import type { UserId } from "@/server/domain/common/ids";
 
 const ids = (...names: string[]): UserId[] => names.map((n) => toUserId(n));
 
+function assertInvariants(
+  rounds: ReturnType<typeof generateRounds>,
+  participants: UserId[],
+): void {
+  // 全ペアがちょうど1回出現する
+  const pairSet = new Set<string>();
+  for (const round of rounds) {
+    for (const p of round.pairings) {
+      const key = [p.player1Id, p.player2Id].sort().join("-");
+      expect(pairSet.has(key)).toBe(false);
+      pairSet.add(key);
+    }
+  }
+  const expectedPairs = (participants.length * (participants.length - 1)) / 2;
+  expect(pairSet.size).toBe(expectedPairs);
+
+  // ラウンド内で同一プレイヤーが重複しない
+  for (const round of rounds) {
+    const playersInRound: string[] = [];
+    for (const p of round.pairings) {
+      playersInRound.push(p.player1Id, p.player2Id);
+    }
+    expect(new Set(playersInRound).size).toBe(playersInRound.length);
+  }
+
+  // 合計対戦数が n*(n-1)/2 と一致する
+  const totalPairings = rounds.reduce(
+    (sum, r) => sum + r.pairings.length,
+    0,
+  );
+  expect(totalPairings).toBe(expectedPairs);
+}
+
 describe("generateRounds", () => {
   describe("バリデーション", () => {
     test("0人の場合エラーになる", () => {
@@ -138,7 +171,9 @@ describe("generateRounds", () => {
 
       const results = new Set<string>();
       for (let i = 0; i < 20; i++) {
-        results.add(serialize(generateRounds(participants)));
+        const rounds = generateRounds(participants);
+        assertInvariants(rounds, participants);
+        results.add(serialize(rounds));
       }
 
       expect(results.size).toBeGreaterThan(1);


### PR DESCRIPTION
## Summary

- ランダム性テスト内で各生成結果に対して不変条件（全ペア網羅・ラウンド内重複なし・合計対戦数）を検証する `assertInvariants` ヘルパーを追加
- 既存のランダム性チェック（`results.size > 1`）は維持

Closes #1086

## Test plan

- [ ] `npx vitest run server/domain/models/round-robin-schedule/generate-rounds.test.ts` → 全13テストがパス
- [ ] `assertInvariants` が3つの不変条件を正しく検証していること
- [ ] 既存テストが変更されていないこと

## Review notes

- `assertInvariants` と個別テストの間にコード重複あり → #1092 で対応予定

🤖 Generated with [Claude Code](https://claude.com/claude-code)