### PR TITLE
refactor(test): tRPCルーターテストのモック境界をリポジトリ層に統一

### DIFF
--- a/server/presentation/trpc/routers/circle-invite-link.test.ts
+++ b/server/presentation/trpc/routers/circle-invite-link.test.ts
@@ -1,127 +1,81 @@
-import { ForbiddenError } from "@/server/domain/common/errors";
+import { beforeEach, describe, expect, test, vi } from "vitest";
+import { appRouter } from "@/server/presentation/trpc/router";
 import {
   toCircleId,
   toCircleInviteLinkId,
+  toInviteLinkToken,
   toUserId,
 } from "@/server/domain/common/ids";
-import type { Context } from "@/server/presentation/trpc/context";
-import { appRouter } from "@/server/presentation/trpc/router";
-import { beforeEach, describe, expect, test, vi } from "vitest";
+import { CircleRole } from "@/server/domain/models/circle/circle-role";
+import {
+  createMockDeps,
+  createServiceContainer,
+  toServiceContainerDeps,
+  type MockDeps,
+} from "@/server/presentation/providers/__tests__/helpers/create-mock-deps";
 
+const ACTOR_ID = toUserId("user-1");
+const CIRCLE_ID = toCircleId("circle-1");
 const TEST_TOKEN_UUID = "550e8400-e29b-41d4-a716-446655440000";
 
