### PR TITLE
refactor(test): router.test.tsのモック境界をリポジトリ層に統一

### DIFF
--- a/server/presentation/trpc/router.test.ts
+++ b/server/presentation/trpc/router.test.ts
@@ -442,7 +442,6 @@ describe("tRPC router", () => {
       {
         circleId: CIRCLE_ID,
         userId: ACTOR_ID,
-        displayName: "テストユーザー",
         role: CircleRole.CircleOwner,
         createdAt: NOW,
         deletedAt: null,
@@ -450,7 +449,6 @@ describe("tRPC router", () => {
       {
         circleId: CIRCLE_ID,
         userId: toUserId("user-2"),
-        displayName: "メンバー",
         role: CircleRole.CircleMember,
         createdAt: NOW,
         deletedAt: null,
@@ -622,7 +620,6 @@ describe("tRPC router", () => {
       {
         circleSessionId: SESSION_ID,
         userId: ACTOR_ID,
-        displayName: "オーナー",
         role: CircleSessionRole.CircleSessionOwner,
         createdAt: NOW,
         deletedAt: null,
@@ -630,7 +627,6 @@ describe("tRPC router", () => {
       {
         circleSessionId: SESSION_ID,
         userId: toUserId("user-2"),
-        displayName: "メンバー",
         role: CircleSessionRole.CircleSessionMember,
         createdAt: NOW,
         deletedAt: null,


### PR DESCRIPTION
## Summary

- `router.test.ts` のモック境界をサービス層からリポジトリ層に移行
- `toHaveBeenCalledWith` による実装詳細の検証（約40箇所）を、tRPC caller の戻り値による振る舞い検証に置換
- Provider テストと同一パターン（`createMockDeps` + `createServiceContainer`）で一貫性を確保

closes #1107

## Test plan

- [x] `npx vitest run server/presentation/trpc/router.test.ts` — 35テスト全パス
- [ ] モックがリポジトリ層のみであることを確認（サービス層のモックが残っていないこと）
- [ ] 認可エラーテストが実 AccessService を通過していることを確認

## Verify artifacts

- Review results: `.claude/artifacts/issue-1107/verify.md`
- Follow-up issues: #1110, #1112, #1113

🤖 Generated with [Claude Code](https://claude.com/claude-code)