### PR TITLE
test(frontend): セッション作成フォームのタイムゾーン境界テストを追加 (#106)

### DIFF
--- a/app/(authenticated)/circles/[circleId]/sessions/new/circle-session-create-form.test.tsx
+++ b/app/(authenticated)/circles/[circleId]/sessions/new/circle-session-create-form.test.tsx
@@ -1,7 +1,7 @@
 // @vitest-environment jsdom
 import { cleanup, render, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
-import { afterEach, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { CircleSessionCreateForm } from "./circle-session-create-form";
 
 const mutateMock = vi.fn();
@@ -215,6 +215,29 @@ describe("CircleSessionCreateForm", () => {
     expect(
       (titleInput as HTMLInputElement).validationMessage,
     ).toBe("タイトルを入力してください");
+  });
+
+  describe("タイムゾーン境界", () => {
+    beforeEach(() => {
+      // JST 2025-01-02 03:00 = UTC 2025-01-01 18:00
+      vi.useFakeTimers();
+      vi.setSystemTime(new Date("2025-01-02T03:00:00+09:00"));
+    });
+
+    afterEach(() => {
+      vi.useRealTimers();
+    });
+
+    it("JST 深夜帯（UTC では前日）でもローカル日付がデフォルト値に使用される", () => {
+      render(<CircleSessionCreateForm circleId={circleId} />);
+
+      expect(screen.getByLabelText("開始日時")).toHaveValue(
+        "2025-01-02T10:00",
+      );
+      expect(screen.getByLabelText("終了日時")).toHaveValue(
+        "2025-01-02T18:00",
+      );
+    });
   });
 
   it("空白のみから有効なタイトルに変更すると customValidity がクリアされる", async () => {

--- a/vitest.config.mts
+++ b/vitest.config.mts
@@ -11,6 +11,9 @@ export default defineConfig({
       "**/*.{test,spec}.mts",
       "**/*.{test,spec}.tsx",
     ],
+    env: {
+      TZ: "Asia/Tokyo",
+    },
     exclude: [
       ...configDefaults.exclude,
       ".next",


### PR DESCRIPTION
## Summary

- JST 深夜帯（UTC では前日）でもデフォルト日付がローカル日付になることを検証するテストを追加
- `vitest.config.mts` に `TZ=Asia/Tokyo` を設定し、CI 環境（UTC）でのテストフレーク防止

Closes #106

## Test plan

- [ ] `npx vitest run "app/(authenticated)/circles/[circleId]/sessions/new/circle-session-create-form.test.tsx"` で全15テスト（既存14 + 新規1）がパスすること
- [ ] 新テストが `vi.useFakeTimers()` / `vi.useRealTimers()` で適切にクリーンアップしていること
- [ ] グローバル TZ 設定が既存テストに影響しないこと

🤖 Generated with [Claude Code](https://claude.com/claude-code)