-const createTestContext = () => {
-  const circleInviteLinkService = {
-    createInviteLink: vi.fn(),
-    getInviteLinkInfo: vi.fn(),
-    redeemInviteLink: vi.fn(),
-  };
+const BASE_CIRCLE = {
+  id: CIRCLE_ID,
+  name: "テスト研究会",
+  createdAt: new Date("2024-01-01T00:00:00Z"),
+  sessionEmailNotificationEnabled: true,
+};
 
-  const context: Context = {
-    actorId: toUserId("user-1"),
-    clientIp: "1.2.3.4",
-    circleService: {
-      getCircle: vi.fn(),
-      createCircle: vi.fn(),
-      renameCircle: vi.fn(),
-      deleteCircle: vi.fn(),
-      updateSessionEmailNotificationEnabled: vi.fn(),
-    },
-    circleMembershipService: {
-      listByCircleId: vi.fn(),
-      listByUserId: vi.fn(),
-      addMembership: vi.fn(),
-      changeMembershipRole: vi.fn(),
-      withdrawMembership: vi.fn(),
-      removeMembership: vi.fn(),
-      transferOwnership: vi.fn(),
-    },
-    circleSessionService: {
-      listByCircleId: vi.fn(),
-      getCircleSession: vi.fn(),
-      createCircleSession: vi.fn(),
-      rescheduleCircleSession: vi.fn(),
-      updateCircleSessionDetails: vi.fn(),
-      deleteCircleSession: vi.fn(),
-    },
-    circleSessionMembershipService: {
-      countPastSessionsByUserId: vi.fn(),
-      listMemberships: vi.fn(),
-      listByUserId: vi.fn(),
-      addMembership: vi.fn(),
-      changeMembershipRole: vi.fn(),
-      removeMembership: vi.fn(),
-      transferOwnership: vi.fn(),
-      withdrawMembership: vi.fn(),
-      listDeletedMemberships: vi.fn(),
-    },
-    matchService: {
-      listByCircleSessionId: vi.fn(),
-      getMatch: vi.fn(),
-      recordMatch: vi.fn(),
-      updateMatch: vi.fn(),
-      deleteMatch: vi.fn(),
-    },
-    userService: {
-      getUser: vi.fn(),
-      listUsers: vi.fn(),
-      getMe: vi.fn(),
-      updateProfile: vi.fn(),
-      updateProfileVisibility: vi.fn(),
-      changePassword: vi.fn(),
-      uploadAvatar: vi.fn().mockResolvedValue(undefined),
-      findImageData: vi.fn().mockResolvedValue(null),
-      deleteAccount: vi.fn(),
-    },
-    signupService: {
-      signup: vi.fn(),
-    },
-    circleInviteLinkService,
-    accessService: {} as Context["accessService"],
-    userStatisticsService: {} as Context["userStatisticsService"],
-    roundRobinScheduleService: {} as Context["roundRobinScheduleService"],
-    holidayProvider: {} as Context["holidayProvider"],
-    notificationPreferenceService: {} as Context["notificationPreferenceService"],
-  };
+let mockDeps: MockDeps;
 
-  return { context, mocks: { circleInviteLinkService } };
+const buildContext = (actorId: ReturnType<typeof toUserId> | null = ACTOR_ID) => {
+  const services = createServiceContainer(toServiceContainerDeps(mockDeps));
+  return { actorId, clientIp: "1.2.3.4", ...services };
 };
 
 describe("circleInviteLink tRPC ルーター", () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    mockDeps = createMockDeps();
   });
 
   test("circles.inviteLinks.create は招待リンクを返す", async () => {
-    const { context, mocks } = createTestContext();
-    mocks.circleInviteLinkService.createInviteLink.mockResolvedValueOnce({
-      id: toCircleInviteLinkId("link-1"),
-      circleId: toCircleId("circle-1"),
-      token: TEST_TOKEN_UUID,
-      createdByUserId: toUserId("user-1"),
-      expiresAt: new Date("2026-02-23T00:00:00Z"),
-      createdAt: new Date("2026-02-16T00:00:00Z"),
+    // createInviteLink needs:
+    // 1. circleRepository.findById → circle exists
+    // 2. accessService.canViewCircle → authzRepository.findCircleMembership → member
+    // 3. circleInviteLinkRepository.findActiveByCircleId → null (no existing link)
+    // 4. circleInviteLinkRepository.save
+    mockDeps.circleRepository.findById.mockResolvedValue(BASE_CIRCLE);
+    mockDeps.authzRepository.findCircleMembership.mockResolvedValue({
+      kind: "member",
+      role: CircleRole.CircleMember,
     });
 
-    const caller = appRouter.createCaller(context);
+    const caller = appRouter.createCaller(buildContext());
     const result = await caller.circles.inviteLinks.create({
       circleId: "circle-1",
     });
 
-    expect(result.token).toBe(TEST_TOKEN_UUID);
     expect(result.circleId).toBe("circle-1");
+    expect(result.token).toBeDefined();
   });
 
   test("circles.inviteLinks.getInfo はリンク情報を返す", async () => {
-    const { context, mocks } = createTestContext();
-    mocks.circleInviteLinkService.getInviteLinkInfo.mockResolvedValueOnce({
-      token: TEST_TOKEN_UUID,
-      circleName: "テスト研究会",
-      circleId: toCircleId("circle-1"),
-      expired: false,
+    // getInviteLinkInfo needs:
+    // 1. circleInviteLinkRepository.findByToken → link
+    // 2. circleRepository.findById → circle (for name)
+    const futureDate = new Date();
+    futureDate.setDate(futureDate.getDate() + 7);
+    mockDeps.circleInviteLinkRepository.findByToken.mockResolvedValue({
+      id: toCircleInviteLinkId("link-1"),
+      circleId: CIRCLE_ID,
+      token: toInviteLinkToken(TEST_TOKEN_UUID),
+      createdByUserId: ACTOR_ID,
+      expiresAt: futureDate,
+      createdAt: new Date("2026-02-16T00:00:00Z"),
     });
+    mockDeps.circleRepository.findById.mockResolvedValue(BASE_CIRCLE);
 
-    const caller = appRouter.createCaller(context);
+    const caller = appRouter.createCaller(buildContext());
     const result = await caller.circles.inviteLinks.getInfo({
       token: TEST_TOKEN_UUID,
     });
@@ -131,13 +85,25 @@ describe("circleInviteLink tRPC ルーター", () => {
   });
 
   test("circles.inviteLinks.redeem は参加結果を返す", async () => {
-    const { context, mocks } = createTestContext();
-    mocks.circleInviteLinkService.redeemInviteLink.mockResolvedValueOnce({
-      circleId: toCircleId("circle-1"),
-      alreadyMember: false,
+    // redeemInviteLink needs:
+    // 1. circleInviteLinkRepository.findByToken → link (not expired)
+    // 2. circleRepository.findById → circle
+    // 3. circleRepository.listMembershipsByCircleId → no matching membership
+    // 4. circleRepository.addMembership
+    const futureDate = new Date();
+    futureDate.setDate(futureDate.getDate() + 7);
+    mockDeps.circleInviteLinkRepository.findByToken.mockResolvedValue({
+      id: toCircleInviteLinkId("link-1"),
+      circleId: CIRCLE_ID,
+      token: toInviteLinkToken(TEST_TOKEN_UUID),
+      createdByUserId: toUserId("other-user"),
+      expiresAt: futureDate,
+      createdAt: new Date("2026-02-16T00:00:00Z"),
     });
+    mockDeps.circleRepository.findById.mockResolvedValue(BASE_CIRCLE);
+    mockDeps.circleRepository.listMembershipsByCircleId.mockResolvedValue([]);
 
-    const caller = appRouter.createCaller(context);
+    const caller = appRouter.createCaller(buildContext());
     const result = await caller.circles.inviteLinks.redeem({
       token: TEST_TOKEN_UUID,
     });
@@ -147,13 +113,28 @@ describe("circleInviteLink tRPC ルーター", () => {
   });
 
   test("circles.inviteLinks.redeem は既存メンバーの場合 alreadyMember=true", async () => {
-    const { context, mocks } = createTestContext();
-    mocks.circleInviteLinkService.redeemInviteLink.mockResolvedValueOnce({
-      circleId: toCircleId("circle-1"),
-      alreadyMember: true,
+    const futureDate = new Date();
+    futureDate.setDate(futureDate.getDate() + 7);
+    mockDeps.circleInviteLinkRepository.findByToken.mockResolvedValue({
+      id: toCircleInviteLinkId("link-1"),
+      circleId: CIRCLE_ID,
+      token: toInviteLinkToken(TEST_TOKEN_UUID),
+      createdByUserId: toUserId("other-user"),
+      expiresAt: futureDate,
+      createdAt: new Date("2026-02-16T00:00:00Z"),
     });
+    mockDeps.circleRepository.findById.mockResolvedValue(BASE_CIRCLE);
+    mockDeps.circleRepository.listMembershipsByCircleId.mockResolvedValue([
+      {
+        circleId: CIRCLE_ID,
+        userId: ACTOR_ID,
+        role: CircleRole.CircleMember,
+        createdAt: new Date(),
+        deletedAt: null,
+      },
+    ]);
 
-    const caller = appRouter.createCaller(context);
+    const caller = appRouter.createCaller(buildContext());
     const result = await caller.circles.inviteLinks.redeem({
       token: TEST_TOKEN_UUID,
     });
@@ -162,12 +143,11 @@ describe("circleInviteLink tRPC ルーター", () => {
   });
 
   test("circles.inviteLinks.create はエラー時に適切なTRPCエラーを返す", async () => {
-    const { context, mocks } = createTestContext();
-    mocks.circleInviteLinkService.createInviteLink.mockRejectedValueOnce(
-      new ForbiddenError(),
-    );
+    // canViewCircle fails → ForbiddenError
+    mockDeps.circleRepository.findById.mockResolvedValue(BASE_CIRCLE);
+    // authzRepository.findCircleMembership defaults to { kind: "none" }
 
-    const caller = appRouter.createCaller(context);
+    const caller = appRouter.createCaller(buildContext());
 
     await expect(
       caller.circles.inviteLinks.create({ circleId: "circle-1" }),
@@ -175,8 +155,7 @@ describe("circleInviteLink tRPC ルーター", () => {
   });
 
   test("不正な形式のトークンはバリデーションエラーになる", async () => {
-    const { context } = createTestContext();
-    const caller = appRouter.createCaller(context);
+    const caller = appRouter.createCaller(buildContext());
 
     await expect(
       caller.circles.inviteLinks.getInfo({ token: "not-a-uuid" }),

--- a/server/presentation/trpc/routers/circle-session.test.ts
+++ b/server/presentation/trpc/routers/circle-session.test.ts
@@ -1,98 +1,41 @@
 import { beforeEach, describe, expect, test, vi } from "vitest";
 import { appRouter } from "@/server/presentation/trpc/router";
-import type { Context } from "@/server/presentation/trpc/context";
-import { toUserId } from "@/server/domain/common/ids";
-import { BadRequestError } from "@/server/domain/common/errors";
+import { toCircleId, toUserId } from "@/server/domain/common/ids";
+import { CircleRole } from "@/server/domain/models/circle/circle-role";
+import {
+  createMockDeps,
+  createServiceContainer,
+  toServiceContainerDeps,
+  type MockDeps,
+} from "@/server/presentation/providers/__tests__/helpers/create-mock-deps";
 
-const createTestContext = (
-  actorIdValue: ReturnType<typeof toUserId> | null = toUserId("user-1"),
-) => {
-  const circleSessionService = {
-    listByCircleId: vi.fn(),
-    getCircleSession: vi.fn(),
-    createCircleSession: vi.fn(),
-    rescheduleCircleSession: vi.fn(),
-    updateCircleSessionDetails: vi.fn(),
-    deleteCircleSession: vi.fn(),
-  };
+const ACTOR_ID = toUserId("user-1");
+const CIRCLE_ID = toCircleId("circle-1");
 
-  const context: Context = {
-    actorId: actorIdValue,
-    clientIp: "1.2.3.4",
-    circleService: {
-      getCircle: vi.fn(),
-      createCircle: vi.fn(),
-      renameCircle: vi.fn(),
-      deleteCircle: vi.fn(),
-      updateSessionEmailNotificationEnabled: vi.fn(),
-    },
-    circleMembershipService: {
-      listByCircleId: vi.fn(),
-      listByUserId: vi.fn(),
-      addMembership: vi.fn(),
-      changeMembershipRole: vi.fn(),
-      withdrawMembership: vi.fn(),
-      removeMembership: vi.fn(),
-      transferOwnership: vi.fn(),
-    },
-    circleSessionService,
-    circleSessionMembershipService: {
-      countPastSessionsByUserId: vi.fn(),
-      listMemberships: vi.fn(),
-      listByUserId: vi.fn(),
-      addMembership: vi.fn(),
-      changeMembershipRole: vi.fn(),
-      removeMembership: vi.fn(),
-      transferOwnership: vi.fn(),
-      withdrawMembership: vi.fn(),
-      listDeletedMemberships: vi.fn(),
-    },
-    matchService: {
-      listByCircleSessionId: vi.fn(),
-      getMatch: vi.fn(),
-      recordMatch: vi.fn(),
-      updateMatch: vi.fn(),
-      deleteMatch: vi.fn(),
-    },
-    userService: {
-      getUser: vi.fn(),
-      listUsers: vi.fn(),
-      getMe: vi.fn(),
-      updateProfile: vi.fn(),
-      updateProfileVisibility: vi.fn(),
-      changePassword: vi.fn(),
-      uploadAvatar: vi.fn().mockResolvedValue(undefined),
-      findImageData: vi.fn().mockResolvedValue(null),
-      deleteAccount: vi.fn(),
-    },
-    signupService: {
-      signup: vi.fn(),
-    },
-    circleInviteLinkService: {
-      createInviteLink: vi.fn(),
-      getInviteLinkInfo: vi.fn(),
-      redeemInviteLink: vi.fn(),
-    },
-    accessService: {} as Context["accessService"],
-    userStatisticsService: {} as Context["userStatisticsService"],
-    roundRobinScheduleService: {} as Context["roundRobinScheduleService"],
-    holidayProvider: {} as Context["holidayProvider"],
-    notificationPreferenceService: {} as Context["notificationPreferenceService"],
-  };
+const BASE_CIRCLE = {
+  id: CIRCLE_ID,
+  name: "テスト研究会",
+  createdAt: new Date("2024-01-01T00:00:00Z"),
+  sessionEmailNotificationEnabled: true,
+};
 
-  return { context, mocks: { circleSessionService } };
+let mockDeps: MockDeps;
+
+const buildContext = (actorId: ReturnType<typeof toUserId> | null = ACTOR_ID) => {
+  const services = createServiceContainer(toServiceContainerDeps(mockDeps));
+  return { actorId, clientIp: "1.2.3.4", ...services };
 };
 
 describe("circle-session tRPC ルーター", () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    mockDeps = createMockDeps();
   });
 
   describe("create", () => {
     test("空のセッション名 → BAD_REQUEST（Zodバリデーション）", async () => {
-      const { context, mocks } = createTestContext();
-
-      const caller = appRouter.createCaller(context);
+      // Zod validation fires before service is called, so no repo setup needed
+      const caller = appRouter.createCaller(buildContext());
 
       await expect(
         caller.circleSessions.create({
@@ -104,19 +47,22 @@ describe("circle-session tRPC ルーター", () => {
       ).rejects.toMatchObject({ code: "BAD_REQUEST" });
 
       expect(
-        mocks.circleSessionService.createCircleSession,
+        mockDeps.circleSessionRepository.save,
       ).not.toHaveBeenCalled();
     });
 
     test("BadRequestError（開始日時が終了日時より後）→ BAD_REQUEST", async () => {
-      const { context, mocks } = createTestContext();
-      mocks.circleSessionService.createCircleSession.mockRejectedValueOnce(
-        new BadRequestError(
-          "CircleSession start must be before or equal to end",
-        ),
-      );
+      // createCircleSession needs:
+      // 1. circleRepository.findById → circle exists
+      // 2. accessService.canCreateCircleSession → authzRepository.findCircleMembership → CircleOwner/Manager
+      // 3. createCircleSession domain function validates startsAt <= endsAt
+      mockDeps.circleRepository.findById.mockResolvedValue(BASE_CIRCLE);
+      mockDeps.authzRepository.findCircleMembership.mockResolvedValue({
+        kind: "member",
+        role: CircleRole.CircleOwner,
+      });
 
-      const caller = appRouter.createCaller(context);
+      const caller = appRouter.createCaller(buildContext());
 
       await expect(
         caller.circleSessions.create({
@@ -129,10 +75,6 @@ describe("circle-session tRPC ルーター", () => {
         code: "BAD_REQUEST",
         message: "CircleSession start must be before or equal to end",
       });
-
-      expect(
-        mocks.circleSessionService.createCircleSession,
-      ).toHaveBeenCalledOnce();
     });
   });
 });

--- a/server/presentation/trpc/routers/circle.test.ts
+++ b/server/presentation/trpc/routers/circle.test.ts
@@ -1,81 +1,57 @@
 import { beforeEach, describe, expect, test, vi } from "vitest";
 import { appRouter } from "@/server/presentation/trpc/router";
-import type { Context } from "@/server/presentation/trpc/context";
-import { toUserId } from "@/server/domain/common/ids";
-import { ForbiddenError } from "@/server/domain/common/errors";
+import { toCircleId, toUserId } from "@/server/domain/common/ids";
+import { CircleRole } from "@/server/domain/models/circle/circle-role";
+import {
+  createMockDeps,
+  createServiceContainer,
+  toServiceContainerDeps,
+  type MockDeps,
+} from "@/server/presentation/providers/__tests__/helpers/create-mock-deps";
 
-const createTestContext = (
-  actorIdValue: ReturnType<typeof toUserId> | null = toUserId("user-1"),
-) => {
-  const circleService = {
-    getCircle: vi.fn(),
-    createCircle: vi.fn(),
-    renameCircle: vi.fn(),
-    deleteCircle: vi.fn(),
-    updateSessionEmailNotificationEnabled: vi.fn(),
-  };
+const ACTOR_ID = toUserId("user-1");
+const CIRCLE_ID = toCircleId("circle-1");
 
-  const context: Context = {
-    actorId: actorIdValue,
-    clientIp: "1.2.3.4",
-    circleService,
-    circleMembershipService: {
-      listByCircleId: vi.fn(),
-      listByUserId: vi.fn(),
-      addMembership: vi.fn(),
-      changeMembershipRole: vi.fn(),
-      withdrawMembership: vi.fn(),
-      removeMembership: vi.fn(),
-      transferOwnership: vi.fn(),
-    },
-    circleSessionService: {} as Context["circleSessionService"],
-    circleSessionMembershipService:
-      {} as Context["circleSessionMembershipService"],
-    matchService: {} as Context["matchService"],
-    userService: {} as Context["userService"],
-    signupService: {} as Context["signupService"],
-    circleInviteLinkService: {} as Context["circleInviteLinkService"],
-    accessService: {} as Context["accessService"],
-    userStatisticsService: {} as Context["userStatisticsService"],
-    roundRobinScheduleService: {} as Context["roundRobinScheduleService"],
-    holidayProvider: {} as Context["holidayProvider"],
-    notificationPreferenceService:
-      {} as Context["notificationPreferenceService"],
-  };
+const BASE_CIRCLE = {
+  id: CIRCLE_ID,
+  name: "テスト研究会",
+  createdAt: new Date("2024-01-01T00:00:00Z"),
+  sessionEmailNotificationEnabled: true,
+};
 
-  return { context, mocks: { circleService } };
+let mockDeps: MockDeps;
+
+const buildContext = (actorId: ReturnType<typeof toUserId> | null = ACTOR_ID) => {
+  const services = createServiceContainer(toServiceContainerDeps(mockDeps));
+  return { actorId, clientIp: "1.2.3.4", ...services };
 };
 
 describe("circles.updateSessionEmailNotification", () => {
-  let ctx: ReturnType<typeof createTestContext>;
-
   beforeEach(() => {
-    ctx = createTestContext();
+    vi.clearAllMocks();
+    mockDeps = createMockDeps();
   });
 
   test("正常に設定を更新できる", async () => {
-    ctx.mocks.circleService.updateSessionEmailNotificationEnabled.mockResolvedValue(
-      undefined,
-    );
+    mockDeps.circleRepository.findById.mockResolvedValue(BASE_CIRCLE);
+    mockDeps.authzRepository.findCircleMembership.mockResolvedValue({
+      kind: "member",
+      role: CircleRole.CircleOwner,
+    });
 
-    const caller = appRouter.createCaller(ctx.context);
+    const caller = appRouter.createCaller(buildContext());
     await caller.circles.updateSessionEmailNotification({
       circleId: "circle-1",
       enabled: false,
     });
 
-    expect(
-      ctx.mocks.circleService.updateSessionEmailNotificationEnabled,
-    ).toHaveBeenCalledWith(
-      toUserId("user-1"),
-      expect.anything(),
-      false,
+    expect(mockDeps.circleRepository.save).toHaveBeenCalledWith(
+      expect.objectContaining({ sessionEmailNotificationEnabled: false }),
     );
   });
 
   test("未認証ユーザーはUNAUTHORIZEDエラーになる", async () => {
-    const unauthCtx = createTestContext(null);
-    const caller = appRouter.createCaller(unauthCtx.context);
+    const caller = appRouter.createCaller(buildContext(null));
 
     await expect(
       caller.circles.updateSessionEmailNotification({
@@ -86,11 +62,10 @@ describe("circles.updateSessionEmailNotification", () => {
   });
 
   test("権限のないユーザーはFORBIDDENエラーになる", async () => {
-    ctx.mocks.circleService.updateSessionEmailNotificationEnabled.mockRejectedValue(
-      new ForbiddenError(),
-    );
+    mockDeps.circleRepository.findById.mockResolvedValue(BASE_CIRCLE);
+    // authzRepository.findCircleMembership defaults to { kind: "none" }
 
-    const caller = appRouter.createCaller(ctx.context);
+    const caller = appRouter.createCaller(buildContext());
 
     await expect(
       caller.circles.updateSessionEmailNotification({

--- a/server/presentation/trpc/routers/match.test.ts
+++ b/server/presentation/trpc/routers/match.test.ts
@@ -1,91 +1,38 @@
 import { beforeEach, describe, expect, test, vi } from "vitest";
 import { appRouter } from "@/server/presentation/trpc/router";
-import type { Context } from "@/server/presentation/trpc/context";
-import { toCircleSessionId, toMatchId, toUserId } from "@/server/domain/common/ids";
-import { BadRequestError, ForbiddenError } from "@/server/domain/common/errors";
+import {
+  toCircleId,
+  toCircleSessionId,
+  toMatchId,
+  toUserId,
+} from "@/server/domain/common/ids";
+import { CircleRole } from "@/server/domain/models/circle/circle-role";
+import {
+  createMockDeps,
+  createServiceContainer,
+  toServiceContainerDeps,
+  type MockDeps,
+} from "@/server/presentation/providers/__tests__/helpers/create-mock-deps";
 
-const createTestContext = (
-  actorIdValue: ReturnType<typeof toUserId> | null = toUserId("user-1"),
-) => {
-  const matchService = {
-    listByCircleSessionId: vi.fn(),
-    getMatch: vi.fn(),
-    recordMatch: vi.fn(),
-    updateMatch: vi.fn(),
-    deleteMatch: vi.fn(),
-  };
+const ACTOR_ID = toUserId("user-1");
+const CIRCLE_ID = toCircleId("circle-1");
+const SESSION_ID = toCircleSessionId("session-1");
+const MATCH_ID = toMatchId("match-1");
 
-  const context: Context = {
-    actorId: actorIdValue,
-    clientIp: "1.2.3.4",
-    circleService: {
-      getCircle: vi.fn(),
-      createCircle: vi.fn(),
-      renameCircle: vi.fn(),
-      deleteCircle: vi.fn(),
-      updateSessionEmailNotificationEnabled: vi.fn(),
-    },
-    circleMembershipService: {
-      listByCircleId: vi.fn(),
-      listByUserId: vi.fn(),
-      addMembership: vi.fn(),
-      changeMembershipRole: vi.fn(),
-      withdrawMembership: vi.fn(),
-      removeMembership: vi.fn(),
-      transferOwnership: vi.fn(),
-    },
-    circleSessionService: {
-      listByCircleId: vi.fn(),
-      getCircleSession: vi.fn(),
-      createCircleSession: vi.fn(),
-      rescheduleCircleSession: vi.fn(),
-      updateCircleSessionDetails: vi.fn(),
-      deleteCircleSession: vi.fn(),
-    },
-    circleSessionMembershipService: {
-      countPastSessionsByUserId: vi.fn(),
-      listMemberships: vi.fn(),
-      listByUserId: vi.fn(),
-      addMembership: vi.fn(),
-      changeMembershipRole: vi.fn(),
-      removeMembership: vi.fn(),
-      transferOwnership: vi.fn(),
-      withdrawMembership: vi.fn(),
-      listDeletedMemberships: vi.fn(),
-    },
-    matchService,
-    userService: {
-      getUser: vi.fn(),
-      listUsers: vi.fn(),
-      getMe: vi.fn(),
-      updateProfile: vi.fn(),
-      updateProfileVisibility: vi.fn(),
-      changePassword: vi.fn(),
-      uploadAvatar: vi.fn().mockResolvedValue(undefined),
-      findImageData: vi.fn().mockResolvedValue(null),
-      deleteAccount: vi.fn(),
-    },
-    signupService: {
-      signup: vi.fn(),
-    },
-    circleInviteLinkService: {
-      createInviteLink: vi.fn(),
-      getInviteLinkInfo: vi.fn(),
-      redeemInviteLink: vi.fn(),
-    },
-    accessService: {} as Context["accessService"],
-    userStatisticsService: {} as Context["userStatisticsService"],
-    roundRobinScheduleService: {} as Context["roundRobinScheduleService"],
-    holidayProvider: {} as Context["holidayProvider"],
-    notificationPreferenceService: {} as Context["notificationPreferenceService"],
-  };
-
-  return { context, mocks: { matchService } };
+const BASE_SESSION = {
+  id: SESSION_ID,
+  circleId: CIRCLE_ID,
+  title: "テスト",
+  startsAt: new Date("2024-06-01T10:00:00Z"),
+  endsAt: new Date("2024-06-01T17:00:00Z"),
+  location: null,
+  note: "",
+  createdAt: new Date("2024-01-01T00:00:00Z"),
 };
 
 const baseMatch = () => ({
-  id: toMatchId("match-1"),
-  circleSessionId: toCircleSessionId("session-1"),
+  id: MATCH_ID,
+  circleSessionId: SESSION_ID,
   createdAt: new Date("2024-06-01T10:00:00Z"),
   player1Id: toUserId("player-1"),
   player2Id: toUserId("player-2"),
@@ -93,18 +40,40 @@ const baseMatch = () => ({
   deletedAt: null,
 });
 
+let mockDeps: MockDeps;
+
+const buildContext = (actorId: ReturnType<typeof toUserId> | null = ACTOR_ID) => {
+  const services = createServiceContainer(toServiceContainerDeps(mockDeps));
+  return { actorId, clientIp: "1.2.3.4", ...services };
+};
+
+/** Set up authz for match operations (circle member = can view/record/edit/delete) */
+const setupMatchAccess = () => {
+  mockDeps.authzRepository.findCircleMembership.mockResolvedValue({
+    kind: "member",
+    role: CircleRole.CircleMember,
+  });
+};
+
 describe("match tRPC ルーター", () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    mockDeps = createMockDeps();
   });
 
   describe("list", () => {
     test("セッションの全対局一覧を取得できる", async () => {
-      const { context, mocks } = createTestContext();
-      const match = baseMatch();
-      mocks.matchService.listByCircleSessionId.mockResolvedValueOnce([match]);
+      setupMatchAccess();
+      // listByCircleSessionId needs:
+      // 1. circleSessionRepository.findById → session
+      // 2. canViewMatch → circle/session membership
+      // 3. matchRepository.listByCircleSessionId → matches
+      mockDeps.circleSessionRepository.findById.mockResolvedValue(BASE_SESSION);
+      mockDeps.matchRepository.listByCircleSessionId.mockResolvedValue([
+        baseMatch(),
+      ]);
 
-      const caller = appRouter.createCaller(context);
+      const caller = appRouter.createCaller(buildContext());
       const result = await caller.matches.list({
         circleSessionId: "session-1",
       });
@@ -116,10 +85,11 @@ describe("match tRPC ルーター", () => {
     });
 
     test("空配列を返す（対局なし）", async () => {
-      const { context, mocks } = createTestContext();
-      mocks.matchService.listByCircleSessionId.mockResolvedValueOnce([]);
+      setupMatchAccess();
+      mockDeps.circleSessionRepository.findById.mockResolvedValue(BASE_SESSION);
+      mockDeps.matchRepository.listByCircleSessionId.mockResolvedValue([]);
 
-      const caller = appRouter.createCaller(context);
+      const caller = appRouter.createCaller(buildContext());
       const result = await caller.matches.list({
         circleSessionId: "session-1",
       });
@@ -128,12 +98,10 @@ describe("match tRPC ルーター", () => {
     });
 
     test("ForbiddenError → FORBIDDEN", async () => {
-      const { context, mocks } = createTestContext();
-      mocks.matchService.listByCircleSessionId.mockRejectedValueOnce(
-        new ForbiddenError(),
-      );
+      // No membership → canViewMatch fails
+      mockDeps.circleSessionRepository.findById.mockResolvedValue(BASE_SESSION);
 
-      const caller = appRouter.createCaller(context);
+      const caller = appRouter.createCaller(buildContext());
 
       await expect(
         caller.matches.list({ circleSessionId: "session-1" }),
@@ -141,8 +109,7 @@ describe("match tRPC ルーター", () => {
     });
 
     test("未認証: actorId null → UNAUTHORIZED", async () => {
-      const { context } = createTestContext(null);
-      const caller = appRouter.createCaller(context);
+      const caller = appRouter.createCaller(buildContext(null));
 
       await expect(
         caller.matches.list({ circleSessionId: "session-1" }),
@@ -152,11 +119,15 @@ describe("match tRPC ルーター", () => {
 
   describe("get", () => {
     test("対局1件を取得できる", async () => {
-      const { context, mocks } = createTestContext();
-      const match = baseMatch();
-      mocks.matchService.getMatch.mockResolvedValueOnce(match);
+      setupMatchAccess();
+      // getMatch needs:
+      // 1. matchRepository.findById → match
+      // 2. circleSessionRepository.findById → session (to get circleId)
+      // 3. canViewMatch
+      mockDeps.matchRepository.findById.mockResolvedValue(baseMatch());
+      mockDeps.circleSessionRepository.findById.mockResolvedValue(BASE_SESSION);
 
-      const caller = appRouter.createCaller(context);
+      const caller = appRouter.createCaller(buildContext());
       const result = await caller.matches.get({ matchId: "match-1" });
 
       expect(result.id).toBe("match-1");
@@ -166,10 +137,8 @@ describe("match tRPC ルーター", () => {
     });
 
     test("存在しない対局 → NOT_FOUND", async () => {
-      const { context, mocks } = createTestContext();
-      mocks.matchService.getMatch.mockResolvedValueOnce(null);
-
-      const caller = appRouter.createCaller(context);
+      // matchRepository.findById defaults to null → NotFoundError in router
+      const caller = appRouter.createCaller(buildContext());
 
       await expect(
         caller.matches.get({ matchId: "nonexistent" }),
@@ -177,10 +146,11 @@ describe("match tRPC ルーター", () => {
     });
 
     test("ForbiddenError → FORBIDDEN", async () => {
-      const { context, mocks } = createTestContext();
-      mocks.matchService.getMatch.mockRejectedValueOnce(new ForbiddenError());
+      // Match exists but no membership → canViewMatch fails
+      mockDeps.matchRepository.findById.mockResolvedValue(baseMatch());
+      mockDeps.circleSessionRepository.findById.mockResolvedValue(BASE_SESSION);
 
-      const caller = appRouter.createCaller(context);
+      const caller = appRouter.createCaller(buildContext());
 
       await expect(
         caller.matches.get({ matchId: "match-1" }),
@@ -188,8 +158,7 @@ describe("match tRPC ルーター", () => {
     });
 
     test("未認証: actorId null → UNAUTHORIZED", async () => {
-      const { context } = createTestContext(null);
-      const caller = appRouter.createCaller(context);
+      const caller = appRouter.createCaller(buildContext(null));
 
       await expect(
         caller.matches.get({ matchId: "match-1" }),
@@ -199,11 +168,18 @@ describe("match tRPC ルーター", () => {
 
   describe("create", () => {
     test("対局を作成できる（outcome あり）", async () => {
-      const { context, mocks } = createTestContext();
-      const match = baseMatch();
-      mocks.matchService.recordMatch.mockResolvedValueOnce(match);
+      setupMatchAccess();
+      // recordMatch needs:
+      // 1. circleSessionRepository.findById → session
+      // 2. canRecordMatch → circle/session membership
+      // 3. circleSessionRepository.areUsersSessionMembers → true
+      // 4. matchRepository.save
+      mockDeps.circleSessionRepository.findById.mockResolvedValue(BASE_SESSION);
+      mockDeps.circleSessionRepository.areUsersSessionMembers.mockResolvedValue(
+        true,
+      );
 
-      const caller = appRouter.createCaller(context);
+      const caller = appRouter.createCaller(buildContext());
       const result = await caller.matches.create({
         circleSessionId: "session-1",
         player1Id: "player-1",
@@ -211,16 +187,18 @@ describe("match tRPC ルーター", () => {
         outcome: "P1_WIN",
       });
 
-      expect(result.id).toBe("match-1");
+      expect(result.id).toBeDefined();
       expect(result.outcome).toBe("P1_WIN");
     });
 
     test("対局を作成できる（outcome なし）", async () => {
-      const { context, mocks } = createTestContext();
-      const match = { ...baseMatch(), outcome: "UNKNOWN" as const };
-      mocks.matchService.recordMatch.mockResolvedValueOnce(match);
+      setupMatchAccess();
+      mockDeps.circleSessionRepository.findById.mockResolvedValue(BASE_SESSION);
+      mockDeps.circleSessionRepository.areUsersSessionMembers.mockResolvedValue(
+        true,
+      );
 
-      const caller = appRouter.createCaller(context);
+      const caller = appRouter.createCaller(buildContext());
       const result = await caller.matches.create({
         circleSessionId: "session-1",
         player1Id: "player-1",
@@ -231,12 +209,10 @@ describe("match tRPC ルーター", () => {
     });
 
     test("ForbiddenError → FORBIDDEN", async () => {
-      const { context, mocks } = createTestContext();
-      mocks.matchService.recordMatch.mockRejectedValueOnce(
-        new ForbiddenError(),
-      );
+      // No membership → canRecordMatch fails
+      mockDeps.circleSessionRepository.findById.mockResolvedValue(BASE_SESSION);
 
-      const caller = appRouter.createCaller(context);
+      const caller = appRouter.createCaller(buildContext());
 
       await expect(
         caller.matches.create({
@@ -248,9 +224,7 @@ describe("match tRPC ルーター", () => {
     });
 
     test("同一プレイヤーID → BAD_REQUEST（Zodバリデーション）", async () => {
-      const { context } = createTestContext();
-
-      const caller = appRouter.createCaller(context);
+      const caller = appRouter.createCaller(buildContext());
 
       await expect(
         caller.matches.create({
@@ -267,8 +241,7 @@ describe("match tRPC ルーター", () => {
     });
 
     test("未認証: actorId null → UNAUTHORIZED", async () => {
-      const { context } = createTestContext(null);
-      const caller = appRouter.createCaller(context);
+      const caller = appRouter.createCaller(buildContext(null));
 
       await expect(
         caller.matches.create({
@@ -282,15 +255,20 @@ describe("match tRPC ルーター", () => {
 
   describe("update", () => {
     test("対局を更新できる（プレイヤー変更）", async () => {
-      const { context, mocks } = createTestContext();
-      const updated = {
-        ...baseMatch(),
-        player1Id: toUserId("player-3"),
-        player2Id: toUserId("player-4"),
-      };
-      mocks.matchService.updateMatch.mockResolvedValueOnce(updated);
+      setupMatchAccess();
+      // updateMatch needs:
+      // 1. matchRepository.findById → match (not deleted)
+      // 2. circleSessionRepository.findById → session
+      // 3. canEditMatch → circle/session membership
+      // 4. circleSessionRepository.areUsersSessionMembers → true (for player change)
+      // 5. matchRepository.save
+      mockDeps.matchRepository.findById.mockResolvedValue(baseMatch());
+      mockDeps.circleSessionRepository.findById.mockResolvedValue(BASE_SESSION);
+      mockDeps.circleSessionRepository.areUsersSessionMembers.mockResolvedValue(
+        true,
+      );
 
-      const caller = appRouter.createCaller(context);
+      const caller = appRouter.createCaller(buildContext());
       const result = await caller.matches.update({
         matchId: "match-1",
         player1Id: "player-3",
@@ -302,11 +280,11 @@ describe("match tRPC ルーター", () => {
     });
 
     test("対局を更新できる（outcome のみ変更）", async () => {
-      const { context, mocks } = createTestContext();
-      const updated = { ...baseMatch(), outcome: "DRAW" as const };
-      mocks.matchService.updateMatch.mockResolvedValueOnce(updated);
+      setupMatchAccess();
+      mockDeps.matchRepository.findById.mockResolvedValue(baseMatch());
+      mockDeps.circleSessionRepository.findById.mockResolvedValue(BASE_SESSION);
 
-      const caller = appRouter.createCaller(context);
+      const caller = appRouter.createCaller(buildContext());
       const result = await caller.matches.update({
         matchId: "match-1",
         outcome: "DRAW",
@@ -316,12 +294,11 @@ describe("match tRPC ルーター", () => {
     });
 
     test("ForbiddenError → FORBIDDEN", async () => {
-      const { context, mocks } = createTestContext();
-      mocks.matchService.updateMatch.mockRejectedValueOnce(
-        new ForbiddenError(),
-      );
+      // No membership → canEditMatch fails
+      mockDeps.matchRepository.findById.mockResolvedValue(baseMatch());
+      mockDeps.circleSessionRepository.findById.mockResolvedValue(BASE_SESSION);
 
-      const caller = appRouter.createCaller(context);
+      const caller = appRouter.createCaller(buildContext());
 
       await expect(
         caller.matches.update({ matchId: "match-1", outcome: "DRAW" }),
@@ -329,12 +306,13 @@ describe("match tRPC ルーター", () => {
     });
 
     test("BadRequestError（削除済み対局）→ BAD_REQUEST", async () => {
-      const { context, mocks } = createTestContext();
-      mocks.matchService.updateMatch.mockRejectedValueOnce(
-        new BadRequestError("Match is deleted"),
-      );
+      setupMatchAccess();
+      mockDeps.matchRepository.findById.mockResolvedValue({
+        ...baseMatch(),
+        deletedAt: new Date("2024-06-02T00:00:00Z"),
+      });
 
-      const caller = appRouter.createCaller(context);
+      const caller = appRouter.createCaller(buildContext());
 
       await expect(
         caller.matches.update({ matchId: "match-1", outcome: "DRAW" }),
@@ -342,8 +320,7 @@ describe("match tRPC ルーター", () => {
     });
 
     test("未認証: actorId null → UNAUTHORIZED", async () => {
-      const { context } = createTestContext(null);
-      const caller = appRouter.createCaller(context);
+      const caller = appRouter.createCaller(buildContext(null));
 
       await expect(
         caller.matches.update({ matchId: "match-1", outcome: "DRAW" }),
@@ -353,26 +330,27 @@ describe("match tRPC ルーター", () => {
 
   describe("delete", () => {
     test("対局を論理削除できる", async () => {
-      const { context, mocks } = createTestContext();
-      const deleted = {
-        ...baseMatch(),
-        deletedAt: new Date("2024-06-02T00:00:00Z"),
-      };
-      mocks.matchService.deleteMatch.mockResolvedValueOnce(deleted);
+      setupMatchAccess();
+      // deleteMatch needs:
+      // 1. matchRepository.findById → match (not deleted)
+      // 2. circleSessionRepository.findById → session
+      // 3. canDeleteMatch → circle/session membership
+      // 4. matchRepository.save (with deletedAt set)
+      mockDeps.matchRepository.findById.mockResolvedValue(baseMatch());
+      mockDeps.circleSessionRepository.findById.mockResolvedValue(BASE_SESSION);
 
-      const caller = appRouter.createCaller(context);
+      const caller = appRouter.createCaller(buildContext());
       const result = await caller.matches.delete({ matchId: "match-1" });
 
-      expect(result.deletedAt).toEqual(new Date("2024-06-02T00:00:00Z"));
+      expect(result.deletedAt).toBeInstanceOf(Date);
     });
 
     test("ForbiddenError → FORBIDDEN", async () => {
-      const { context, mocks } = createTestContext();
-      mocks.matchService.deleteMatch.mockRejectedValueOnce(
-        new ForbiddenError(),
-      );
+      // No membership → canDeleteMatch fails
+      mockDeps.matchRepository.findById.mockResolvedValue(baseMatch());
+      mockDeps.circleSessionRepository.findById.mockResolvedValue(BASE_SESSION);
 
-      const caller = appRouter.createCaller(context);
+      const caller = appRouter.createCaller(buildContext());
 
       await expect(
         caller.matches.delete({ matchId: "match-1" }),
@@ -380,12 +358,13 @@ describe("match tRPC ルーター", () => {
     });
 
     test("BadRequestError（削除済み対局）→ BAD_REQUEST", async () => {
-      const { context, mocks } = createTestContext();
-      mocks.matchService.deleteMatch.mockRejectedValueOnce(
-        new BadRequestError("Match is deleted"),
-      );
+      setupMatchAccess();
+      mockDeps.matchRepository.findById.mockResolvedValue({
+        ...baseMatch(),
+        deletedAt: new Date("2024-06-02T00:00:00Z"),
+      });
 
-      const caller = appRouter.createCaller(context);
+      const caller = appRouter.createCaller(buildContext());
 
       await expect(
         caller.matches.delete({ matchId: "match-1" }),
@@ -396,8 +375,7 @@ describe("match tRPC ルーター", () => {
     });
 
     test("未認証: actorId null → UNAUTHORIZED", async () => {
-      const { context } = createTestContext(null);
-      const caller = appRouter.createCaller(context);
+      const caller = appRouter.createCaller(buildContext(null));
 
       await expect(
         caller.matches.delete({ matchId: "match-1" }),

--- a/server/presentation/trpc/routers/round-robin-schedule.test.ts
+++ b/server/presentation/trpc/routers/round-robin-schedule.test.ts
@@ -1,103 +1,36 @@
 import { beforeEach, describe, expect, test, vi } from "vitest";
 import { appRouter } from "@/server/presentation/trpc/router";
-import type { Context } from "@/server/presentation/trpc/context";
 import {
+  toCircleId,
   toCircleSessionId,
   toRoundRobinScheduleId,
   toUserId,
 } from "@/server/domain/common/ids";
-import { BadRequestError, ForbiddenError } from "@/server/domain/common/errors";
+import { CircleRole } from "@/server/domain/models/circle/circle-role";
+import { CircleSessionRole } from "@/server/domain/models/circle-session/circle-session-role";
+import {
+  createMockDeps,
+  createServiceContainer,
+  toServiceContainerDeps,
+  type MockDeps,
+} from "@/server/presentation/providers/__tests__/helpers/create-mock-deps";
 import type { RoundRobinSchedule } from "@/server/domain/models/round-robin-schedule/round-robin-schedule";
 import type { User } from "@/server/domain/models/user/user";
 
-const createTestContext = (
-  actorIdValue: ReturnType<typeof toUserId> | null = toUserId("user-1"),
-) => {
-  const roundRobinScheduleService = {
-    getSchedule: vi.fn(),
-    generateSchedule: vi.fn(),
-    deleteSchedule: vi.fn(),
-  };
+const ACTOR_ID = toUserId("user-1");
+const CIRCLE_ID = toCircleId("circle-1");
+const SESSION_ID = toCircleSessionId("session-1");
 
-  const userService = {
-    getUser: vi.fn(),
-    listUsers: vi.fn(),
-    getMe: vi.fn(),
-    updateProfile: vi.fn(),
-    updateProfileVisibility: vi.fn(),
-    changePassword: vi.fn(),
-    uploadAvatar: vi.fn().mockResolvedValue(undefined),
-    findImageData: vi.fn().mockResolvedValue(null),
-    deleteAccount: vi.fn(),
-  };
+let mockDeps: MockDeps;
 
-  const context: Context = {
-    actorId: actorIdValue,
-    clientIp: "1.2.3.4",
-    circleService: {
-      getCircle: vi.fn(),
-      createCircle: vi.fn(),
-      renameCircle: vi.fn(),
-      deleteCircle: vi.fn(),
-      updateSessionEmailNotificationEnabled: vi.fn(),
-    },
-    circleMembershipService: {
-      listByCircleId: vi.fn(),
-      listByUserId: vi.fn(),
-      addMembership: vi.fn(),
-      changeMembershipRole: vi.fn(),
-      withdrawMembership: vi.fn(),
-      removeMembership: vi.fn(),
-      transferOwnership: vi.fn(),
-    },
-    circleSessionService: {
-      listByCircleId: vi.fn(),
-      getCircleSession: vi.fn(),
-      createCircleSession: vi.fn(),
-      rescheduleCircleSession: vi.fn(),
-      updateCircleSessionDetails: vi.fn(),
-      deleteCircleSession: vi.fn(),
-    },
-    circleSessionMembershipService: {
-      countPastSessionsByUserId: vi.fn(),
-      listMemberships: vi.fn(),
-      listByUserId: vi.fn(),
-      addMembership: vi.fn(),
-      changeMembershipRole: vi.fn(),
-      removeMembership: vi.fn(),
-      transferOwnership: vi.fn(),
-      withdrawMembership: vi.fn(),
-      listDeletedMemberships: vi.fn(),
-    },
-    matchService: {
-      listByCircleSessionId: vi.fn(),
-      getMatch: vi.fn(),
-      recordMatch: vi.fn(),
-      updateMatch: vi.fn(),
-      deleteMatch: vi.fn(),
-    },
-    userService,
-    signupService: {
-      signup: vi.fn(),
-    },
-    circleInviteLinkService: {
-      createInviteLink: vi.fn(),
-      getInviteLinkInfo: vi.fn(),
-      redeemInviteLink: vi.fn(),
-    },
-    accessService: {} as Context["accessService"],
-    userStatisticsService: {} as Context["userStatisticsService"],
-    roundRobinScheduleService,
-    holidayProvider: {} as Context["holidayProvider"],
-    notificationPreferenceService: {} as Context["notificationPreferenceService"],
-  };
-
-  return { context, mocks: { roundRobinScheduleService, userService } };
+const buildContext = (actorId: ReturnType<typeof toUserId> | null = ACTOR_ID) => {
+  const services = createServiceContainer(toServiceContainerDeps(mockDeps));
+  return { actorId, clientIp: "1.2.3.4", ...services };
 };
 
 const baseSchedule = (): RoundRobinSchedule => ({
   id: toRoundRobinScheduleId("schedule-1"),
-  circleSessionId: toCircleSessionId("session-1"),
+  circleSessionId: SESSION_ID,
   rounds: [
     {
       roundNumber: 1,
@@ -131,20 +64,43 @@ const baseUsers = (): User[] => [
   },
 ];
 
+const setupViewAccess = () => {
+  // canViewRoundRobinSchedule checks both circle and session membership
+  mockDeps.authzRepository.findCircleMembership.mockResolvedValue({
+    kind: "member",
+    role: CircleRole.CircleMember,
+  });
+  // canViewUser for listUsers
+  mockDeps.authzRepository.isRegisteredUser.mockResolvedValue(true);
+};
+
+const setupManageAccess = () => {
+  // canManageRoundRobinSchedule checks session membership with Owner/Manager role
+  mockDeps.authzRepository.findCircleSessionMembership.mockResolvedValue({
+    kind: "member",
+    role: CircleSessionRole.CircleSessionOwner,
+  });
+  // canViewUser for listUsers
+  mockDeps.authzRepository.isRegisteredUser.mockResolvedValue(true);
+};
+
 describe("roundRobinSchedule tRPC ルーター", () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    mockDeps = createMockDeps();
   });
 
   describe("get", () => {
     test("順番存在時: DTO形式で返却される", async () => {
-      const { context, mocks } = createTestContext();
-      mocks.roundRobinScheduleService.getSchedule.mockResolvedValueOnce(
+      setupViewAccess();
+      // getSchedule: roundRobinScheduleRepository.findByCircleSessionId → schedule
+      mockDeps.roundRobinScheduleRepository.findByCircleSessionId.mockResolvedValue(
         baseSchedule(),
       );
-      mocks.userService.listUsers.mockResolvedValueOnce(baseUsers());
+      // listUsers for player info: userRepository.findByIds → users
+      mockDeps.userRepository.findByIds.mockResolvedValue(baseUsers());
 
-      const caller = appRouter.createCaller(context);
+      const caller = appRouter.createCaller(buildContext());
       const result = await caller.roundRobinSchedules.get({
         circleId: "circle-1",
         circleSessionId: "session-1",
@@ -161,10 +117,10 @@ describe("roundRobinSchedule tRPC ルーター", () => {
     });
 
     test("順番未存在時: nullを返す", async () => {
-      const { context, mocks } = createTestContext();
-      mocks.roundRobinScheduleService.getSchedule.mockResolvedValueOnce(null);
+      setupViewAccess();
+      // roundRobinScheduleRepository.findByCircleSessionId defaults to null
 
-      const caller = appRouter.createCaller(context);
+      const caller = appRouter.createCaller(buildContext());
       const result = await caller.roundRobinSchedules.get({
         circleId: "circle-1",
         circleSessionId: "session-1",
@@ -174,12 +130,10 @@ describe("roundRobinSchedule tRPC ルーター", () => {
     });
 
     test("ForbiddenError → FORBIDDEN", async () => {
-      const { context, mocks } = createTestContext();
-      mocks.roundRobinScheduleService.getSchedule.mockRejectedValueOnce(
-        new ForbiddenError(),
-      );
+      // No circle or session membership → canViewRoundRobinSchedule fails
+      // authzRepository defaults return { kind: "none" }
 
-      const caller = appRouter.createCaller(context);
+      const caller = appRouter.createCaller(buildContext());
 
       await expect(
         caller.roundRobinSchedules.get({
@@ -190,8 +144,7 @@ describe("roundRobinSchedule tRPC ルーター", () => {
     });
 
     test("未認証: actorId null → UNAUTHORIZED", async () => {
-      const { context } = createTestContext(null);
-      const caller = appRouter.createCaller(context);
+      const caller = appRouter.createCaller(buildContext(null));
 
       await expect(
         caller.roundRobinSchedules.get({
@@ -204,31 +157,69 @@ describe("roundRobinSchedule tRPC ルーター", () => {
 
   describe("generate", () => {
     test("正常生成: DTO形式で返却される", async () => {
-      const { context, mocks } = createTestContext();
-      mocks.roundRobinScheduleService.generateSchedule.mockResolvedValueOnce(
-        baseSchedule(),
-      );
-      mocks.userService.listUsers.mockResolvedValueOnce(baseUsers());
+      setupManageAccess();
+      // generateSchedule needs:
+      // 1. circleSessionRepository.findById → session (for existence check)
+      // 2. circleSessionRepository.listMemberships → members (for schedule generation)
+      // 3. roundRobinScheduleRepository.deleteByCircleSessionId
+      // 4. roundRobinScheduleRepository.save
+      mockDeps.circleSessionRepository.findById.mockResolvedValue({
+        id: SESSION_ID,
+        circleId: CIRCLE_ID,
+        title: "テスト",
+        startsAt: new Date(),
+        endsAt: new Date(),
+        location: null,
+        note: "",
+        createdAt: new Date(),
+      });
+      mockDeps.circleSessionRepository.listMemberships.mockResolvedValue([
+        {
+          circleSessionId: SESSION_ID,
+          userId: toUserId("player-1"),
+          role: CircleSessionRole.CircleSessionMember,
+          createdAt: new Date(),
+          deletedAt: null,
+        },
+        {
+          circleSessionId: SESSION_ID,
+          userId: toUserId("player-2"),
+          role: CircleSessionRole.CircleSessionMember,
+          createdAt: new Date(),
+          deletedAt: null,
+        },
+      ]);
+      // listUsers for player info
+      mockDeps.userRepository.findByIds.mockResolvedValue(baseUsers());
 
-      const caller = appRouter.createCaller(context);
+      const caller = appRouter.createCaller(buildContext());
       const result = await caller.roundRobinSchedules.generate({
         circleSessionId: "session-1",
       });
 
-      expect(result.id).toBe("schedule-1");
       expect(result.circleSessionId).toBe("session-1");
       expect(result.rounds).toHaveLength(1);
-      expect(result.rounds[0].pairings[0].player1.id).toBe("player-1");
-      expect(result.rounds[0].pairings[0].player2.id).toBe("player-2");
+      const playerIds = [
+        result.rounds[0].pairings[0].player1.id,
+        result.rounds[0].pairings[0].player2.id,
+      ].sort();
+      expect(playerIds).toEqual(["player-1", "player-2"]);
     });
 
     test("ForbiddenError → FORBIDDEN", async () => {
-      const { context, mocks } = createTestContext();
-      mocks.roundRobinScheduleService.generateSchedule.mockRejectedValueOnce(
-        new ForbiddenError(),
-      );
+      // canManageRoundRobinSchedule fails (default: { kind: "none" })
+      mockDeps.circleSessionRepository.findById.mockResolvedValue({
+        id: SESSION_ID,
+        circleId: CIRCLE_ID,
+        title: "テスト",
+        startsAt: new Date(),
+        endsAt: new Date(),
+        location: null,
+        note: "",
+        createdAt: new Date(),
+      });
 
-      const caller = appRouter.createCaller(context);
+      const caller = appRouter.createCaller(buildContext());
 
       await expect(
         caller.roundRobinSchedules.generate({
@@ -238,12 +229,30 @@ describe("roundRobinSchedule tRPC ルーター", () => {
     });
 
     test("BadRequestError → BAD_REQUEST", async () => {
-      const { context, mocks } = createTestContext();
-      mocks.roundRobinScheduleService.generateSchedule.mockRejectedValueOnce(
-        new BadRequestError("Schedule already exists"),
-      );
+      // Generate with < 2 participants → BadRequestError from domain
+      setupManageAccess();
+      mockDeps.circleSessionRepository.findById.mockResolvedValue({
+        id: SESSION_ID,
+        circleId: CIRCLE_ID,
+        title: "テスト",
+        startsAt: new Date(),
+        endsAt: new Date(),
+        location: null,
+        note: "",
+        createdAt: new Date(),
+      });
+      // Only 1 member → BadRequestError
+      mockDeps.circleSessionRepository.listMemberships.mockResolvedValue([
+        {
+          circleSessionId: SESSION_ID,
+          userId: toUserId("player-1"),
+          role: CircleSessionRole.CircleSessionMember,
+          createdAt: new Date(),
+          deletedAt: null,
+        },
+      ]);
 
-      const caller = appRouter.createCaller(context);
+      const caller = appRouter.createCaller(buildContext());
 
       await expect(
         caller.roundRobinSchedules.generate({
@@ -253,8 +262,7 @@ describe("roundRobinSchedule tRPC ルーター", () => {
     });
 
     test("未認証: actorId null → UNAUTHORIZED", async () => {
-      const { context } = createTestContext(null);
-      const caller = appRouter.createCaller(context);
+      const caller = appRouter.createCaller(buildContext(null));
 
       await expect(
         caller.roundRobinSchedules.generate({
@@ -266,12 +274,9 @@ describe("roundRobinSchedule tRPC ルーター", () => {
 
   describe("delete", () => {
     test("正常削除: voidを返す", async () => {
-      const { context, mocks } = createTestContext();
-      mocks.roundRobinScheduleService.deleteSchedule.mockResolvedValueOnce(
-        undefined,
-      );
+      setupManageAccess();
 
-      const caller = appRouter.createCaller(context);
+      const caller = appRouter.createCaller(buildContext());
       const result = await caller.roundRobinSchedules.delete({
         circleSessionId: "session-1",
       });
@@ -280,12 +285,9 @@ describe("roundRobinSchedule tRPC ルーター", () => {
     });
 
     test("ForbiddenError → FORBIDDEN", async () => {
-      const { context, mocks } = createTestContext();
-      mocks.roundRobinScheduleService.deleteSchedule.mockRejectedValueOnce(
-        new ForbiddenError(),
-      );
+      // canManageRoundRobinSchedule fails (default: { kind: "none" })
 
-      const caller = appRouter.createCaller(context);
+      const caller = appRouter.createCaller(buildContext());
 
       await expect(
         caller.roundRobinSchedules.delete({
@@ -295,8 +297,7 @@ describe("roundRobinSchedule tRPC ルーター", () => {
     });
 
     test("未認証: actorId null → UNAUTHORIZED", async () => {
-      const { context } = createTestContext(null);
-      const caller = appRouter.createCaller(context);
+      const caller = appRouter.createCaller(buildContext(null));
 
       await expect(
         caller.roundRobinSchedules.delete({

--- a/server/presentation/trpc/routers/user-circle-membership.test.ts
+++ b/server/presentation/trpc/routers/user-circle-membership.test.ts
@@ -1,110 +1,69 @@
 import { beforeEach, describe, expect, test, vi } from "vitest";
 import { appRouter } from "@/server/presentation/trpc/router";
-import type { Context } from "@/server/presentation/trpc/context";
 import { toCircleId, toUserId } from "@/server/domain/common/ids";
-import { ForbiddenError } from "@/server/domain/common/errors";
+import { CircleRole } from "@/server/domain/models/circle/circle-role";
+import {
+  createMockDeps,
+  createServiceContainer,
+  toServiceContainerDeps,
+  type MockDeps,
+} from "@/server/presentation/providers/__tests__/helpers/create-mock-deps";
 
-const createTestContext = (
-  actorIdValue: ReturnType<typeof toUserId> | null = toUserId("user-1"),
-) => {
-  const circleMembershipService = {
-    listByCircleId: vi.fn(),
-    listByUserId: vi.fn(),
-    addMembership: vi.fn(),
-    changeMembershipRole: vi.fn(),
-    withdrawMembership: vi.fn(),
-    removeMembership: vi.fn(),
-    transferOwnership: vi.fn(),
-  };
+const ACTOR_ID = toUserId("user-1");
 
-  const context: Context = {
-    actorId: actorIdValue,
-    clientIp: "1.2.3.4",
-    circleService: {
-      getCircle: vi.fn(),
-      createCircle: vi.fn(),
-      renameCircle: vi.fn(),
-      deleteCircle: vi.fn(),
-      updateSessionEmailNotificationEnabled: vi.fn(),
-    },
-    circleMembershipService,
-    circleSessionService: {
-      listByCircleId: vi.fn(),
-      getCircleSession: vi.fn(),
-      createCircleSession: vi.fn(),
-      rescheduleCircleSession: vi.fn(),
-      updateCircleSessionDetails: vi.fn(),
-      deleteCircleSession: vi.fn(),
-    },
-    circleSessionMembershipService: {
-      countPastSessionsByUserId: vi.fn(),
-      listMemberships: vi.fn(),
-      listByUserId: vi.fn(),
-      addMembership: vi.fn(),
-      changeMembershipRole: vi.fn(),
-      removeMembership: vi.fn(),
-      transferOwnership: vi.fn(),
-      withdrawMembership: vi.fn(),
-      listDeletedMemberships: vi.fn(),
-    },
-    matchService: {
-      listByCircleSessionId: vi.fn(),
-      getMatch: vi.fn(),
-      recordMatch: vi.fn(),
-      updateMatch: vi.fn(),
-      deleteMatch: vi.fn(),
-    },
-    userService: {
-      getUser: vi.fn(),
-      listUsers: vi.fn(),
-      getMe: vi.fn(),
-      updateProfile: vi.fn(),
-      updateProfileVisibility: vi.fn(),
-      changePassword: vi.fn(),
-      uploadAvatar: vi.fn().mockResolvedValue(undefined),
-      findImageData: vi.fn().mockResolvedValue(null),
-      deleteAccount: vi.fn(),
-    },
-    signupService: {
-      signup: vi.fn(),
-    },
-    circleInviteLinkService: {
-      createInviteLink: vi.fn(),
-      getInviteLinkInfo: vi.fn(),
-      redeemInviteLink: vi.fn(),
-    },
-    accessService: {} as Context["accessService"],
-    userStatisticsService: {} as Context["userStatisticsService"],
-    roundRobinScheduleService: {} as Context["roundRobinScheduleService"],
-    holidayProvider: {} as Context["holidayProvider"],
-    notificationPreferenceService: {} as Context["notificationPreferenceService"],
-  };
+let mockDeps: MockDeps;
 
-  return { context, mocks: { circleMembershipService } };
+const buildContext = (actorId: ReturnType<typeof toUserId> | null = ACTOR_ID) => {
+  const services = createServiceContainer(toServiceContainerDeps(mockDeps));
+  return { actorId, clientIp: "1.2.3.4", ...services };
 };
 
 describe("userCircleMembership tRPC ルーター", () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    mockDeps = createMockDeps();
   });
 
   describe("list", () => {
     test("ユーザーの研究会参加一覧を取得できる", async () => {
-      const { context, mocks } = createTestContext();
-      mocks.circleMembershipService.listByUserId.mockResolvedValueOnce([
+      // listByUserId needs:
+      // 1. actorId === userId (self-access only) → OK since router passes actorId as userId
+      // 2. accessService.canListOwnCircles → authzRepository.isRegisteredUser → true
+      // 3. circleRepository.listMembershipsByUserId → memberships
+      // 4. circleRepository.findByIds → circles (for names)
+      mockDeps.authzRepository.isRegisteredUser.mockResolvedValue(true);
+      mockDeps.circleRepository.listMembershipsByUserId.mockResolvedValue([
         {
           circleId: toCircleId("circle-1"),
-          circleName: "さくら将棋研究会",
-          role: "CircleMember",
+          userId: ACTOR_ID,
+          role: CircleRole.CircleMember,
+          createdAt: new Date(),
+          deletedAt: null,
         },
         {
           circleId: toCircleId("circle-2"),
-          circleName: "テスト研究会",
-          role: "CircleOwner",
+          userId: ACTOR_ID,
+          role: CircleRole.CircleOwner,
+          createdAt: new Date(),
+          deletedAt: null,
+        },
+      ]);
+      mockDeps.circleRepository.findByIds.mockResolvedValue([
+        {
+          id: toCircleId("circle-1"),
+          name: "さくら将棋研究会",
+          createdAt: new Date(),
+          sessionEmailNotificationEnabled: true,
+        },
+        {
+          id: toCircleId("circle-2"),
+          name: "テスト研究会",
+          createdAt: new Date(),
+          sessionEmailNotificationEnabled: true,
         },
       ]);
 
-      const caller = appRouter.createCaller(context);
+      const caller = appRouter.createCaller(buildContext());
       const result = await caller.users.circles.memberships.list({});
 
       expect(result).toHaveLength(2);
@@ -116,22 +75,20 @@ describe("userCircleMembership tRPC ルーター", () => {
     });
 
     test("空配列を返す（参加なし）", async () => {
-      const { context, mocks } = createTestContext();
-      mocks.circleMembershipService.listByUserId.mockResolvedValueOnce([]);
+      mockDeps.authzRepository.isRegisteredUser.mockResolvedValue(true);
+      mockDeps.circleRepository.listMembershipsByUserId.mockResolvedValue([]);
 
-      const caller = appRouter.createCaller(context);
+      const caller = appRouter.createCaller(buildContext());
       const result = await caller.users.circles.memberships.list({});
 
       expect(result).toEqual([]);
     });
 
     test("ForbiddenError → FORBIDDEN", async () => {
-      const { context, mocks } = createTestContext();
-      mocks.circleMembershipService.listByUserId.mockRejectedValueOnce(
-        new ForbiddenError(),
-      );
+      // isRegisteredUser returns false → canListOwnCircles fails → ForbiddenError
+      mockDeps.authzRepository.isRegisteredUser.mockResolvedValue(false);
 
-      const caller = appRouter.createCaller(context);
+      const caller = appRouter.createCaller(buildContext());
 
       await expect(
         caller.users.circles.memberships.list({}),
@@ -139,8 +96,7 @@ describe("userCircleMembership tRPC ルーター", () => {
     });
 
     test("未認証: actorId null → UNAUTHORIZED", async () => {
-      const { context } = createTestContext(null);
-      const caller = appRouter.createCaller(context);
+      const caller = appRouter.createCaller(buildContext(null));
 
       await expect(
         caller.users.circles.memberships.list({}),

--- a/server/presentation/trpc/routers/user-circle-session-membership.test.ts
+++ b/server/presentation/trpc/routers/user-circle-session-membership.test.ts
@@ -1,112 +1,84 @@
 import { beforeEach, describe, expect, test, vi } from "vitest";
 import { appRouter } from "@/server/presentation/trpc/router";
-import type { Context } from "@/server/presentation/trpc/context";
-import { toCircleId, toCircleSessionId, toUserId } from "@/server/domain/common/ids";
-import { ForbiddenError } from "@/server/domain/common/errors";
+import {
+  toCircleId,
+  toCircleSessionId,
+  toUserId,
+} from "@/server/domain/common/ids";
+import { CircleSessionRole } from "@/server/domain/models/circle-session/circle-session-role";
+import {
+  createMockDeps,
+  createServiceContainer,
+  toServiceContainerDeps,
+  type MockDeps,
+} from "@/server/presentation/providers/__tests__/helpers/create-mock-deps";
 
-const createTestContext = (
-  actorIdValue: ReturnType<typeof toUserId> | null = toUserId("user-1"),
-) => {
-  const circleSessionMembershipService = {
-    countPastSessionsByUserId: vi.fn(),
-    listMemberships: vi.fn(),
-    listByUserId: vi.fn(),
-    addMembership: vi.fn(),
-    changeMembershipRole: vi.fn(),
-    removeMembership: vi.fn(),
-    transferOwnership: vi.fn(),
-    withdrawMembership: vi.fn(),
-    listDeletedMemberships: vi.fn(),
-  };
+const ACTOR_ID = toUserId("user-1");
+const SESSION_ID = toCircleSessionId("session-1");
+const CIRCLE_ID = toCircleId("circle-1");
 
-  const context: Context = {
-    actorId: actorIdValue,
-    clientIp: "1.2.3.4",
-    circleService: {
-      getCircle: vi.fn(),
-      createCircle: vi.fn(),
-      renameCircle: vi.fn(),
-      deleteCircle: vi.fn(),
-      updateSessionEmailNotificationEnabled: vi.fn(),
-    },
-    circleMembershipService: {
-      listByCircleId: vi.fn(),
-      listByUserId: vi.fn(),
-      addMembership: vi.fn(),
-      changeMembershipRole: vi.fn(),
-      withdrawMembership: vi.fn(),
-      removeMembership: vi.fn(),
-      transferOwnership: vi.fn(),
-    },
-    circleSessionService: {
-      listByCircleId: vi.fn(),
-      getCircleSession: vi.fn(),
-      createCircleSession: vi.fn(),
-      rescheduleCircleSession: vi.fn(),
-      updateCircleSessionDetails: vi.fn(),
-      deleteCircleSession: vi.fn(),
-    },
-    circleSessionMembershipService,
-    matchService: {
-      listByCircleSessionId: vi.fn(),
-      getMatch: vi.fn(),
-      recordMatch: vi.fn(),
-      updateMatch: vi.fn(),
-      deleteMatch: vi.fn(),
-    },
-    userService: {
-      getUser: vi.fn(),
-      listUsers: vi.fn(),
-      getMe: vi.fn(),
-      updateProfile: vi.fn(),
-      updateProfileVisibility: vi.fn(),
-      changePassword: vi.fn(),
-      uploadAvatar: vi.fn().mockResolvedValue(undefined),
-      findImageData: vi.fn().mockResolvedValue(null),
-      deleteAccount: vi.fn(),
-    },
-    signupService: {
-      signup: vi.fn(),
-    },
-    circleInviteLinkService: {
-      createInviteLink: vi.fn(),
-      getInviteLinkInfo: vi.fn(),
-      redeemInviteLink: vi.fn(),
-    },
-    accessService: {} as Context["accessService"],
-    userStatisticsService: {} as Context["userStatisticsService"],
-    roundRobinScheduleService: {} as Context["roundRobinScheduleService"],
-    holidayProvider: {} as Context["holidayProvider"],
-    notificationPreferenceService: {} as Context["notificationPreferenceService"],
-  };
+let mockDeps: MockDeps;
 
-  return { context, mocks: { circleSessionMembershipService } };
+const buildContext = (actorId: ReturnType<typeof toUserId> | null = ACTOR_ID) => {
+  const services = createServiceContainer(toServiceContainerDeps(mockDeps));
+  return { actorId, clientIp: "1.2.3.4", ...services };
 };
 
-const baseSummary = (overrides?: Record<string, unknown>) => ({
-  circleSessionId: toCircleSessionId("session-1"),
-  circleId: toCircleId("circle-1"),
-  circleName: "さくら将棋研究会",
+const setupRegisteredUser = () => {
+  mockDeps.authzRepository.isRegisteredUser.mockResolvedValue(true);
+};
+
+const baseMembership = () => ({
+  circleSessionId: SESSION_ID,
+  userId: ACTOR_ID,
+  role: CircleSessionRole.CircleSessionMember,
+  createdAt: new Date("2024-01-01T00:00:00Z"),
+  deletedAt: null,
+});
+
+const baseSession = (overrides?: Record<string, unknown>) => ({
+  id: SESSION_ID,
+  circleId: CIRCLE_ID,
   title: "第1回例会",
   startsAt: new Date("2024-06-01T13:00:00Z"),
   endsAt: new Date("2024-06-01T17:00:00Z"),
   location: "部室",
+  note: "",
+  createdAt: new Date("2024-01-01T00:00:00Z"),
   ...overrides,
+});
+
+const baseCircle = () => ({
+  id: CIRCLE_ID,
+  name: "さくら将棋研究会",
+  createdAt: new Date("2024-01-01T00:00:00Z"),
+  sessionEmailNotificationEnabled: true,
 });
 
 describe("userCircleSessionMembership tRPC ルーター", () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    mockDeps = createMockDeps();
   });
 
   describe("list", () => {
     test("ユーザーのセッション参加一覧を取得できる（limit 指定あり）", async () => {
-      const { context, mocks } = createTestContext();
-      mocks.circleSessionMembershipService.listByUserId.mockResolvedValueOnce([
-        baseSummary(),
+      // listByUserId needs:
+      // 1. actorId === userId → OK
+      // 2. accessService.canListOwnCircles → isRegisteredUser
+      // 3. circleSessionRepository.listMembershipsByUserId → memberships
+      // 4. circleSessionRepository.findByIds → sessions
+      // 5. circleRepository.findByIds → circles (for names)
+      setupRegisteredUser();
+      mockDeps.circleSessionRepository.listMembershipsByUserId.mockResolvedValue([
+        baseMembership(),
       ]);
+      mockDeps.circleSessionRepository.findByIds.mockResolvedValue([
+        baseSession(),
+      ]);
+      mockDeps.circleRepository.findByIds.mockResolvedValue([baseCircle()]);
 
-      const caller = appRouter.createCaller(context);
+      const caller = appRouter.createCaller(buildContext());
       const result = await caller.users.circleSessions.memberships.list({
         limit: 5,
       });
@@ -120,48 +92,52 @@ describe("userCircleSessionMembership tRPC ルーター", () => {
     });
 
     test("ユーザーのセッション参加一覧を取得できる（limit 省略）", async () => {
-      const { context, mocks } = createTestContext();
-      mocks.circleSessionMembershipService.listByUserId.mockResolvedValueOnce([
-        baseSummary(),
+      setupRegisteredUser();
+      mockDeps.circleSessionRepository.listMembershipsByUserId.mockResolvedValue([
+        baseMembership(),
       ]);
+      mockDeps.circleSessionRepository.findByIds.mockResolvedValue([
+        baseSession(),
+      ]);
+      mockDeps.circleRepository.findByIds.mockResolvedValue([baseCircle()]);
 
-      const caller = appRouter.createCaller(context);
+      const caller = appRouter.createCaller(buildContext());
       const result = await caller.users.circleSessions.memberships.list({});
 
       expect(result).toHaveLength(1);
     });
 
     test("空配列を返す（参加なし）", async () => {
-      const { context, mocks } = createTestContext();
-      mocks.circleSessionMembershipService.listByUserId.mockResolvedValueOnce(
-        [],
-      );
+      setupRegisteredUser();
+      mockDeps.circleSessionRepository.listMembershipsByUserId.mockResolvedValue([]);
 
-      const caller = appRouter.createCaller(context);
+      const caller = appRouter.createCaller(buildContext());
       const result = await caller.users.circleSessions.memberships.list({});
 
       expect(result).toEqual([]);
     });
 
     test("location が null の場合も正しく返す", async () => {
-      const { context, mocks } = createTestContext();
-      mocks.circleSessionMembershipService.listByUserId.mockResolvedValueOnce([
-        baseSummary({ location: null }),
+      setupRegisteredUser();
+      mockDeps.circleSessionRepository.listMembershipsByUserId.mockResolvedValue([
+        baseMembership(),
       ]);
+      mockDeps.circleSessionRepository.findByIds.mockResolvedValue([
+        baseSession({ location: null }),
+      ]);
+      mockDeps.circleRepository.findByIds.mockResolvedValue([baseCircle()]);
 
-      const caller = appRouter.createCaller(context);
+      const caller = appRouter.createCaller(buildContext());
       const result = await caller.users.circleSessions.memberships.list({});
 
       expect(result[0].location).toBeNull();
     });
 
     test("ForbiddenError → FORBIDDEN", async () => {
-      const { context, mocks } = createTestContext();
-      mocks.circleSessionMembershipService.listByUserId.mockRejectedValueOnce(
-        new ForbiddenError(),
-      );
+      // isRegisteredUser returns false → canListOwnCircles fails → ForbiddenError
+      mockDeps.authzRepository.isRegisteredUser.mockResolvedValue(false);
 
-      const caller = appRouter.createCaller(context);
+      const caller = appRouter.createCaller(buildContext());
 
       await expect(
         caller.users.circleSessions.memberships.list({}),
@@ -169,8 +145,7 @@ describe("userCircleSessionMembership tRPC ルーター", () => {
     });
 
     test("未認証: actorId null → UNAUTHORIZED", async () => {
-      const { context } = createTestContext(null);
-      const caller = appRouter.createCaller(context);
+      const caller = appRouter.createCaller(buildContext(null));
 
       await expect(
         caller.users.circleSessions.memberships.list({}),

--- a/server/presentation/trpc/routers/user.test.ts
+++ b/server/presentation/trpc/routers/user.test.ts
@@ -1,114 +1,45 @@
 import { beforeEach, describe, expect, test, vi } from "vitest";
 import { appRouter } from "@/server/presentation/trpc/router";
-import type { Context } from "@/server/presentation/trpc/context";
 import { toUserId } from "@/server/domain/common/ids";
 import {
-  BadRequestError,
-  ForbiddenError,
-  TooManyRequestsError,
-} from "@/server/domain/common/errors";
+  createMockDeps,
+  createServiceContainer,
+  toServiceContainerDeps,
+  type MockDeps,
+} from "@/server/presentation/providers/__tests__/helpers/create-mock-deps";
 
-const createTestContext = (
-  actorIdValue: ReturnType<typeof toUserId> | null = toUserId("user-1"),
-) => {
-  const userService = {
-    getUser: vi.fn(),
-    listUsers: vi.fn(),
-    getMe: vi.fn(),
-    updateProfile: vi.fn(),
-    changePassword: vi.fn(),
-    updateProfileVisibility: vi.fn(),
-    uploadAvatar: vi.fn().mockResolvedValue(undefined),
-    findImageData: vi.fn().mockResolvedValue(null),
-    deleteAccount: vi.fn().mockResolvedValue(undefined),
-  };
+const ACTOR_ID = toUserId("user-1");
 
-  const context: Context = {
-    actorId: actorIdValue,
-    clientIp: "1.2.3.4",
-    circleService: {
-      getCircle: vi.fn(),
-      createCircle: vi.fn(),
-      renameCircle: vi.fn(),
-      deleteCircle: vi.fn(),
-      updateSessionEmailNotificationEnabled: vi.fn(),
-    },
-    circleMembershipService: {
-      listByCircleId: vi.fn(),
-      listByUserId: vi.fn(),
-      addMembership: vi.fn(),
-      changeMembershipRole: vi.fn(),
-      withdrawMembership: vi.fn(),
-      removeMembership: vi.fn(),
-      transferOwnership: vi.fn(),
-    },
-    circleSessionService: {
-      listByCircleId: vi.fn(),
-      getCircleSession: vi.fn(),
-      createCircleSession: vi.fn(),
-      rescheduleCircleSession: vi.fn(),
-      updateCircleSessionDetails: vi.fn(),
-      deleteCircleSession: vi.fn(),
-    },
-    circleSessionMembershipService: {
-      countPastSessionsByUserId: vi.fn(),
-      listMemberships: vi.fn(),
-      listByUserId: vi.fn(),
-      addMembership: vi.fn(),
-      changeMembershipRole: vi.fn(),
-      removeMembership: vi.fn(),
-      transferOwnership: vi.fn(),
-      withdrawMembership: vi.fn(),
-      listDeletedMemberships: vi.fn(),
-    },
-    matchService: {
-      listByCircleSessionId: vi.fn(),
-      getMatch: vi.fn(),
-      recordMatch: vi.fn(),
-      updateMatch: vi.fn(),
-      deleteMatch: vi.fn(),
-    },
-    userService,
-    signupService: {
-      signup: vi.fn(),
-    },
-    circleInviteLinkService: {
-      createInviteLink: vi.fn(),
-      getInviteLinkInfo: vi.fn(),
-      redeemInviteLink: vi.fn(),
-    },
-    accessService: {} as Context["accessService"],
-    userStatisticsService: {} as Context["userStatisticsService"],
-    roundRobinScheduleService: {} as Context["roundRobinScheduleService"],
-    holidayProvider: {} as Context["holidayProvider"],
-    notificationPreferenceService: {} as Context["notificationPreferenceService"],
-  };
+const BASE_USER = {
+  id: ACTOR_ID,
+  name: "Taro",
+  email: "taro@example.com",
+  image: null,
+  hasCustomImage: false,
+  profileVisibility: "PUBLIC" as const,
+  createdAt: new Date("2024-01-01"),
+};
 
-  return { context, mocks: { userService } };
+let mockDeps: MockDeps;
+
+const buildContext = (actorId: ReturnType<typeof toUserId> | null = ACTOR_ID) => {
+  const services = createServiceContainer(toServiceContainerDeps(mockDeps));
+  return { actorId, clientIp: "1.2.3.4", ...services };
 };
 
 describe("user tRPC ルーター", () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    mockDeps = createMockDeps();
   });
 
   describe("me", () => {
     test("ユーザー情報を meDtoSchema 準拠で返す", async () => {
-      const { context, mocks } = createTestContext();
-      mocks.userService.getMe.mockResolvedValueOnce({
-        user: {
-          id: toUserId("user-1"),
-          name: "Taro",
-          email: "taro@example.com",
-          image: null,
-          hasCustomImage: false,
-          profileVisibility: "PUBLIC",
-          createdAt: new Date("2024-01-01"),
-        },
-        hasPassword: true,
-      });
+      // getMe needs: userRepository.findById → user, userRepository.findPasswordHashById → hash
+      mockDeps.userRepository.findById.mockResolvedValue(BASE_USER);
+      mockDeps.userRepository.findPasswordHashById.mockResolvedValue("hashed-password");
 
-      const caller = appRouter.createCaller(context);
+      const caller = appRouter.createCaller(buildContext());
       const result = await caller.users.me();
 
       expect(result.id).toBe("user-1");
@@ -119,10 +50,10 @@ describe("user tRPC ルーター", () => {
     });
 
     test("ForbiddenError → FORBIDDEN", async () => {
-      const { context, mocks } = createTestContext();
-      mocks.userService.getMe.mockRejectedValueOnce(new ForbiddenError());
+      // getMe: userRepository.findById returns null → ForbiddenError
+      mockDeps.userRepository.findById.mockResolvedValue(null);
 
-      const caller = appRouter.createCaller(context);
+      const caller = appRouter.createCaller(buildContext());
 
       await expect(caller.users.me()).rejects.toMatchObject({
         code: "FORBIDDEN",
@@ -132,30 +63,29 @@ describe("user tRPC ルーター", () => {
 
   describe("updateProfile", () => {
     test("BadRequestError → BAD_REQUEST", async () => {
-      const { context, mocks } = createTestContext();
-      mocks.userService.updateProfile.mockRejectedValueOnce(
-        new BadRequestError("Email already in use"),
-      );
+      // updateProfile: user exists, has password (not OAuth), email already in use
+      mockDeps.userRepository.findById.mockResolvedValue(BASE_USER);
+      mockDeps.userRepository.findPasswordHashById.mockResolvedValue("hashed");
+      mockDeps.userRepository.emailExists.mockResolvedValue(true);
 
-      const caller = appRouter.createCaller(context);
+      const caller = appRouter.createCaller(buildContext());
 
       await expect(
         caller.users.updateProfile({
           name: "Name",
           email: "taken@example.com",
         }),
-      ).rejects.toMatchObject({ code: "BAD_REQUEST" });
+      ).rejects.toMatchObject({ code: "CONFLICT" });
     });
   });
 
   describe("changePassword", () => {
     test("BadRequestError → BAD_REQUEST", async () => {
-      const { context, mocks } = createTestContext();
-      mocks.userService.changePassword.mockRejectedValueOnce(
-        new BadRequestError("Current password is incorrect"),
-      );
+      // changePassword: rate limiter passes, password hash found, verify fails
+      mockDeps.userRepository.findPasswordHashById.mockResolvedValue("hashed");
+      mockDeps.passwordHasher.verify.mockReturnValue(false);
 
-      const caller = appRouter.createCaller(context);
+      const caller = appRouter.createCaller(buildContext());
 
       await expect(
         caller.users.changePassword({
@@ -166,12 +96,15 @@ describe("user tRPC ルーター", () => {
     });
 
     test("TooManyRequestsError → TOO_MANY_REQUESTS", async () => {
-      const { context, mocks } = createTestContext();
-      mocks.userService.changePassword.mockRejectedValueOnce(
+      // changePassword: rate limiter throws
+      const { TooManyRequestsError } = await import(
+        "@/server/domain/common/errors"
+      );
+      mockDeps.changePasswordRateLimiter.check.mockRejectedValue(
         new TooManyRequestsError(50_000),
       );
 
-      const caller = appRouter.createCaller(context);
+      const caller = appRouter.createCaller(buildContext());
 
       await expect(
         caller.users.changePassword({
@@ -184,12 +117,10 @@ describe("user tRPC ルーター", () => {
 
   describe("updateProfileVisibility", () => {
     test("ForbiddenError → FORBIDDEN", async () => {
-      const { context, mocks } = createTestContext();
-      mocks.userService.updateProfileVisibility.mockRejectedValueOnce(
-        new ForbiddenError(),
-      );
+      // updateProfileVisibility: user not found → ForbiddenError
+      mockDeps.userRepository.findById.mockResolvedValue(null);
 
-      const caller = appRouter.createCaller(context);
+      const caller = appRouter.createCaller(buildContext());
 
       await expect(
         caller.users.updateProfileVisibility({ visibility: "PRIVATE" }),
@@ -199,9 +130,7 @@ describe("user tRPC ルーター", () => {
 
   describe("未認証アクセス", () => {
     test("me: actorId null で UNAUTHORIZED を返す", async () => {
-      const { context } = createTestContext(null);
-
-      const caller = appRouter.createCaller(context);
+      const caller = appRouter.createCaller(buildContext(null));
 
       await expect(caller.users.me()).rejects.toMatchObject({
         code: "UNAUTHORIZED",
@@ -209,9 +138,7 @@ describe("user tRPC ルーター", () => {
     });
 
     test("updateProfile: actorId null で UNAUTHORIZED を返す", async () => {
-      const { context } = createTestContext(null);
-
-      const caller = appRouter.createCaller(context);
+      const caller = appRouter.createCaller(buildContext(null));
 
       await expect(
         caller.users.updateProfile({
@@ -222,9 +149,7 @@ describe("user tRPC ルーター", () => {
     });
 
     test("changePassword: actorId null で UNAUTHORIZED を返す", async () => {
-      const { context } = createTestContext(null);
-
-      const caller = appRouter.createCaller(context);
+      const caller = appRouter.createCaller(buildContext(null));
 
       await expect(
         caller.users.changePassword({
@@ -235,9 +160,7 @@ describe("user tRPC ルーター", () => {
     });
 
     test("updateProfileVisibility: actorId null で UNAUTHORIZED を返す", async () => {
-      const { context } = createTestContext(null);
-
-      const caller = appRouter.createCaller(context);
+      const caller = appRouter.createCaller(buildContext(null));
 
       await expect(
         caller.users.updateProfileVisibility({ visibility: "PRIVATE" }),


### PR DESCRIPTION
## Summary

- tRPCルーターテスト全8ファイルのモック戦略を、サービス層モックから `createMockDeps` パターン（リポジトリ層モック）に移行
- Provider層テストと同一のモック境界に統一し、認可ロジック（AccessService）・ビジネスロジックが実コードを通るように改善
- 結果として271行削減（642追加 / 913削除）— モックのボイラープレートが大幅に減少

closes #1097

## 変更対象

- `circle-invite-link.test.ts`
- `circle-session.test.ts`
- `circle.test.ts`
- `match.test.ts`
- `round-robin-schedule.test.ts`
- `user-circle-membership.test.ts`
- `user-circle-session-membership.test.ts`
- `user.test.ts`

## Test plan

- [ ] `pnpm vitest run server/presentation/trpc/routers/` で全ルーターテストがパスすることを確認
- [ ] 既存のProvider層テスト（`server/presentation/providers/`）に影響がないことを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)