### PR TITLE
refactor(test): Infrastructure層テストのtoHaveBeenCalledWithを出力ベース検証に置換

### DIFF
--- a/server/infrastructure/rate-limit/prisma-rate-limiter.test.ts
+++ b/server/infrastructure/rate-limit/prisma-rate-limiter.test.ts
@@ -64,22 +64,7 @@ describe("PrismaRateLimiter", () => {
     );
   });
 
-  test("checkはkey, category, windowMsでフィルタする", async () => {
-    mockedPrisma.rateLimitAttempt.count.mockResolvedValueOnce(0);
-
-    const limiter = createPrismaRateLimiter(config);
-    await limiter.check("user-1");
-
-    expect(mockedPrisma.rateLimitAttempt.count).toHaveBeenCalledWith({
-      where: {
-        key: "user-1",
-        category: "test",
-        attemptedAt: { gte: expect.any(Date) },
-      },
-    });
-  });
-
-  test("確率的pruningが発動した場合、トランザクション内でdeleteMany+countを実行する", async () => {
+  test("確率的pruningが発動した場合でもcheckはエラーなく完了する", async () => {
     vi.spyOn(Math, "random").mockReturnValue(0.05); // 0.1未満 → pruning発動
 
     mockedPrisma.rateLimitAttempt.deleteMany.mockResolvedValueOnce({
@@ -88,61 +73,36 @@ describe("PrismaRateLimiter", () => {
     mockedPrisma.rateLimitAttempt.count.mockResolvedValueOnce(0);
 
     const limiter = createPrismaRateLimiter(config);
-    await limiter.check("user-1");
-
-    expect(mockedPrisma.$transaction).toHaveBeenCalledTimes(1);
-    expect(mockedPrisma.rateLimitAttempt.deleteMany).toHaveBeenCalledWith({
-      where: {
-        category: "test",
-        attemptedAt: { lt: expect.any(Date) },
-      },
-    });
+    await expect(limiter.check("user-1")).resolves.toBeUndefined();
 
     vi.spyOn(Math, "random").mockRestore();
   });
 
-  test("確率的pruningが発動しない場合、countのみ実行する", async () => {
+  test("確率的pruningが発動しない場合でもcheckはエラーなく完了する", async () => {
     vi.spyOn(Math, "random").mockReturnValue(0.5); // 0.1以上 → pruningスキップ
 
     mockedPrisma.rateLimitAttempt.count.mockResolvedValueOnce(0);
 
     const limiter = createPrismaRateLimiter(config);
-    await limiter.check("user-1");
-
-    expect(mockedPrisma.$transaction).not.toHaveBeenCalled();
-    expect(mockedPrisma.rateLimitAttempt.deleteMany).not.toHaveBeenCalled();
+    await expect(limiter.check("user-1")).resolves.toBeUndefined();
 
     vi.spyOn(Math, "random").mockRestore();
   });
 
-  test("recordAttemptはレコードを作成する", async () => {
+  test("recordAttemptはエラーなく完了する", async () => {
     mockedPrisma.rateLimitAttempt.create.mockResolvedValueOnce({} as never);
 
     const limiter = createPrismaRateLimiter(config);
-    await limiter.recordAttempt("user-1");
-
-    expect(mockedPrisma.rateLimitAttempt.create).toHaveBeenCalledWith({
-      data: {
-        key: "user-1",
-        category: "test",
-      },
-    });
+    await expect(limiter.recordAttempt("user-1")).resolves.toBeUndefined();
   });
 
-  test("resetは該当キー+カテゴリのレコードを削除する", async () => {
+  test("resetはエラーなく完了する", async () => {
     mockedPrisma.rateLimitAttempt.deleteMany.mockResolvedValueOnce({
       count: 3,
     });
 
     const limiter = createPrismaRateLimiter(config);
-    await limiter.reset("user-1");
-
-    expect(mockedPrisma.rateLimitAttempt.deleteMany).toHaveBeenCalledWith({
-      where: {
-        key: "user-1",
-        category: "test",
-      },
-    });
+    await expect(limiter.reset("user-1")).resolves.toBeUndefined();
   });
 
   test("異なるキー間で試行回数は独立している", async () => {
@@ -179,33 +139,9 @@ describe("PrismaRateLimiter", () => {
     });
   });
 
-  test("pruning発動時のトランザクションにcount引数が正しく渡される", async () => {
-    vi.spyOn(Math, "random").mockReturnValue(0.05); // pruning発動
-
-    mockedPrisma.rateLimitAttempt.deleteMany.mockResolvedValueOnce({
-      count: 0,
-    });
-    mockedPrisma.rateLimitAttempt.count.mockResolvedValueOnce(0);
-
-    const limiter = createPrismaRateLimiter(config);
-    await limiter.check("user-1");
-
-    expect(mockedPrisma.rateLimitAttempt.count).toHaveBeenCalledWith({
-      where: {
-        key: "user-1",
-        category: "test",
-        attemptedAt: { gte: expect.any(Date) },
-      },
-    });
-
-    vi.spyOn(Math, "random").mockRestore();
-  });
-
   describe("DBエラー時の振る舞い", () => {
     test("checkはDBエラー時にTooManyRequestsErrorをスローする（fail-closed）", async () => {
-      const consoleErrorSpy = vi
-        .spyOn(console, "error")
-        .mockImplementation(() => {});
+      vi.spyOn(console, "error").mockImplementation(() => {});
       mockedPrisma.rateLimitAttempt.count.mockRejectedValueOnce(
         new Error("DB connection failed"),
       );
@@ -215,17 +151,11 @@ describe("PrismaRateLimiter", () => {
         TooManyRequestsError,
       );
 
-      expect(consoleErrorSpy).toHaveBeenCalledWith(
-        "[rate-limit] DB error during check:",
-        expect.any(Error),
-      );
-      consoleErrorSpy.mockRestore();
+      vi.mocked(console.error).mockRestore();
     });
 
     test("recordAttemptはDBエラー時に例外をスローしない（fail-open）", async () => {
-      const consoleErrorSpy = vi
-        .spyOn(console, "error")
-        .mockImplementation(() => {});
+      vi.spyOn(console, "error").mockImplementation(() => {});
       mockedPrisma.rateLimitAttempt.create.mockRejectedValueOnce(
         new Error("DB connection failed"),
       );
@@ -233,17 +163,11 @@ describe("PrismaRateLimiter", () => {
       const limiter = createPrismaRateLimiter(config);
       await expect(limiter.recordAttempt("user-1")).resolves.toBeUndefined();
 
-      expect(consoleErrorSpy).toHaveBeenCalledWith(
-        "[rate-limit] DB error during recordAttempt:",
-        expect.any(Error),
-      );
-      consoleErrorSpy.mockRestore();
+      vi.mocked(console.error).mockRestore();
     });
 
     test("resetはDBエラー時に例外をスローしない（fail-open）", async () => {
-      const consoleErrorSpy = vi
-        .spyOn(console, "error")
-        .mockImplementation(() => {});
+      vi.spyOn(console, "error").mockImplementation(() => {});
       mockedPrisma.rateLimitAttempt.deleteMany.mockRejectedValueOnce(
         new Error("DB connection failed"),
       );
@@ -251,11 +175,7 @@ describe("PrismaRateLimiter", () => {
       const limiter = createPrismaRateLimiter(config);
       await expect(limiter.reset("user-1")).resolves.toBeUndefined();
 
-      expect(consoleErrorSpy).toHaveBeenCalledWith(
-        "[rate-limit] DB error during reset:",
-        expect.any(Error),
-      );
-      consoleErrorSpy.mockRestore();
+      vi.mocked(console.error).mockRestore();
     });
   });
 });

--- a/server/infrastructure/repository/authz/prisma-authz-repository.test.ts
+++ b/server/infrastructure/repository/authz/prisma-authz-repository.test.ts
@@ -42,10 +42,6 @@ describe("Prisma Authz リポジトリ", () => {
 
     const result = await prismaAuthzRepository.isRegisteredUser("user-1");
 
-    expect(mockedPrisma.user.findUnique).toHaveBeenCalledWith({
-      where: { id: "user-1" },
-      select: { id: true },
-    });
     expect(result).toBe(true);
   });
 
@@ -72,10 +68,6 @@ describe("Prisma Authz リポジトリ", () => {
       "circle-1",
     );
 
-    expect(mockedPrisma.circleMembership.findFirst).toHaveBeenCalledWith({
-      where: { userId: "user-1", circleId: "circle-1", deletedAt: null },
-      select: { role: true },
-    });
     expect(membership).toEqual({ kind: "member", role: "CircleOwner" });
   });
 
@@ -105,16 +97,6 @@ describe("Prisma Authz リポジトリ", () => {
       "session-1",
     );
 
-    expect(mockedPrisma.circleSessionMembership.findFirst).toHaveBeenCalledWith(
-      {
-        where: {
-          userId: "user-1",
-          circleSessionId: "session-1",
-          deletedAt: null,
-        },
-        select: { role: true },
-      },
-    );
     expect(membership).toEqual({ kind: "member", role: "CircleSessionMember" });
   });
 
@@ -138,10 +120,6 @@ describe("Prisma Authz リポジトリ", () => {
       "circle-1",
     );
 
-    expect(mockedPrisma.circleMembership.findFirst).toHaveBeenCalledWith({
-      where: { userId: "user-1", circleId: "circle-1", deletedAt: null },
-      select: { role: true },
-    });
     expect(membership).toEqual({ kind: "none" });
   });
 
@@ -153,16 +131,6 @@ describe("Prisma Authz リポジトリ", () => {
       "session-1",
     );
 
-    expect(mockedPrisma.circleSessionMembership.findFirst).toHaveBeenCalledWith(
-      {
-        where: {
-          userId: "user-1",
-          circleSessionId: "session-1",
-          deletedAt: null,
-        },
-        select: { role: true },
-      },
-    );
     expect(membership).toEqual({ kind: "none" });
   });
 });

--- a/server/infrastructure/repository/circle-session/prisma-circle-session-repository.test.ts
+++ b/server/infrastructure/repository/circle-session/prisma-circle-session-repository.test.ts
@@ -23,7 +23,6 @@ import { toCircleId, toCircleSessionId, toUserId } from "@/server/domain/common/
 import { createCircleSession } from "@/server/domain/models/circle-session/circle-session";
 import { prisma } from "@/server/infrastructure/db";
 import { Prisma } from "@/generated/prisma/client";
-import { mapCircleSessionToPersistence } from "@/server/infrastructure/mappers/circle-session-mapper";
 import { prismaCircleSessionRepository } from "@/server/infrastructure/repository/circle-session/prisma-circle-session-repository";
 
 const mockedPrisma = vi.mocked(prisma, { deep: true });
@@ -52,9 +51,6 @@ describe("Prisma CircleSession リポジトリ", () => {
       toCircleSessionId("session-1"),
     );
 
-    expect(mockedPrisma.circleSession.findUnique).toHaveBeenCalledWith({
-      where: { id: "session-1" },
-    });
     expect(session?.id).toBe("session-1");
   });
 
@@ -101,9 +97,6 @@ describe("Prisma CircleSession リポジトリ", () => {
       toCircleSessionId("session-2"),
     ]);
 
-    expect(mockedPrisma.circleSession.findMany).toHaveBeenCalledWith({
-      where: { id: { in: ["session-1", "session-2"] } },
-    });
     expect(sessions.map((session) => session.id)).toEqual([
       toCircleSessionId("session-1"),
       toCircleSessionId("session-2"),
@@ -129,10 +122,6 @@ describe("Prisma CircleSession リポジトリ", () => {
       toCircleId("circle-1"),
     );
 
-    expect(mockedPrisma.circleSession.findMany).toHaveBeenCalledWith({
-      where: { circleId: "circle-1" },
-      orderBy: [{ startsAt: "asc" }, { createdAt: "asc" }],
-    });
     expect(sessions).toHaveLength(1);
   });
 
@@ -183,7 +172,7 @@ describe("Prisma CircleSession リポジトリ", () => {
     ]);
   });
 
-  test("save は upsert を呼ぶ", async () => {
+  test("save はエラーなく完了する", async () => {
     const session = createCircleSession({
       id: toCircleSessionId("session-1"),
       circleId: toCircleId("circle-1"),
@@ -196,29 +185,15 @@ describe("Prisma CircleSession リポジトリ", () => {
       createdAt: new Date("2024-01-01T00:00:00Z"),
     });
 
-    const data = mapCircleSessionToPersistence(session);
-
-    await prismaCircleSessionRepository.save(session);
-
-    expect(mockedPrisma.circleSession.upsert).toHaveBeenCalledWith({
-      where: { id: data.id },
-      update: {
-        title: data.title,
-        startsAt: data.startsAt,
-        endsAt: data.endsAt,
-        location: data.location,
-        note: data.note,
-      },
-      create: data,
-    });
+    await expect(
+      prismaCircleSessionRepository.save(session),
+    ).resolves.toBeUndefined();
   });
 
-  test("delete は削除を呼ぶ", async () => {
-    await prismaCircleSessionRepository.delete(toCircleSessionId("session-1"));
-
-    expect(mockedPrisma.circleSession.delete).toHaveBeenCalledWith({
-      where: { id: "session-1" },
-    });
+  test("delete はエラーなく完了する", async () => {
+    await expect(
+      prismaCircleSessionRepository.delete(toCircleSessionId("session-1")),
+    ).resolves.toBeUndefined();
   });
 });
 
@@ -235,13 +210,6 @@ describe("Prisma CircleSession メンバーシップリポジトリ", () => {
       [toUserId("user-1"), toUserId("user-2")],
     );
 
-    expect(mockedPrisma.circleSessionMembership.count).toHaveBeenCalledWith({
-      where: {
-        circleSessionId: "session-1",
-        userId: { in: ["user-1", "user-2"] },
-        deletedAt: null,
-      },
-    });
     expect(result).toBe(true);
   });
 
@@ -274,13 +242,6 @@ describe("Prisma CircleSession メンバーシップリポジトリ", () => {
       [toUserId("user-1"), toUserId("user-1")],
     );
 
-    expect(mockedPrisma.circleSessionMembership.count).toHaveBeenCalledWith({
-      where: {
-        circleSessionId: "session-1",
-        userId: { in: ["user-1"] },
-        deletedAt: null,
-      },
-    });
     expect(result).toBe(true);
   });
 
@@ -310,16 +271,6 @@ describe("Prisma CircleSession メンバーシップリポジトリ", () => {
       toCircleSessionId("session-1"),
     );
 
-    expect(mockedPrisma.circleSessionMembership.findMany).toHaveBeenCalledWith({
-      where: { circleSessionId: "session-1", deletedAt: null },
-      select: {
-        circleSessionId: true,
-        userId: true,
-        role: true,
-        createdAt: true,
-        deletedAt: true,
-      },
-    });
     expect(result).toEqual([
       {
         circleSessionId: toCircleSessionId("session-1"),
@@ -364,16 +315,6 @@ describe("Prisma CircleSession メンバーシップリポジトリ", () => {
       toUserId("user-1"),
     );
 
-    expect(mockedPrisma.circleSessionMembership.findMany).toHaveBeenCalledWith({
-      where: { userId: "user-1", deletedAt: null },
-      select: {
-        circleSessionId: true,
-        userId: true,
-        role: true,
-        createdAt: true,
-        deletedAt: true,
-      },
-    });
     expect(result).toEqual([
       {
         circleSessionId: toCircleSessionId("session-1"),
@@ -392,20 +333,14 @@ describe("Prisma CircleSession メンバーシップリポジトリ", () => {
     ]);
   });
 
-  test("addMembership はメンバーを追加する", async () => {
-    await prismaCircleSessionRepository.addMembership(
-      toCircleSessionId("session-1"),
-      toUserId("user-1"),
-      "CircleSessionMember",
-    );
-
-    expect(mockedPrisma.circleSessionMembership.create).toHaveBeenCalledWith({
-      data: {
-        circleSessionId: "session-1",
-        userId: "user-1",
-        role: "CircleSessionMember",
-      },
-    });
+  test("addMembership はエラーなく完了する", async () => {
+    await expect(
+      prismaCircleSessionRepository.addMembership(
+        toCircleSessionId("session-1"),
+        toUserId("user-1"),
+        "CircleSessionMember",
+      ),
+    ).resolves.toBeUndefined();
   });
 
   test("addMembership は P2002（userId+circleSessionId 一意制約違反）で ConflictError をスローする", async () => {
@@ -464,27 +399,18 @@ describe("Prisma CircleSession メンバーシップリポジトリ", () => {
     ).rejects.toThrow(otherError);
   });
 
-  test("updateMembershipRole はメンバーのロールを更新する", async () => {
+  test("updateMembershipRole はエラーなく完了する", async () => {
     mockedPrisma.circleSessionMembership.updateMany.mockResolvedValueOnce({
       count: 1,
     });
 
-    await prismaCircleSessionRepository.updateMembershipRole(
-      toCircleSessionId("session-1"),
-      toUserId("user-1"),
-      "CircleSessionManager",
-    );
-
-    expect(
-      mockedPrisma.circleSessionMembership.updateMany,
-    ).toHaveBeenCalledWith({
-      where: {
-        userId: "user-1",
-        circleSessionId: "session-1",
-        deletedAt: null,
-      },
-      data: { role: "CircleSessionManager" },
-    });
+    await expect(
+      prismaCircleSessionRepository.updateMembershipRole(
+        toCircleSessionId("session-1"),
+        toUserId("user-1"),
+        "CircleSessionManager",
+      ),
+    ).resolves.toBeUndefined();
   });
 
   test("updateMembershipRole はレコードが見つからない場合エラーをスローする", async () => {
@@ -501,7 +427,7 @@ describe("Prisma CircleSession メンバーシップリポジトリ", () => {
     ).rejects.toThrow("CircleSessionMembership not found");
   });
 
-  test("論理削除後の再参加で create が呼ばれる", async () => {
+  test("論理削除後の再参加がエラーなく完了する", async () => {
     // 1. removeMembership で論理削除
     const deletedAt = new Date("2025-06-01T00:00:00Z");
     mockedPrisma.circleSessionMembership.updateMany.mockResolvedValueOnce({
@@ -513,31 +439,14 @@ describe("Prisma CircleSession メンバーシップリポジトリ", () => {
       deletedAt,
     );
 
-    expect(
-      mockedPrisma.circleSessionMembership.updateMany,
-    ).toHaveBeenCalledWith({
-      where: {
-        circleSessionId: "session-1",
-        userId: "user-1",
-        deletedAt: null,
-      },
-      data: { deletedAt },
-    });
-
     // 2. addMembership で再参加（新レコード作成）
-    await prismaCircleSessionRepository.addMembership(
-      toCircleSessionId("session-1"),
-      toUserId("user-1"),
-      "CircleSessionMember",
-    );
-
-    expect(mockedPrisma.circleSessionMembership.create).toHaveBeenCalledWith({
-      data: {
-        circleSessionId: "session-1",
-        userId: "user-1",
-        role: "CircleSessionMember",
-      },
-    });
+    await expect(
+      prismaCircleSessionRepository.addMembership(
+        toCircleSessionId("session-1"),
+        toUserId("user-1"),
+        "CircleSessionMember",
+      ),
+    ).resolves.toBeUndefined();
   });
 
   test("再参加後に listMemberships はアクティブなメンバーのみ返す", async () => {
@@ -556,16 +465,6 @@ describe("Prisma CircleSession メンバーシップリポジトリ", () => {
       toCircleSessionId("session-1"),
     );
 
-    expect(mockedPrisma.circleSessionMembership.findMany).toHaveBeenCalledWith({
-      where: { circleSessionId: "session-1", deletedAt: null },
-      select: {
-        circleSessionId: true,
-        userId: true,
-        role: true,
-        createdAt: true,
-        deletedAt: true,
-      },
-    });
     expect(result).toEqual([
       {
         circleSessionId: toCircleSessionId("session-1"),
@@ -608,16 +507,6 @@ describe("Prisma CircleSession メンバーシップリポジトリ", () => {
       toUserId("user-1"),
     );
 
-    expect(mockedPrisma.circleSessionMembership.findMany).toHaveBeenCalledWith({
-      where: { userId: "user-1", deletedAt: null },
-      select: {
-        circleSessionId: true,
-        userId: true,
-        role: true,
-        createdAt: true,
-        deletedAt: true,
-      },
-    });
     expect(result).toEqual([
       {
         circleSessionId: toCircleSessionId("session-1"),
@@ -627,22 +516,6 @@ describe("Prisma CircleSession メンバーシップリポジトリ", () => {
         deletedAt: null,
       },
     ]);
-  });
-
-  test("再参加時のロールが正しく設定される", async () => {
-    await prismaCircleSessionRepository.addMembership(
-      toCircleSessionId("session-1"),
-      toUserId("user-1"),
-      "CircleSessionMember",
-    );
-
-    expect(mockedPrisma.circleSessionMembership.create).toHaveBeenCalledWith({
-      data: {
-        circleSessionId: "session-1",
-        userId: "user-1",
-        role: "CircleSessionMember",
-      },
-    });
   });
 
   test("論理削除済みメンバーへの removeMembership が NotFoundError をスローする", async () => {
@@ -681,17 +554,6 @@ describe("Prisma CircleSession メンバーシップリポジトリ", () => {
         new Date("2025-07-01T00:00:00Z"),
       ),
     ).rejects.toThrow(NotFoundError);
-
-    expect(
-      mockedPrisma.circleSessionMembership.updateMany,
-    ).toHaveBeenLastCalledWith({
-      where: {
-        circleSessionId: "session-1",
-        userId: "user-1",
-        deletedAt: null,
-      },
-      data: { deletedAt: new Date("2025-07-01T00:00:00Z") },
-    });
   });
 
   test("removeMembership はメンバーシップを論理削除する", async () => {
@@ -699,21 +561,13 @@ describe("Prisma CircleSession メンバーシップリポジトリ", () => {
     mockedPrisma.circleSessionMembership.updateMany.mockResolvedValueOnce({
       count: 1,
     });
-    await prismaCircleSessionRepository.removeMembership(
-      toCircleSessionId("session-1"),
-      toUserId("user-1"),
-      deletedAt,
-    );
 
-    expect(
-      mockedPrisma.circleSessionMembership.updateMany,
-    ).toHaveBeenCalledWith({
-      where: {
-        circleSessionId: "session-1",
-        userId: "user-1",
-        deletedAt: null,
-      },
-      data: { deletedAt },
-    });
+    await expect(
+      prismaCircleSessionRepository.removeMembership(
+        toCircleSessionId("session-1"),
+        toUserId("user-1"),
+        deletedAt,
+      ),
+    ).resolves.toBeUndefined();
   });
 });

--- a/server/infrastructure/repository/circle/prisma-circle-repository.test.ts
+++ b/server/infrastructure/repository/circle/prisma-circle-repository.test.ts
@@ -23,7 +23,6 @@ import { createCircle } from "@/server/domain/models/circle/circle";
 import { prisma } from "@/server/infrastructure/db";
 import { Prisma } from "@/generated/prisma/client";
 import { prismaCircleRepository } from "@/server/infrastructure/repository/circle/prisma-circle-repository";
-import { mapCircleToPersistence } from "@/server/infrastructure/mappers/circle-mapper";
 
 const mockedPrisma = vi.mocked(prisma, { deep: true });
 
@@ -43,9 +42,6 @@ describe("Prisma Circle リポジトリ", () => {
 
     const circle = await prismaCircleRepository.findById(toCircleId("circle-1"));
 
-    expect(mockedPrisma.circle.findUnique).toHaveBeenCalledWith({
-      where: { id: "circle-1" },
-    });
     expect(circle?.id).toBe("circle-1");
   });
 
@@ -78,42 +74,26 @@ describe("Prisma Circle リポジトリ", () => {
       toCircleId("circle-2"),
     ]);
 
-    expect(mockedPrisma.circle.findMany).toHaveBeenCalledWith({
-      where: { id: { in: ["circle-1", "circle-2"] } },
-    });
     expect(circles.map((circle) => circle.id)).toEqual([
       toCircleId("circle-1"),
       toCircleId("circle-2"),
     ]);
   });
 
-  test("save は upsert を呼ぶ", async () => {
+  test("save はエラーなく完了する", async () => {
     const circle = createCircle({
       id: toCircleId("circle-1"),
       name: "Home",
       createdAt: new Date("2024-01-01T00:00:00Z"),
     });
 
-    const data = mapCircleToPersistence(circle);
-
-    await prismaCircleRepository.save(circle);
-
-    expect(mockedPrisma.circle.upsert).toHaveBeenCalledWith({
-      where: { id: data.id },
-      update: {
-        name: data.name,
-        sessionEmailNotificationEnabled: data.sessionEmailNotificationEnabled,
-      },
-      create: data,
-    });
+    await expect(prismaCircleRepository.save(circle)).resolves.toBeUndefined();
   });
 
-  test("delete は削除を呼ぶ", async () => {
-    await prismaCircleRepository.delete(toCircleId("circle-1"));
-
-    expect(mockedPrisma.circle.delete).toHaveBeenCalledWith({
-      where: { id: "circle-1" },
-    });
+  test("delete はエラーなく完了する", async () => {
+    await expect(
+      prismaCircleRepository.delete(toCircleId("circle-1")),
+    ).resolves.toBeUndefined();
   });
 });
 
@@ -147,16 +127,6 @@ describe("Prisma Circle メンバーシップリポジトリ", () => {
       toCircleId("circle-1"),
     );
 
-    expect(mockedPrisma.circleMembership.findMany).toHaveBeenCalledWith({
-      where: { circleId: "circle-1", deletedAt: null },
-      select: {
-        circleId: true,
-        userId: true,
-        role: true,
-        createdAt: true,
-        deletedAt: true,
-      },
-    });
     expect(result).toEqual([
       {
         circleId: toCircleId("circle-1"),
@@ -200,17 +170,6 @@ describe("Prisma Circle メンバーシップリポジトリ", () => {
       toUserId("user-1"),
     );
 
-    expect(mockedPrisma.circleMembership.findMany).toHaveBeenCalledWith({
-      where: { userId: "user-1", deletedAt: null },
-      orderBy: { createdAt: "desc" },
-      select: {
-        circleId: true,
-        userId: true,
-        role: true,
-        createdAt: true,
-        deletedAt: true,
-      },
-    });
     expect(result).toEqual([
       {
         circleId: toCircleId("circle-1"),
@@ -229,20 +188,14 @@ describe("Prisma Circle メンバーシップリポジトリ", () => {
     ]);
   });
 
-  test("addMembership はメンバーを追加する", async () => {
-    await prismaCircleRepository.addMembership(
-      toCircleId("circle-1"),
-      toUserId("user-1"),
-      "CircleManager",
-    );
-
-    expect(mockedPrisma.circleMembership.create).toHaveBeenCalledWith({
-      data: {
-        circleId: "circle-1",
-        userId: "user-1",
-        role: "CircleManager",
-      },
-    });
+  test("addMembership はエラーなく完了する", async () => {
+    await expect(
+      prismaCircleRepository.addMembership(
+        toCircleId("circle-1"),
+        toUserId("user-1"),
+        "CircleManager",
+      ),
+    ).resolves.toBeUndefined();
   });
 
   test("addMembership は P2002（userId+circleId 一意制約違反）で ConflictError をスローする", async () => {
@@ -299,25 +252,18 @@ describe("Prisma Circle メンバーシップリポジトリ", () => {
     ).rejects.toThrow(otherError);
   });
 
-  test("updateMembershipRole はメンバーのロールを更新する", async () => {
+  test("updateMembershipRole はエラーなく完了する", async () => {
     mockedPrisma.circleMembership.updateMany.mockResolvedValueOnce({
       count: 1,
     });
 
-    await prismaCircleRepository.updateMembershipRole(
-      toCircleId("circle-1"),
-      toUserId("user-1"),
-      "CircleMember",
-    );
-
-    expect(mockedPrisma.circleMembership.updateMany).toHaveBeenCalledWith({
-      where: {
-        userId: "user-1",
-        circleId: "circle-1",
-        deletedAt: null,
-      },
-      data: { role: "CircleMember" },
-    });
+    await expect(
+      prismaCircleRepository.updateMembershipRole(
+        toCircleId("circle-1"),
+        toUserId("user-1"),
+        "CircleMember",
+      ),
+    ).resolves.toBeUndefined();
   });
 
   test("updateMembershipRole はレコードが見つからない場合エラーをスローする", async () => {
@@ -334,7 +280,7 @@ describe("Prisma Circle メンバーシップリポジトリ", () => {
     ).rejects.toThrow("CircleMembership not found");
   });
 
-  test("論理削除後の再参加で create が呼ばれる", async () => {
+  test("論理削除後の再参加がエラーなく完了する", async () => {
     // 1. removeMembership で論理削除
     const deletedAt = new Date("2025-06-01T00:00:00Z");
     mockedPrisma.circleMembership.updateMany.mockResolvedValueOnce({
@@ -346,29 +292,14 @@ describe("Prisma Circle メンバーシップリポジトリ", () => {
       deletedAt,
     );
 
-    expect(mockedPrisma.circleMembership.updateMany).toHaveBeenCalledWith({
-      where: {
-        circleId: "circle-1",
-        userId: "user-1",
-        deletedAt: null,
-      },
-      data: { deletedAt },
-    });
-
     // 2. addMembership で再参加（新レコード作成）
-    await prismaCircleRepository.addMembership(
-      toCircleId("circle-1"),
-      toUserId("user-1"),
-      "CircleMember",
-    );
-
-    expect(mockedPrisma.circleMembership.create).toHaveBeenCalledWith({
-      data: {
-        circleId: "circle-1",
-        userId: "user-1",
-        role: "CircleMember",
-      },
-    });
+    await expect(
+      prismaCircleRepository.addMembership(
+        toCircleId("circle-1"),
+        toUserId("user-1"),
+        "CircleMember",
+      ),
+    ).resolves.toBeUndefined();
   });
 
   test("再参加後に listMembershipsByCircleId はアクティブなメンバーのみ返す", async () => {
@@ -387,16 +318,6 @@ describe("Prisma Circle メンバーシップリポジトリ", () => {
       toCircleId("circle-1"),
     );
 
-    expect(mockedPrisma.circleMembership.findMany).toHaveBeenCalledWith({
-      where: { circleId: "circle-1", deletedAt: null },
-      select: {
-        circleId: true,
-        userId: true,
-        role: true,
-        createdAt: true,
-        deletedAt: true,
-      },
-    });
     expect(result).toEqual([
       {
         circleId: toCircleId("circle-1"),
@@ -439,17 +360,6 @@ describe("Prisma Circle メンバーシップリポジトリ", () => {
       toUserId("user-1"),
     );
 
-    expect(mockedPrisma.circleMembership.findMany).toHaveBeenCalledWith({
-      where: { userId: "user-1", deletedAt: null },
-      orderBy: { createdAt: "desc" },
-      select: {
-        circleId: true,
-        userId: true,
-        role: true,
-        createdAt: true,
-        deletedAt: true,
-      },
-    });
     expect(result).toEqual([
       {
         circleId: toCircleId("circle-1"),
@@ -459,23 +369,6 @@ describe("Prisma Circle メンバーシップリポジトリ", () => {
         deletedAt: null,
       },
     ]);
-  });
-
-  test("再参加時のロールが正しく設定される", async () => {
-    // 論理削除後に CircleMember ロールで再参加
-    await prismaCircleRepository.addMembership(
-      toCircleId("circle-1"),
-      toUserId("user-1"),
-      "CircleMember",
-    );
-
-    expect(mockedPrisma.circleMembership.create).toHaveBeenCalledWith({
-      data: {
-        circleId: "circle-1",
-        userId: "user-1",
-        role: "CircleMember",
-      },
-    });
   });
 
   test("論理削除済みメンバーへの removeMembership が NotFoundError をスローする", async () => {
@@ -516,17 +409,6 @@ describe("Prisma Circle メンバーシップリポジトリ", () => {
         new Date("2025-07-01T00:00:00Z"),
       ),
     ).rejects.toThrow(NotFoundError);
-
-    // updateMany は where: { deletedAt: null } で呼ばれるため、
-    // 既に論理削除済みのレコードの deletedAt は上書きされない
-    expect(mockedPrisma.circleMembership.updateMany).toHaveBeenLastCalledWith({
-      where: {
-        circleId: "circle-1",
-        userId: "user-1",
-        deletedAt: null,
-      },
-      data: { deletedAt: new Date("2025-07-01T00:00:00Z") },
-    });
   });
 
   test("removeMembership は研究会メンバーシップを論理削除する", async () => {
@@ -534,19 +416,13 @@ describe("Prisma Circle メンバーシップリポジトリ", () => {
     mockedPrisma.circleMembership.updateMany.mockResolvedValueOnce({
       count: 1,
     });
-    await prismaCircleRepository.removeMembership(
-      toCircleId("circle-1"),
-      toUserId("user-1"),
-      deletedAt,
-    );
 
-    expect(mockedPrisma.circleMembership.updateMany).toHaveBeenCalledWith({
-      where: {
-        circleId: "circle-1",
-        userId: "user-1",
-        deletedAt: null,
-      },
-      data: { deletedAt },
-    });
+    await expect(
+      prismaCircleRepository.removeMembership(
+        toCircleId("circle-1"),
+        toUserId("user-1"),
+        deletedAt,
+      ),
+    ).resolves.toBeUndefined();
   });
 });

--- a/server/infrastructure/repository/match/prisma-match-repository.test.ts
+++ b/server/infrastructure/repository/match/prisma-match-repository.test.ts
@@ -15,7 +15,6 @@ import { prisma } from "@/server/infrastructure/db";
 import { toCircleSessionId, toMatchId, toUserId } from "@/server/domain/common/ids";
 import { createMatch } from "@/server/domain/models/match/match";
 import { prismaMatchRepository } from "@/server/infrastructure/repository/match/prisma-match-repository";
-import { mapMatchToPersistence } from "@/server/infrastructure/mappers/match-mapper";
 
 const mockedPrisma = vi.mocked(prisma, { deep: true });
 
@@ -39,9 +38,6 @@ describe("Prisma Match リポジトリ", () => {
 
     const match = await prismaMatchRepository.findById(toMatchId("match-1"));
 
-    expect(mockedPrisma.match.findUnique).toHaveBeenCalledWith({
-      where: { id: "match-1" },
-    });
     expect(match?.id).toBe("match-1");
   });
 
@@ -70,14 +66,10 @@ describe("Prisma Match リポジトリ", () => {
       toCircleSessionId("session-1"),
     );
 
-    expect(mockedPrisma.match.findMany).toHaveBeenCalledWith({
-      where: { circleSessionId: "session-1" },
-      orderBy: { createdAt: "asc" },
-    });
     expect(matches).toHaveLength(1);
   });
 
-  test("save は upsert を呼ぶ", async () => {
+  test("save はエラーなく完了する", async () => {
     const match = createMatch({
       id: toMatchId("match-1"),
       circleSessionId: toCircleSessionId("session-1"),
@@ -86,19 +78,6 @@ describe("Prisma Match リポジトリ", () => {
       outcome: "P2_WIN",
     });
 
-    const data = mapMatchToPersistence(match);
-
-    await prismaMatchRepository.save(match);
-
-    expect(mockedPrisma.match.upsert).toHaveBeenCalledWith({
-      where: { id: data.id },
-      update: {
-        player1Id: data.player1Id,
-        player2Id: data.player2Id,
-        outcome: data.outcome,
-        deletedAt: data.deletedAt,
-      },
-      create: data,
-    });
+    await expect(prismaMatchRepository.save(match)).resolves.toBeUndefined();
   });
 });

--- a/server/infrastructure/repository/user/prisma-user-repository.test.ts
+++ b/server/infrastructure/repository/user/prisma-user-repository.test.ts
@@ -18,7 +18,6 @@ import { toUserId } from "@/server/domain/common/ids";
 import { ConflictError } from "@/server/domain/common/errors";
 import { createUser } from "@/server/domain/models/user/user";
 import { prismaUserRepository } from "@/server/infrastructure/repository/user/prisma-user-repository";
-import { mapUserToPersistence } from "@/server/infrastructure/mappers/user-mapper";
 
 const mockedPrisma = vi.mocked(prisma, { deep: true });
 
@@ -40,9 +39,6 @@ describe("Prisma User リポジトリ", () => {
 
     const user = await prismaUserRepository.findById(toUserId("user-1"));
 
-    expect(mockedPrisma.user.findUnique).toHaveBeenCalledWith({
-      where: { id: "user-1" },
-    });
     expect(user?.id).toBe("user-1");
   });
 
@@ -80,13 +76,10 @@ describe("Prisma User リポジトリ", () => {
       toUserId("user-3"),
     ]);
 
-    expect(mockedPrisma.user.findMany).toHaveBeenCalledWith({
-      where: { id: { in: ["user-1", "user-2", "user-3"] } },
-    });
     expect(users.map((user) => user.id)).toEqual(["user-1", "user-3"]);
   });
 
-  test("save は upsert を呼ぶ", async () => {
+  test("save はエラーなく完了する", async () => {
     const user = createUser({
       id: toUserId("user-1"),
       name: "Alice",
@@ -95,19 +88,7 @@ describe("Prisma User リポジトリ", () => {
       createdAt: new Date("2024-01-01T00:00:00Z"),
     });
 
-    const data = mapUserToPersistence(user);
-
-    await prismaUserRepository.save(user);
-
-    expect(mockedPrisma.user.upsert).toHaveBeenCalledWith({
-      where: { id: data.id },
-      update: {
-        name: data.name,
-        email: data.email,
-        image: data.image,
-      },
-      create: data,
-    });
+    await expect(prismaUserRepository.save(user)).resolves.toBeUndefined();
   });
 
   test("updateProfile は P2002（email 一意制約違反）で ConflictError をスローする", async () => {


### PR DESCRIPTION
## Summary

- Infrastructure層リポジトリテスト6ファイルから `toHaveBeenCalledWith` / `toHaveBeenCalledTimes` を除去
- Prismaモックの返り値・例外スローによる出力ベース（state-based）の検証に移行
- リファクタリング耐性の向上（内部実装変更でテストが壊れにくくなる）

## 変更対象

| ファイル | 変更内容 |
|---------|---------|
| `prisma-circle-repository.test.ts` | ~20件の呼び出し検証を除去、write操作テスト名を更新 |
| `prisma-circle-session-repository.test.ts` | ~20件の呼び出し検証を除去、write操作テスト名を更新 |
| `prisma-rate-limiter.test.ts` | 8件の呼び出し検証を除去、重複テスト2件を削除 |
| `prisma-authz-repository.test.ts` | 5件の呼び出し検証を除去 |
| `prisma-match-repository.test.ts` | 3件の呼び出し検証を除去 |
| `prisma-user-repository.test.ts` | 3件の呼び出し検証を除去 |

## レビューポイント

- void write操作（save, delete, addMembership等）のテストは `resolves.toBeUndefined()` のみの検証になっている。Provider層テストが上位で振る舞いをカバーしているため実害はないが、Infrastructure層単独での検証力は低下している点を認識の上レビューをお願いします。

## 検証方法

- `npx vitest run` で対象6ファイル（81テスト）が全パス

closes #1108

🤖 Generated with [Claude Code](https://claude.com/claude-code)