### PR TITLE
feat(round-robin): generateRoundsにオプショナルなrandomパラメータを追加

### DIFF
--- a/server/domain/models/round-robin-schedule/generate-rounds.ts
+++ b/server/domain/models/round-robin-schedule/generate-rounds.ts
@@ -17,7 +17,10 @@ export type Round = {
  * - 先頭の参加者を固定し、残りを回転させてペアリングを作る
  * - 奇数人数の場合は BYE（null）を追加し、BYE とのペアリングは除外する
  */
-export const generateRounds = (participantIds: UserId[]): Round[] => {
+export const generateRounds = (
+  participantIds: UserId[],
+  random: () => number = Math.random,
+): Round[] => {
   if (participantIds.length < 2) {
     throw new BadRequestError(
       "Round-robin requires at least 2 participants",
@@ -32,7 +35,7 @@ export const generateRounds = (participantIds: UserId[]): Round[] => {
   // 入力をシャッフルして毎回異なる対戦順序を生成（Fisher-Yates）
   const shuffled = [...participantIds];
   for (let i = shuffled.length - 1; i > 0; i--) {
-    const j = Math.floor(Math.random() * (i + 1));
+    const j = Math.floor(random() * (i + 1));
     [shuffled[i], shuffled[j]] = [shuffled[j], shuffled[i]];
   }
 


### PR DESCRIPTION
## Summary

- `generateRounds` にオプショナルな `random: () => number` パラメータを追加（デフォルト: `Math.random`）
- Fisher-Yatesシャッフルのランダム関数を外部から注入可能にし、テスト時の決定性を確保
- 既存の呼び出し元への影響なし（後方互換）

Closes #1087

## Test plan

- [x] 既存テスト13件が全て合格
- [x] 決定的 `random` 関数（`() => 0`, `() => 0.999`）で構造的正当性を検証済み
- [ ] 第2引数なしでの呼び出しが従来通り動作することを確認（後方互換性）

🤖 Generated with [Claude Code](https://claude.com/claude-code)